### PR TITLE
[API] Fix native loading by stopping creating tmpDir every time

### DIFF
--- a/imgui-binding/.gitignore
+++ b/imgui-binding/.gitignore
@@ -1,1 +1,0 @@
-src/main/resources/META-INF/imgui-java.properties

--- a/imgui-binding/.gitignore
+++ b/imgui-binding/.gitignore
@@ -1,0 +1,1 @@
+src/main/resources/META-INF/imgui-java.properties

--- a/imgui-binding/build.gradle
+++ b/imgui-binding/build.gradle
@@ -1,4 +1,5 @@
 import tool.generator.GenerateLibs
+import java.nio.file.Files
 
 plugins {
     id 'java'
@@ -33,4 +34,20 @@ jar {
     manifest {
         attributes  'Automatic-Module-Name': 'imgui.binding'
     }
+}
+
+tasks.register('makePropertyResource') {
+    def directory = file "src/main/resources/META-INF"
+    Files.createDirectories(directory.toPath())
+    def propertyFile = file "${project.projectDir}/src/main/resources/META-INF/imgui-java.properties"
+    def props = new Properties()
+    if (propertyFile.exists()) {
+        propertyFile.withReader { props.load(it) }
+    }
+    props.setProperty("version", project.version)
+    propertyFile.withWriter { props.store(it, "imgui-java") }
+}
+
+processResources {
+    dependsOn makePropertyResource
 }

--- a/imgui-binding/build.gradle
+++ b/imgui-binding/build.gradle
@@ -1,5 +1,4 @@
 import tool.generator.GenerateLibs
-import java.nio.file.Files
 
 plugins {
     id 'java'
@@ -37,9 +36,9 @@ jar {
 }
 
 tasks.register('makePropertyResource') {
-    def directory = file "src/main/resources/META-INF"
-    Files.createDirectories(directory.toPath())
-    def propertyFile = file "${project.projectDir}/src/main/resources/META-INF/imgui-java.properties"
+    def directory = file "${buildDir}/resources/main/imgui/"
+    directory.mkdirs()
+    def propertyFile = file "${directory}/imgui-java.properties"
     def props = new Properties()
     if (propertyFile.exists()) {
         propertyFile.withReader { props.load(it) }

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -142,7 +142,7 @@ public class ImGui {
     }
 
     private static String getVersionString() {
-        Properties properties = new Properties();
+        final Properties properties = new Properties();
         try (InputStream is = ImGui.class.getResourceAsStream("/META-INF/imgui-java.properties")) {
             if (is != null) {
                 properties.load(is);

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -143,7 +143,7 @@ public class ImGui {
 
     private static String getVersionString() {
         final Properties properties = new Properties();
-        try (InputStream is = ImGui.class.getResourceAsStream("/META-INF/imgui-java.properties")) {
+        try (InputStream is = ImGui.class.getResourceAsStream("/imgui/imgui-java.properties")) {
             if (is != null) {
                 properties.load(is);
                 return properties.get("version").toString();

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -55,10 +55,18 @@ public class ImGui {
 
         if (libPath != null) {
             System.load(Paths.get(libPath).resolve(fullLibName).toFile().getAbsolutePath());
-        } else if (extractedLibAbsPath != null) {
-            System.load(extractedLibAbsPath);
         } else {
-            System.loadLibrary(libName);
+            try {
+                System.loadLibrary(libName);
+            } catch (Exception | Error e) {
+                if (extractedLibAbsPath != null) {
+                    System.out.println("Extract");
+                    System.load(extractedLibAbsPath);
+                    e.printStackTrace();
+                } else {
+                    throw e;
+                }
+            }
         }
 
         IMGUI_CONTEXT = new ImGuiContext(0);

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -124,7 +124,7 @@ public class ImGui {
             final Path libBin = tmpDir.resolve(fullLibName);
             try {
                 Files.copy(is, libBin, StandardCopyOption.REPLACE_EXISTING);
-            } catch(AccessDeniedException e) {
+            } catch (AccessDeniedException e) {
                 if (!Files.exists(libBin)) {
                     throw e;
                 }

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -60,9 +60,7 @@ public class ImGui {
                 System.loadLibrary(libName);
             } catch (Exception | Error e) {
                 if (extractedLibAbsPath != null) {
-                    System.out.println("Extract");
                     System.load(extractedLibAbsPath);
-                    e.printStackTrace();
                 } else {
                     throw e;
                 }

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -51,14 +51,13 @@ public class ImGui {
         final String libName = System.getProperty(LIB_NAME_PROP, LIB_NAME_DEFAULT);
         final String fullLibName = resolveFullLibName();
 
-        final String extractedLibAbsPath = tryLoadFromClasspath(fullLibName);
-
         if (libPath != null) {
-            System.load(Paths.get(libPath).resolve(fullLibName).toFile().getAbsolutePath());
+            System.load(Paths.get(libPath).resolve(fullLibName).toAbsolutePath().toString());
         } else {
             try {
                 System.loadLibrary(libName);
             } catch (Exception | Error e) {
+                final String extractedLibAbsPath = tryLoadFromClasspath(fullLibName);
                 if (extractedLibAbsPath != null) {
                     System.load(extractedLibAbsPath);
                 } else {

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Properties;
 
 public class ImGui {
     private static final String LIB_PATH_PROP = "imgui.library.path";
@@ -116,7 +117,11 @@ public class ImGui {
                 return null;
             }
 
-            final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir")).resolve(LIB_TMP_DIR_PREFIX).resolve(ImGui.class.getPackage().getImplementationVersion());
+            String version = getVersionString();
+            if (version == null) {
+                version = "unknown";
+            }
+            final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir")).resolve(LIB_TMP_DIR_PREFIX).resolve(version);
             if (!Files.exists(tmpDir)) {
                 Files.createDirectories(tmpDir);
             }
@@ -134,6 +139,19 @@ public class ImGui {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private static String getVersionString() {
+        Properties properties = new Properties();
+        try (InputStream is = ImGui.class.getResourceAsStream("/META-INF/imgui-java.properties")) {
+            if (is != null) {
+                properties.load(is);
+                return properties.get("version").toString();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
# Description
imgui-java tries delete the native library when JVM shutdowns, but JVM locks the native library until JVM shutdowns, so deleteOnExit() will fail.

Instead of creating a temporary directory, imgui-java creates a directory that depends on its version on tmp dir of OS. This enables us to launch different versions of imgui-java at the same time.
This way is used by LWJGL.

Fixes #182 

## Type of change

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
