### PR TITLE
build(deps): bump com.gradleup.shadow from 7.1.2 to 8.3.0

### DIFF
--- a/imgui-app/build.gradle
+++ b/imgui-app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.gradleup.shadow' version '8.3.0'
     id 'checkstyle'
     id 'maven-publish'
     id 'signing'
@@ -36,6 +36,7 @@ jar {
         include 'libimgui-java64.dylib'
         into 'io/imgui/java/native-bin/'
     }
+
     manifest {
         attributes  'Automatic-Module-Name': 'imgui.app'
     }


### PR DESCRIPTION
closes #173 