### PR TITLE
Adjust module name depending on deploy type

### DIFF
--- a/imgui-binding-natives/build.gradle
+++ b/imgui-binding-natives/build.gradle
@@ -6,6 +6,7 @@ plugins {
 
 def packageName = 'imgui-java-natives-linux'
 def packageDesc = 'Native binaries for imgui-java binding for Linux'
+def moduleName = "imgui.natives.linux"
 def fromDir = '../bin'
 def libName = 'libimgui-java64.so'
 
@@ -13,16 +14,19 @@ switch (findProperty('deployType')) {
     case 'win':
         packageName = 'imgui-java-natives-windows'
         packageDesc = 'Native binaries for imgui-java binding for Windows'
+        moduleName = "imgui.natives.windows"
         libName = 'imgui-java64.dll'
         break
     case 'linux':
         packageName = 'imgui-java-natives-linux'
         packageDesc = 'Native binaries for imgui-java binding for Linux'
+        moduleName = "imgui.natives.linux"
         libName = 'libimgui-java64.so'
         break
     case 'mac':
         packageName = 'imgui-java-natives-macos'
         packageDesc = 'Native binaries for imgui-java binding for MacOS'
+        moduleName = "imgui.natives.macos"
         libName = 'libimgui-java64.dylib'
         break
 }
@@ -39,7 +43,7 @@ jar {
         into 'io/imgui/java/native-bin/'
     }
     manifest {
-        attributes  'Automatic-Module-Name': 'imgui.natives'
+        attributes  'Automatic-Module-Name': moduleName
     }
 }
 

--- a/imgui-binding-natives/build.gradle
+++ b/imgui-binding-natives/build.gradle
@@ -20,7 +20,7 @@ switch (findProperty('deployType')) {
     case 'linux':
         packageName = 'imgui-java-natives-linux'
         packageDesc = 'Native binaries for imgui-java binding for Linux'
-        moduleName = "imgui.natives.linux"
+        moduleName = 'imgui.natives.linux'
         libName = 'libimgui-java64.so'
         break
     case 'mac':

--- a/imgui-binding-natives/build.gradle
+++ b/imgui-binding-natives/build.gradle
@@ -14,7 +14,7 @@ switch (findProperty('deployType')) {
     case 'win':
         packageName = 'imgui-java-natives-windows'
         packageDesc = 'Native binaries for imgui-java binding for Windows'
-        moduleName = "imgui.natives.windows"
+        moduleName = 'imgui.natives.windows'
         libName = 'imgui-java64.dll'
         break
     case 'linux':

--- a/imgui-binding-natives/build.gradle
+++ b/imgui-binding-natives/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 def packageName = 'imgui-java-natives-linux'
 def packageDesc = 'Native binaries for imgui-java binding for Linux'
-def moduleName = "imgui.natives.linux"
+def moduleName = 'imgui.natives.linux'
 def fromDir = '../bin'
 def libName = 'libimgui-java64.so'
 

--- a/imgui-binding-natives/build.gradle
+++ b/imgui-binding-natives/build.gradle
@@ -26,7 +26,7 @@ switch (findProperty('deployType')) {
     case 'mac':
         packageName = 'imgui-java-natives-macos'
         packageDesc = 'Native binaries for imgui-java binding for MacOS'
-        moduleName = "imgui.natives.macos"
+        moduleName = 'imgui.natives.macos'
         libName = 'libimgui-java64.dylib'
         break
 }


### PR DESCRIPTION
# Description
Changes module name depending on deploy type, this is workaround for Minecraft forge not being able to load multiple native libs, as it cannot load 2 or more modules with same module name

Fixes #118

## Type of change

Please check options that are relevant.

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
