### PR TITLE
ImNodes::EditorContextGetPanning missing

### DIFF
--- a/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
@@ -440,8 +440,9 @@ public final class ImNodes {
         ImNodes::EditorContextResetPanning(ImVec2(x, y));
     */
 
-    public static native ImVec2 editorContextGetPanning(); /*
-        return ImNodes::EditorContextGetPanning();
+    public static native void editorContextGetPanning(ImVec2 result); /*
+        ImVec2 dst = ImNodes::EditorContextGetPanning();
+        Jni::ImVec2Cpy(env, $dst, result);
     */
 
     public static native void editorMoveToNode(int node); /*

--- a/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
@@ -442,7 +442,7 @@ public final class ImNodes {
 
     public static native void editorContextGetPanning(ImVec2 result); /*
         ImVec2 dst = ImNodes::EditorContextGetPanning();
-        Jni::ImVec2Cpy(env, $dst, result);
+        Jni::ImVec2Cpy(env, &dst, result);
     */
 
     public static native void editorMoveToNode(int node); /*

--- a/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
@@ -440,6 +440,10 @@ public final class ImNodes {
         ImNodes::EditorContextResetPanning(ImVec2(x, y));
     */
 
+    public static native ImVec2 editorContextGetPanning(); /*
+        return ImNodes::EditorContextGetPanning();
+    */
+
     public static native void editorMoveToNode(int node); /*
         ImNodes::EditorContextMoveToNode(node);
     */


### PR DESCRIPTION
# Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->
This PR adds a missing binding for `ImVec2 ImNodes::EditorContextGetPanning()`.

## Type of change

<!-- 
Please check options that are relevant.
-->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
