### PR TITLE
Fix nullpointer exception when running with LWJGLX-debug

### DIFF
--- a/imgui-lwjgl3/src/main/java/imgui/glfw/ImGuiImplGlfw.java
+++ b/imgui-lwjgl3/src/main/java/imgui/glfw/ImGuiImplGlfw.java
@@ -32,6 +32,7 @@ import org.lwjgl.glfw.GLFWNativeWin32;
 import org.lwjgl.glfw.GLFWScrollCallback;
 import org.lwjgl.glfw.GLFWVidMode;
 import org.lwjgl.glfw.GLFWWindowFocusCallback;
+import org.lwjgl.opengl.GL;
 
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
@@ -676,6 +677,7 @@ public class ImGuiImplGlfw {
 
             glfwMakeContextCurrent(data.window);
             glfwSwapInterval(0);
+            GL.createCapabilities();
         }
     }
 


### PR DESCRIPTION
# Description

I added a call to [this function](https://github.com/LWJGLX/debug/blob/402539ae55f2b5356d63cf58ca073943ca1b8cea/src/org/lwjglx/debug/org/lwjgl/opengl/GL.java#L31) after platform window creation as it initializes a `MAX_VERTEX_ATTRIBS` variable for the current OpenGL context which is then used as a size for the creation of an array which is accessed [here](https://github.com/LWJGLX/debug/blob/402539ae55f2b5356d63cf58ca073943ca1b8cea/src/org/lwjglx/debug/org/lwjgl/opengl/GL20.java#L40). When this function isn't called, the length of the array is zero and thus [this function call](https://github.com/SpaiR/imgui-java/blob/8a65518093485d68049479af08aca15007a734d4/imgui-lwjgl3/src/main/java/imgui/gl3/ImGuiImplGl3.java#L420) throws an index-out-of-bounds exception.

Note: This only occurs when LWJGLX-debug is used.

## Type of change

- [X] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
