### PR TITLE
Fix java.lang.NoClassDefFoundError on gradlew :imgui-lwjgl3:startExample

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sat Dec 14 22:33:02 MSK 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
See https://stackoverflow.com/questions/61289461/java-lang-noclassdeffounderror-could-not-initialize-class-org-codehaus-groovy-v
and https://github.com/gradle/gradle/issues/10248

This error happened for me on Java jdk 14. I don't know if this "fix" introduces problems for other java versions. But it was necessary to get the example to work for me.