### PR TITLE
M1 natives support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
             expected: /tmp/imgui/libsNative/linux64/libimgui-java64.so
           - type: mac
             expected: /tmp/imgui/libsNative/macosx64/libimgui-java64.dylib
+          - type: mac
+          expected: /tmp/imgui/libsNative/macosx64/libimgui-javaarm64.dylib
         exclude:
           - os: ubuntu-20.04
             type: mac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build-java:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-latest]
     name: Build Java
     runs-on: ${{ matrix.os }}
     steps:
@@ -25,7 +25,7 @@ jobs:
       FREETYPE_URL: https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.gz
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-latest]
         type: [win, linux, mac]
         freetype: [true, false]
         include:
@@ -40,9 +40,9 @@ jobs:
         exclude:
           - os: ubuntu-20.04
             type: mac
-          - os: macos-10.15
+          - os: macos-latest
             type: win
-          - os: macos-10.15
+          - os: macos-latest
             type: linux
     name: Build Native (type=${{ matrix.type }}, freetype=${{ matrix.freetype }})
     runs-on: ${{ matrix.os }}
@@ -63,6 +63,16 @@ jobs:
       - if: matrix.os == 'ubuntu-20.04'
         name: Install MinGW-w64/GCC/G++
         run: sudo apt install mingw-w64
