### PR TITLE
Fix `calcTextSize` to be used in a static context

### DIFF
--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -5543,19 +5543,19 @@ public class ImGui {
 
     // Text Utilities
 
-    public final ImVec2 calcTextSize(final String text) {
+    public static ImVec2 calcTextSize(final String text) {
         final ImVec2 value = new ImVec2();
         calcTextSize(value, text);
         return value;
     }
 
-    public final ImVec2 calcTextSize(final String text, final boolean hideTextAfterDoubleHash) {
+    public static ImVec2 calcTextSize(final String text, final boolean hideTextAfterDoubleHash) {
         final ImVec2 value = new ImVec2();
         calcTextSize(value, text, hideTextAfterDoubleHash);
         return value;
     }
 
-    public final ImVec2 calcTextSize(final String text, final boolean hideTextAfterDoubleHash, final float wrapWidth) {
+    public static ImVec2 calcTextSize(final String text, final boolean hideTextAfterDoubleHash, final float wrapWidth) {
         final ImVec2 value = new ImVec2();
         calcTextSize(value, text, hideTextAfterDoubleHash, wrapWidth);
         return value;


### PR DESCRIPTION
# Description

`calcTextSize` was missing the `static` keyword. I also removed the `final` one because it seems inconsistent with the rest of methods

## Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
