### PR TITLE
[API] Allow null to be passed as the shortcut param to MenuItem

### DIFF
--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -4045,17 +4045,17 @@ public class ImGui {
     /**
      * Return true when activated
      */
-    private static native boolean nMenuItem(String obj_label, String obj_shortcut, boolean selected, boolean enabled); /*MANUAL
-	    char* label = (char*)env->GetStringUTFChars(obj_label, JNI_FALSE);
-	    char* shortcut = NULL;
-        if (obj_shortcut != NULL)
-            shortcut = (char*)env->GetStringUTFChars(obj_shortcut, JNI_FALSE);
+    private static native boolean nMenuItem(String labelObj, String shortcutObj, boolean selected, boolean enabled); /*MANUAL
+        char* label = (char*)env->GetStringUTFChars(labelObj, JNI_FALSE);
+        char* shortcut = NULL;
+        if (shortcutObj != NULL)
+            shortcut = (char*)env->GetStringUTFChars(shortcutObj, JNI_FALSE);
 
-	    jboolean result = ImGui::MenuItem(label, shortcut, selected, enabled);
+        jboolean result = ImGui::MenuItem(label, shortcut, selected, enabled);
 
-        if (obj_shortcut != NULL)
-            env->ReleaseStringUTFChars(obj_shortcut, shortcut);
-        env->ReleaseStringUTFChars(obj_label, label);
+        if (shortcutObj != NULL)
+            env->ReleaseStringUTFChars(shortcutObj, shortcut);
+        env->ReleaseStringUTFChars(labelObj, label);
 
         return result;
     */
@@ -4063,19 +4063,19 @@ public class ImGui {
     /**
      * Return true when activated + toggle (*pSelected) if pSelected != NULL
      */
-    private static native boolean nMenuItem(String obj_label, String obj_shortcut, boolean[] obj_pSelected, boolean enabled); /*MANUAL
-	    char* label = (char*)env->GetStringUTFChars(obj_label, JNI_FALSE);
-	    char* shortcut = NULL;
-        if (obj_shortcut != NULL)
-            shortcut = (char*)env->GetStringUTFChars(obj_shortcut, JNI_FALSE);
-	    bool* pSelected = (bool*)env->GetPrimitiveArrayCritical(obj_pSelected, JNI_FALSE);
+    private static native boolean nMenuItem(String labelObj, String shortcutObj, boolean[] pSelectedObj, boolean enabled); /*MANUAL
+        char* label = (char*)env->GetStringUTFChars(labelObj, JNI_FALSE);
+        char* shortcut = NULL;
+        if (shortcutObj != NULL)
+            shortcut = (char*)env->GetStringUTFChars(shortcutObj, JNI_FALSE);
+        bool* pSelected = (bool*)env->GetPrimitiveArrayCritical(pSelectedObj, JNI_FALSE);
 
-	    jboolean result = ImGui::MenuItem(label, shortcut, &pSelected[0], enabled);
+        jboolean result = ImGui::MenuItem(label, shortcut, &pSelected[0], enabled);
 
-	    env->ReleasePrimitiveArrayCritical(obj_pSelected, pSelected, 0);
-        if (obj_shortcut != NULL)
-            env->ReleaseStringUTFChars(obj_shortcut, shortcut);
-        env->ReleaseStringUTFChars(obj_label, label);
+        env->ReleasePrimitiveArrayCritical(pSelectedObj, pSelected, 0);
+        if (shortcutObj != NULL)
+            env->ReleaseStringUTFChars(shortcutObj, shortcut);
+        env->ReleaseStringUTFChars(labelObj, label);
 
         return result;
     */

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -4024,14 +4024,20 @@ public class ImGui {
     /**
      * Return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
      */
-    public static native boolean menuItem(String label, String shortcut, boolean selected, boolean enabled); /*
-        return ImGui::MenuItem(label, shortcut, selected, enabled);
-    */
+    public static boolean menuItem(String label, String shortcut, boolean selected, boolean enabled) {
+        if (shortcut == null) {
+            return nMenuItem(label, selected, enabled);
+        }
+        return nMenuItem(label, shortcut, selected, enabled);
+    }
 
     /**
      * Return true when activated + toggle (*pSelected) if pSelected != NULL
      */
     public static boolean menuItem(String label, String shortcut, ImBoolean pSelected) {
+        if (shortcut == null) {
+            return nMenuItem(label, pSelected.getData(), true);
+        }
         return nMenuItem(label, shortcut, pSelected.getData(), true);
     }
 
@@ -4039,8 +4045,32 @@ public class ImGui {
      * Return true when activated + toggle (*pSelected) if pSelected != NULL
      */
     public static boolean menuItem(String label, String shortcut, ImBoolean pSelected, boolean enabled) {
+        if (shortcut == null) {
+            return nMenuItem(label, pSelected.getData(), enabled);
+        }
         return nMenuItem(label, shortcut, pSelected.getData(), enabled);
     }
+
+    /**
+     * Return true when activated
+     */
+    private static native boolean nMenuItem(String label, boolean selected, boolean enabled); /*
+        return ImGui::MenuItem(label, NULL, selected, enabled);
+    */
+
+    /**
+     * Return true when activated
+     */
+    private static native boolean nMenuItem(String label, String shortcut, boolean selected, boolean enabled); /*
+        return ImGui::MenuItem(label, shortcut, selected, enabled);
+    */
+
+    /**
+     * Return true when activated + toggle (*pSelected) if pSelected != NULL
+     */
+    private static native boolean nMenuItem(String label, boolean[] pSelected, boolean enabled); /*
+        return ImGui::MenuItem(label, NULL, &pSelected[0], enabled);
+    */
 
     /**
      * Return true when activated + toggle (*pSelected) if pSelected != NULL

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -4010,24 +4010,21 @@ public class ImGui {
     /**
      * Return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
      */
-    public static native boolean menuItem(String label, String shortcut); /*
-        return ImGui::MenuItem(label, shortcut);
-    */
+    public static boolean menuItem(String label, String shortcut) {
+        return nMenuItem(label, shortcut, false, true);
+    }
 
     /**
      * Return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
      */
-    public static native boolean menuItem(String label, String shortcut, boolean selected); /*
-        return ImGui::MenuItem(label, shortcut, selected);
-    */
+    public static boolean menuItem(String label, String shortcut, boolean selected) {
+        return nMenuItem(label, shortcut, selected, true);
+    }
 
     /**
      * Return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
      */
     public static boolean menuItem(String label, String shortcut, boolean selected, boolean enabled) {
-        if (shortcut == null) {
-            return nMenuItem(label, selected, enabled);
-        }
         return nMenuItem(label, shortcut, selected, enabled);
     }
 
@@ -4035,9 +4032,6 @@ public class ImGui {
      * Return true when activated + toggle (*pSelected) if pSelected != NULL
      */
     public static boolean menuItem(String label, String shortcut, ImBoolean pSelected) {
-        if (shortcut == null) {
-            return nMenuItem(label, pSelected.getData(), true);
-        }
         return nMenuItem(label, shortcut, pSelected.getData(), true);
     }
 
@@ -4045,38 +4039,45 @@ public class ImGui {
      * Return true when activated + toggle (*pSelected) if pSelected != NULL
      */
     public static boolean menuItem(String label, String shortcut, ImBoolean pSelected, boolean enabled) {
-        if (shortcut == null) {
-            return nMenuItem(label, pSelected.getData(), enabled);
-        }
         return nMenuItem(label, shortcut, pSelected.getData(), enabled);
     }
 
     /**
      * Return true when activated
      */
-    private static native boolean nMenuItem(String label, boolean selected, boolean enabled); /*
-        return ImGui::MenuItem(label, NULL, selected, enabled);
-    */
+    private static native boolean nMenuItem(String obj_label, String obj_shortcut, boolean selected, boolean enabled); /*MANUAL
+	    char* label = (char*)env->GetStringUTFChars(obj_label, JNI_FALSE);
+	    char* shortcut = NULL;
+        if (obj_shortcut != NULL)
+            shortcut = (char*)env->GetStringUTFChars(obj_shortcut, JNI_FALSE);
 
-    /**
-     * Return true when activated
-     */
-    private static native boolean nMenuItem(String label, String shortcut, boolean selected, boolean enabled); /*
-        return ImGui::MenuItem(label, shortcut, selected, enabled);
+	    jboolean result = ImGui::MenuItem(label, shortcut, selected, enabled);
+
+        if (obj_shortcut != NULL)
+            env->ReleaseStringUTFChars(obj_shortcut, shortcut);
+        env->ReleaseStringUTFChars(obj_label, label);
+
+        return result;
     */
 
     /**
      * Return true when activated + toggle (*pSelected) if pSelected != NULL
      */
-    private static native boolean nMenuItem(String label, boolean[] pSelected, boolean enabled); /*
-        return ImGui::MenuItem(label, NULL, &pSelected[0], enabled);
-    */
+    private static native boolean nMenuItem(String obj_label, String obj_shortcut, boolean[] obj_pSelected, boolean enabled); /*MANUAL
+	    char* label = (char*)env->GetStringUTFChars(obj_label, JNI_FALSE);
+	    char* shortcut = NULL;
+        if (obj_shortcut != NULL)
+            shortcut = (char*)env->GetStringUTFChars(obj_shortcut, JNI_FALSE);
+	    bool* pSelected = (bool*)env->GetPrimitiveArrayCritical(obj_pSelected, JNI_FALSE);
 
-    /**
-     * Return true when activated + toggle (*pSelected) if pSelected != NULL
-     */
-    private static native boolean nMenuItem(String label, String shortcut, boolean[] pSelected, boolean enabled); /*
-        return ImGui::MenuItem(label, shortcut, &pSelected[0], enabled);
+	    jboolean result = ImGui::MenuItem(label, shortcut, &pSelected[0], enabled);
+
+	    env->ReleasePrimitiveArrayCritical(obj_pSelected, pSelected, 0);
+        if (obj_shortcut != NULL)
+            env->ReleaseStringUTFChars(obj_shortcut, shortcut);
+        env->ReleaseStringUTFChars(obj_label, label);
+
+        return result;
     */
 
     // Tooltips


### PR DESCRIPTION
Fixes #34

I don't know JNI too well so I think my fix could be less verbose. All it really needs to do is communicate to the autogenerator that the `shortcut` param can be null. Not checked in any updated binaries.