+
+      - if: matrix.os == 'macos-latest'
+        name: Build Setup Mac xcode
+        run: |
+          # See https://github.com/actions/virtual-environments/issues/2557
+          sudo mv /Library/Developer/CommandLineTools/SDKs/* /tmp
+          sudo mv /Applications/Xcode.app /Applications/Xcode.app.bak
+          sudo mv /Applications/Xcode_12.4.app /Applications/Xcode.app
+          sudo xcode-select -switch /Applications/Xcode.app
+          /usr/bin/xcodebuild -version
 
       - if: matrix.os == 'ubuntu-20.04' && matrix.type == 'linux' && matrix.freetype == true
         name: FreeType - Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - type: mac
             expected: /tmp/imgui/libsNative/macosx64/libimgui-java64.dylib
           - type: mac
-          expected: /tmp/imgui/libsNative/macosx64/libimgui-javaarm64.dylib
+            expected: /tmp/imgui/libsNative/macosx64/libimgui-javaarm64.dylib
         exclude:
           - os: ubuntu-20.04
             type: mac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           sudo mv /Applications/Xcode_12.4.app /Applications/Xcode.app
           sudo xcode-select -switch /Applications/Xcode.app
           /usr/bin/xcodebuild -version
+          brew install freetype
 
       - if: matrix.os == 'ubuntu-20.04' && matrix.type == 'linux' && matrix.freetype == true
         name: FreeType - Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - type: mac
             expected: /tmp/imgui/libsNative/macosx64/libimgui-java64.dylib
           - type: mac
-            expected: /tmp/imgui/libsNative/macosx64/libimgui-javaarm64.dylib
+            expected: /tmp/imgui/libsNative/macosxarm64/libimgui-javaarm64.dylib
         exclude:
           - os: ubuntu-20.04
             type: mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,5 @@ jobs:
             imgui-lwjgl3/build/libs/*.jar
             bin/imgui-java64.dll
             bin/libimgui-java64.dylib
+            bin/libimgui-javaarm64.dylib
             bin/libimgui-java64.so

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ dependencies {
    - imgui-java64.dll - Windows
    - libimgui-java64.so - Linux
    - libimgui-java64.dylib - MacOS
+   - libimgui-javaarm64.dylib - MacOS
  3. Add jars to your classpath;
  4. Provide a VM option: `imgui.library.path` or `java.library.path`. It should point to the folder where you've placed downloaded native libraries.
 </details>

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Ensure you've downloaded git submodules. That could be achieved:
  - Check dependencies from "Linux" section and make sure you have them installed.
  - Build with: `./gradlew :imgui-binding:generateLibs -Denvs=mac -Dlocal`
  - Run with: `./gradlew :example:run -PlibPath=../imgui-binding/build/libsNative/macosx64`
+ - Alternatively for M1 Run with: `./gradlew :example:run -PlibPath=../imgui-binding/build/libsNative/macosxarm64`
 
 In `envs` parameter next values could be used `win`, `linux` or `mac`.<br>
 `-Dlocal` is optional and means that natives will be built under the `./imgui-binding/build/` folder. Otherwise `/tmp/imgui` folder will be used.

--- a/bin/README.txt
+++ b/bin/README.txt
@@ -9,5 +9,6 @@ You can change that by using 'imgui.library.name' VM option (ex: -Dimgui.library
 - imgui-java64.dll      << Windows
 - libimgui-java64.so    << Linux
 - libimgui-java64.dylib << MacOS
+- libimgui-javaarm64.dylib << MacOS
 
 Freetype folder contains same libraries, but with Freetype support.

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 ext {
-    jnigenVersion = '2.0.1'
+    jnigenVersion = '2.2.1'
 }
 
 dependencies {

--- a/buildSrc/scripts/copy-ft.sh
+++ b/buildSrc/scripts/copy-ft.sh
@@ -10,3 +10,4 @@ mkdir ./bin/freetype
 [ -e "/tmp/imgui/libsNative/linux32/libimgui-java.so" ] && cp /tmp/imgui/libsNative/linux32/libimgui-java.so ./bin/freetype
 [ -e "/tmp/imgui/libsNative/linux64/libimgui-java64.so" ] && cp /tmp/imgui/libsNative/linux64/libimgui-java64.so ./bin/freetype
 [ -e "/tmp/imgui/libsNative/macosx64/libimgui-java64.dylib" ] && cp /tmp/imgui/libsNative/macosx64/libimgui-java64.dylib ./bin/freetype
+[ -e "/tmp/imgui/libsNative/macosxarm64/libimgui-javaarm64.dylib" ] && cp /tmp/imgui/libsNative/macosxarm64/libimgui-javaarm64.dylib ./bin/freetype

--- a/buildSrc/scripts/copy.sh
+++ b/buildSrc/scripts/copy.sh
@@ -8,3 +8,4 @@ cd $BASEDIR/../.. || exit
 [ -e "/tmp/imgui/libsNative/linux32/libimgui-java.so" ] && cp /tmp/imgui/libsNative/linux32/libimgui-java.so ./bin
 [ -e "/tmp/imgui/libsNative/linux64/libimgui-java64.so" ] && cp /tmp/imgui/libsNative/linux64/libimgui-java64.so ./bin
 [ -e "/tmp/imgui/libsNative/macosx64/libimgui-java64.dylib" ] && cp /tmp/imgui/libsNative/macosx64/libimgui-java64.dylib ./bin
+[ -e "/tmp/imgui/libsNative/macosxarm64/libimgui-javaarm64.dylib" ] && cp /tmp/imgui/libsNative/macosxarm64/libimgui-javaarm64.dylib ./bin

--- a/buildSrc/src/main/groovy/tool/generator/GenerateLibs.groovy
+++ b/buildSrc/src/main/groovy/tool/generator/GenerateLibs.groovy
@@ -104,6 +104,13 @@ class GenerateLibs extends DefaultTask {
             mac64.linkerFlags = mac64.linkerFlags.replace('10.7', minMacOsVersion)
             addFreeTypeIfEnabled(mac64)
             buildTargets += mac64
+
+            def macM1 = BuildTarget.newDefaultTarget(BuildTarget.TargetOs.MacOsX, true, true)
+            macM1.cppFlags += ' -std=c++14'
+            macM1.cppFlags = macM1.cppFlags.replace('10.7', minMacOsVersion)
+            macM1.linkerFlags = macM1.linkerFlags.replace('10.7', minMacOsVersion)
+            addFreeTypeIfEnabled(macM1)
+            buildTargets += macM1
         }
 
         new AntScriptGenerator().generate(buildConfig, buildTargets)
@@ -117,8 +124,10 @@ class GenerateLibs extends DefaultTask {
             BuildExecutor.executeAnt(jniDir + '/build-windows64.xml', commonParams)
         if (forLinux)
             BuildExecutor.executeAnt(jniDir + '/build-linux64.xml', commonParams)
-        if (forMac)
+        if (forMac) {
             BuildExecutor.executeAnt(jniDir + '/build-macosx64.xml', commonParams)
+            BuildExecutor.executeAnt(jniDir + '/build-macosxarm64.xml', commonParams)
+        }
 
         BuildExecutor.executeAnt(jniDir + '/build.xml', '-v', 'pack-natives')
     }

--- a/buildSrc/src/main/groovy/tool/generator/GenerateLibs.groovy
+++ b/buildSrc/src/main/groovy/tool/generator/GenerateLibs.groovy
@@ -19,6 +19,7 @@ class GenerateLibs extends DefaultTask {
     private final boolean forWindows = buildEnvs?.contains('win')
     private final boolean forLinux = buildEnvs?.contains('linux')
     private final boolean forMac = buildEnvs?.contains('mac')
+    private static final boolean isARM = System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64");
 
     private final boolean isLocal = System.properties.containsKey('local')
     private final boolean withFreeType = Boolean.valueOf(System.properties.getProperty('freetype', 'false'))
@@ -145,7 +146,12 @@ class GenerateLibs extends DefaultTask {
                 target.cppFlags += ' -I/usr/include/freetype2'
                 break
             case BuildTarget.TargetOs.MacOsX:
-                target.cppFlags += ' -I/usr/local/include/freetype2'
+                if (isARM) {
+                    target.cppFlags += " -I/opt/homebrew/Cellar/freetype/2.11.1/include/freetype2"
+                    target.linkerFlags += " -L/opt/homebrew/Cellar/freetype/2.11.1/lib/"
+                } else {
+                    target.cppFlags += ' -I/usr/local/include/freetype2'
+                }
                 break
         }
 

--- a/buildSrc/src/main/groovy/tool/generator/GenerateLibs.groovy
+++ b/buildSrc/src/main/groovy/tool/generator/GenerateLibs.groovy
@@ -148,7 +148,6 @@ class GenerateLibs extends DefaultTask {
             case BuildTarget.TargetOs.MacOsX:
                 if (isARM) {
                     target.cppFlags += " -I/opt/homebrew/Cellar/freetype/2.11.1/include/freetype2"
-                    target.linkerFlags += " -L/opt/homebrew/Cellar/freetype/2.11.1/lib/"
                 } else {
                     target.cppFlags += ' -I/usr/local/include/freetype2'
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.86.3
+version=1.86.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.86.2
+version=1.86.3

--- a/imgui-app/build.gradle
+++ b/imgui-app/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api 'org.lwjgl:lwjgl-glfw'
     api 'org.lwjgl:lwjgl-opengl'
 
-    ['natives-linux', 'natives-windows', 'natives-macos'].each {
+    ['natives-linux', 'natives-windows', 'natives-macos', 'natives-macos-arm64'].each {
         api "org.lwjgl:lwjgl::$it"
         api "org.lwjgl:lwjgl-glfw::$it"
         api "org.lwjgl:lwjgl-opengl::$it"
@@ -31,6 +31,7 @@ jar {
     from('../bin') {
         include 'libimgui-java64.so'
         include 'libimgui-java64.dylib'
+        include 'libimgui-javaarm64.dylib'
         into 'io/imgui/java/native-bin/'
     }
     from('../bin/freetype') {

--- a/imgui-binding-natives/build.gradle
+++ b/imgui-binding-natives/build.gradle
@@ -7,23 +7,23 @@ plugins {
 def packageName = 'imgui-java-natives-linux'
 def packageDesc = 'Native binaries for imgui-java binding for Linux'
 def fromDir = '../bin'
-def libName = 'libimgui-java64.so'
+def libNames = ['libimgui-java64.so']
 
 switch (findProperty('deployType')) {
     case 'win':
         packageName = 'imgui-java-natives-windows'
         packageDesc = 'Native binaries for imgui-java binding for Windows'
-        libName = 'imgui-java64.dll'
+        libName = ['imgui-java64.dll']
         break
     case 'linux':
         packageName = 'imgui-java-natives-linux'
         packageDesc = 'Native binaries for imgui-java binding for Linux'
-        libName = 'libimgui-java64.so'
+        libNames = ['libimgui-java64.so']
         break
     case 'mac':
         packageName = 'imgui-java-natives-macos'
         packageDesc = 'Native binaries for imgui-java binding for MacOS'
-        libName = 'libimgui-java64.dylib'
+        libNames = ['libimgui-java64.dylib', 'libimgui-javaarm64.dylib']
         break
 }
 
@@ -35,7 +35,7 @@ if (findProperty('freetype') == 'true') {
 
 jar {
     from(fromDir) {
-        include "$libName" // this is fine
+        include libNames // this is fine
         into 'io/imgui/java/native-bin/'
     }
     manifest {

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -50,8 +50,12 @@ public class ImGui {
         final String libPath = System.getProperty(LIB_PATH_PROP);
         String genLibName = LIB_NAME_BASE;
 
-        if (isARM) genLibName += "arm";
-        if (is64Bit) genLibName += "64";
+        if (isARM) {
+            genLibName += "arm";
+        }
+        if (is64Bit) {
+            genLibName += "64";
+        }
 
         final String libName = System.getProperty(LIB_NAME_PROP, genLibName);
         final String fullLibName = resolveFullLibName();
@@ -114,8 +118,12 @@ public class ImGui {
 
         String genLibName = LIB_NAME_BASE;
 
-        if (isARM) genLibName += "arm";
-        if (is64Bit) genLibName += "64";
+        if (isARM) {
+            genLibName += "arm";
+        }
+        if (is64Bit) {
+            genLibName += "64";
+        }
 
 
         return System.getProperty(LIB_NAME_PROP, libPrefix + genLibName + libSuffix);

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -25,7 +25,10 @@ import java.nio.file.StandardCopyOption;
 public class ImGui {
     private static final String LIB_PATH_PROP = "imgui.library.path";
     private static final String LIB_NAME_PROP = "imgui.library.name";
-    private static final String LIB_NAME_DEFAULT = System.getProperty("os.arch").contains("64") ? "imgui-java64" : "imgui-java";
+    private static final String LIB_NAME_BASE = "imgui-java";
+    private static final boolean is64Bit = System.getProperty("os.arch").contains("64") || System.getProperty("os.arch").startsWith("armv8");
+    private static final boolean isARM = System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64");
+
     private static final String LIB_TMP_DIR_PREFIX = "imgui-java-natives_" + System.currentTimeMillis();
 
     private static final ImGuiContext IMGUI_CONTEXT;
@@ -45,7 +48,12 @@ public class ImGui {
 
     static {
         final String libPath = System.getProperty(LIB_PATH_PROP);
-        final String libName = System.getProperty(LIB_NAME_PROP, LIB_NAME_DEFAULT);
+        String genLibName = LIB_NAME_BASE;
+
+        if (isARM) genLibName += "arm";
+        if (is64Bit) genLibName += "64";
+
+        final String libName = System.getProperty(LIB_NAME_PROP, genLibName);
         final String fullLibName = resolveFullLibName();
 
         final String extractedLibAbsPath = tryLoadFromClasspath(fullLibName);
@@ -104,7 +112,13 @@ public class ImGui {
             libSuffix = ".so";
         }
 
-        return System.getProperty(LIB_NAME_PROP, libPrefix + LIB_NAME_DEFAULT + libSuffix);
+        String genLibName = LIB_NAME_BASE;
+
+        if (isARM) genLibName += "arm";
+        if (is64Bit) genLibName += "64";
+
+
+        return System.getProperty(LIB_NAME_PROP, libPrefix + genLibName + libSuffix);
     }
 
     // This method tries to unpack the library binary from classpath into the temp dir.


### PR DESCRIPTION
- Upgrades gdx-jnigen to latest release version.
- Changes the library loader to check for 64bit and arm to pick the right native path.
- Added the new binary. Let me know if you want that removed, or generated yourself/GHA.

Tested this with local maven publishing, GHA untested.