### PR TITLE
Add missing import in example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ A very simple application may look like this:
 ```
 import imgui.ImGui;
 import imgui.app.Application;
+import imgui.app.Configuration;
 
 public class Main extends Application {
     @Override


### PR DESCRIPTION
# Description

I tried running the example from readme and got error `cannot find symbol ... class Configuration`. So I added the missing import `import imgui.app.Configuration;`.

## Type of change

- [x] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
