### PR TITLE
Fix nHasDragDropPayload SIGSEGV when payload doesn't exist

### DIFF
--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -5118,11 +5118,13 @@ public class ImGui {
     }
 
     private static native boolean nHasDragDropPayload(); /*
-        return ImGui::GetDragDropPayload()->Data != NULL;
+        const ImGuiPayload* payload = ImGui::GetDragDropPayload();
+        return payload != NULL && payload->Data != NULL;
     */
 
     private static native boolean nHasDragDropPayload(String dataType); /*
-        return ImGui::GetDragDropPayload()->IsDataType(dataType);
+        const ImGuiPayload* payload = ImGui::GetDragDropPayload();
+        return payload != NULL && payload->IsDataType(dataType);
     */
 
     /**


### PR DESCRIPTION
# Description

`getDragDropPayload()` functions should simply return null when the payload doesn't exist.

Currently, DearImGui will return NULL from `ImGui::GetDragDropPayload()` when the payload does not exist.
This causes a null dereference since the nHasDragDropPayload function performs no NULL check

## Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
