### PR TITLE
Update lwjgl from 3.2.3 to 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ repositories {
 }
 
 ext {
-    lwjglVersion = '3.2.3'
+    lwjglVersion = '3.3.0'
     imguiVersion = '1.85.0'
 }
 
@@ -171,7 +171,7 @@ dependencies {
 
 ```
 <properties>
-    <lwjgl.version>3.2.3</lwjgl.version>
+    <lwjgl.version>3.3.0</lwjgl.version>
     <imgui.java.version>1.85.0</imgui.java.version>
 </properties>
 
@@ -289,7 +289,7 @@ Don't forget to make clear for your Linux/Mac users, that they will need to inst
     }
     
     ext {
-        lwjglVersion = '3.2.3'
+        lwjglVersion = '3.3.0'
         imguiVersion = '1.85.0'
     }
     

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import tool.UpVersion
 
+ext["lwjgl"] = [bom:"org.lwjgl:lwjgl-bom:3.3.0"]
+
 allprojects {
     group 'imgui-java'
     version property('version')

--- a/imgui-app/build.gradle
+++ b/imgui-app/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    api platform('org.lwjgl:lwjgl-bom:3.2.3')
+    api platform(lwjgl.bom)
 
     api 'org.lwjgl:lwjgl'
     api 'org.lwjgl:lwjgl-glfw'

--- a/imgui-lwjgl3/build.gradle
+++ b/imgui-lwjgl3/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    implementation platform("org.lwjgl:lwjgl-bom:3.2.3")
+    implementation platform(lwjgl.bom)
 
     implementation 'org.lwjgl:lwjgl'
     implementation 'org.lwjgl:lwjgl-glfw'


### PR DESCRIPTION
Update lwjgl from 3.2.3 to 3.3.0
In order to use imgui-java with the lwjgl 3.3.0 without errors there is need for an update.
To remove code duplication when changing dependencies,
an lwjgl.bom variable was added.
Fixes: SpaiR#95

- update lwjgl version from 3.2.3 to 3.3.0 across all submodules