### PR TITLE
Fix glyph range size

### DIFF
--- a/imgui-binding/src/main/java/imgui/ImFontAtlas.java
+++ b/imgui-binding/src/main/java/imgui/ImFontAtlas.java
@@ -390,7 +390,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
             const ImWchar* ranges = glyphs; \
             int size = 0; \
             for (; ranges[0]; ranges += 2) \
-                size++; \
+                size += 2; \
             jshortArray jShorts = env->NewShortArray(size); \
             env->SetShortArrayRegion(jShorts, 0, size, (jshort*)glyphs); \
             return jShorts;

--- a/imgui-binding/src/main/java/imgui/ImFontAtlas.java
+++ b/imgui-binding/src/main/java/imgui/ImFontAtlas.java
@@ -387,7 +387,10 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
 
     /*JNI
         #define RETURN_GLYPH_2_SHORT(glyphs) \
-            int size = sizeof(glyphs); \
+            int size = 0; \
+            for (; glyphs[0]; glyphs += 2) \
+                size++;
+            glyphs -= size * 2;
             jshortArray jShorts = env->NewShortArray(size); \
             env->SetShortArrayRegion(jShorts, 0, size, (jshort*)glyphs); \
             return jShorts;

--- a/imgui-binding/src/main/java/imgui/ImFontAtlas.java
+++ b/imgui-binding/src/main/java/imgui/ImFontAtlas.java
@@ -387,10 +387,10 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
 
     /*JNI
         #define RETURN_GLYPH_2_SHORT(glyphs) \
+            const ImWchar* ranges = glyphs; \
             int size = 0; \
-            for (; glyphs[0]; glyphs += 2) \
+            for (; ranges[0]; ranges += 2) \
                 size++; \
-            glyphs -= size * 2; \
             jshortArray jShorts = env->NewShortArray(size); \
             env->SetShortArrayRegion(jShorts, 0, size, (jshort*)glyphs); \
             return jShorts;

--- a/imgui-binding/src/main/java/imgui/ImFontAtlas.java
+++ b/imgui-binding/src/main/java/imgui/ImFontAtlas.java
@@ -389,8 +389,8 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         #define RETURN_GLYPH_2_SHORT(glyphs) \
             int size = 0; \
             for (; glyphs[0]; glyphs += 2) \
-                size++;
-            glyphs -= size * 2;
+                size++; \
+            glyphs -= size * 2; \
             jshortArray jShorts = env->NewShortArray(size); \
             env->SetShortArrayRegion(jShorts, 0, size, (jshort*)glyphs); \
             return jShorts;


### PR DESCRIPTION
# Description

`ImFontAtlas#getGlyphRanges***` returns invalid length of short array. This causes an problem that by using this method we can't render Japanese, Chinese and so on. This bug comes from the bug of RETURN_GLYPH_2_SHORT. The size comes from sizeof(glyphs), but glyphs is ImWchar*, which is pointer, so it returns the size of pointer not array length.

Fixes #131
Fixes #70

## Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
