### PR TITLE
[Build] Add support for arm64 build (Apple Silicon)

### DIFF
--- a/buildSrc/src/main/groovy/tool/generator/GenerateLibs.groovy
+++ b/buildSrc/src/main/groovy/tool/generator/GenerateLibs.groovy
@@ -19,6 +19,7 @@ class GenerateLibs extends DefaultTask {
     private final boolean forWindows = buildEnvs?.contains('win')
     private final boolean forLinux = buildEnvs?.contains('linux')
     private final boolean forMac = buildEnvs?.contains('mac')
+    private final boolean forArm64 = System.getProperty('arch') == 'arm64'
 
     private final boolean isLocal = System.properties.containsKey('local')
     private final boolean withFreeType = Boolean.valueOf(System.properties.getProperty('freetype', 'false'))
@@ -97,10 +98,15 @@ class GenerateLibs extends DefaultTask {
 
         if (forMac) {
             def minMacOsVersion = '10.15'
-            def mac64 = BuildTarget.newDefaultTarget(BuildTarget.TargetOs.MacOsX, true)
+            def mac64 = BuildTarget.newDefaultTarget(BuildTarget.TargetOs.MacOsX, true, forArm64)
             mac64.cppFlags += ' -std=c++14'
             mac64.cppFlags = mac64.cppFlags.replace('10.7', minMacOsVersion)
             mac64.linkerFlags = mac64.linkerFlags.replace('10.7', minMacOsVersion)
+            if (forArm64) {
+                mac64.cFlags = mac64.cFlags.replace('x86_64', 'arm64')
+                mac64.cppFlags = mac64.cppFlags.replace('x86_64', 'arm64')
+                mac64.linkerFlags = mac64.linkerFlags.replace('x86_64', 'arm64')
+            }
             addFreeTypeIfEnabled(mac64)
             buildTargets += mac64
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -366,7 +366,9 @@ Ensure you've downloaded git submodules. That could be achieved:
  
 ### macOS
  - Check dependencies from "Linux" section and make sure you have them installed.
- - Build with: `./gradlew :imgui-binding:generateLibs -Denvs=mac -Dlocal`
+ - Build with:
+    * x86_64: `./gradlew :imgui-binding:generateLibs -Denvs=mac -Dlocal`
+    * arm64: `./gradlew :imgui-binding:generateLibs -Denvs=mac -Darch=arm64 -Dlocal`
  - Run with: `./gradlew :example:run -PlibPath=../imgui-binding/build/libsNative/macosx64`
 
 In `envs` parameter next values could be used `win`, `linux` or `mac`.<br>

--- a/imgui-app/build.gradle
+++ b/imgui-app/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api 'org.lwjgl:lwjgl-glfw'
     api 'org.lwjgl:lwjgl-opengl'
 
-    ['natives-linux', 'natives-windows', 'natives-macos'].each {
+    ['natives-linux', 'natives-windows', 'natives-macos', 'natives-macos-arm64'].each {
         api "org.lwjgl:lwjgl::$it"
         api "org.lwjgl:lwjgl-glfw::$it"
         api "org.lwjgl:lwjgl-opengl::$it"


### PR DESCRIPTION
# Description

Adds support for local arm64 build on macs (imgui-binding) by adding build property `-Darch=arm64`

## Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
