### PR TITLE
Ast generator stores more info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,18 +52,14 @@ tasks.register('buildAll') { t ->
 
 tasks.register('generateAst', GenerateAst) {
     headerFiles = [
-            (file('include/imgui/imgui.h')): [],
-            (file('include/imgui/imgui_internal.h')): [
-                    "#define IMGUI_HAS_TABLE",
-                    "#define IMGUI_HAS_VIEWPORT",
-                    "#define IMGUI_HAS_DOCK",
-            ],
-            (file('include/ImGuiFileDialog/ImGuiFileDialog.h')): [],
-            (file('include/imgui-knobs/imgui-knobs.h')): [],
-            (file('include/imguizmo/ImGuizmo.h')): [],
-            (file('include/imnodes/imnodes.h')): [],
-            (file('include/implot/implot.h')): [],
-            (file('include/imgui-node-editor/imgui_node_editor.h')): [],
-            (file('include/ImGuiColorTextEdit/TextEditor.h')): [],
+            file('include/imgui/imgui.h'),
+            file('include/imgui/imgui_internal.h'),
+            file('include/ImGuiFileDialog/ImGuiFileDialog.h'),
+            file('include/imgui-knobs/imgui-knobs.h'),
+            file('include/imguizmo/ImGuizmo.h'),
+            file('include/imnodes/imnodes.h'),
+            file('include/implot/implot.h'),
+            file('include/imgui-node-editor/imgui_node_editor.h'),
+            file('include/ImGuiColorTextEdit/TextEditor.h'),
     ]
 }

--- a/buildSrc/src/main/kotlin/tool/generator/ast/decl.kt
+++ b/buildSrc/src/main/kotlin/tool/generator/ast/decl.kt
@@ -115,7 +115,7 @@ data class AstEnumConstantDecl(
     val qualType: String = "",
     val order: Int = -1,
     val value: String? = null,
-    val evaluatedValue: String? = null,
+    val evaluatedValue: Int? = null,
 ) : Decl
 
 data class AstRecordDecl(

--- a/buildSrc/src/main/kotlin/tool/generator/ast/task/GenerateAst.kt
+++ b/buildSrc/src/main/kotlin/tool/generator/ast/task/GenerateAst.kt
@@ -314,7 +314,7 @@ open class GenerateAst : DefaultTask() {
                             decl.qualType,
                             order++,
                             decl.value,
-                            lookupEnumEvaluatedValue0(enumDecls, idx).toString(),
+                            lookupEnumEvaluatedValue0(enumDecls, idx),
                         )
                     }
 
@@ -349,7 +349,7 @@ open class GenerateAst : DefaultTask() {
                         // We provide a proper order in EnumDecl, after sorting all enums by their offset.
                         -1,
                         declValue,
-                        evaluatedValue.toString()
+                        evaluatedValue
                     )
                 }
 
@@ -431,9 +431,7 @@ open class GenerateAst : DefaultTask() {
         val decl = decls[idx]
 
         if (decl.evaluatedValue != null) {
-            decl.evaluatedValue.toIntOrNull()?.let {
-                return it
-            }
+            return decl.evaluatedValue
         }
 
         if (decl.value != null) {

--- a/buildSrc/src/main/resources/generator/api/ast/ast-ImGuiFileDialog.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-ImGuiFileDialog.json
@@ -6,6 +6,794 @@
     "revision" : "007091af18c69a2eed15cf5016951eb481a1de79"
   },
   "decls" : [ {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswalnum_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswblank_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswalpha_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswhexnumber_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "timespec",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "tv_sec",
+      "qualType" : "__darwin_time_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tv_nsec",
+      "qualType" : "long",
+      "desugaredQualType" : "long"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswcntrl_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswideogram_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswctype_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswnumber_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswdigit_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswphonogram_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswgraph_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswrune_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswalnum",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswlower_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswspecial_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswalpha",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswblank",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "lconv",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "decimal_point",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "thousands_sep",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "grouping",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_curr_symbol",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "currency_symbol",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "mon_decimal_point",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "mon_thousands_sep",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "mon_grouping",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "positive_sign",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "negative_sign",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_frac_digits",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "frac_digits",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "p_cs_precedes",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "p_sep_by_space",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "n_cs_precedes",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "n_sep_by_space",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "p_sign_posn",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "n_sign_posn",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_p_cs_precedes",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_n_cs_precedes",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_p_sep_by_space",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_n_sep_by_space",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_p_sign_posn",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_n_sign_posn",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswprint_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswcntrl",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswascii",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswpunct_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswctype",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswhexnumber",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswspace_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswdigit",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswideogram",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswgraph",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswupper_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswnumber",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswlower",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswphonogram",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswxdigit_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswprint",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "digittoint_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswrune",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "towlower_l",
+    "resultType" : "wint_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswpunct",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isalnum_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswspecial",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "towupper_l",
+    "resultType" : "wint_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswspace",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isalpha_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswupper",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isblank_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswxdigit",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iscntrl_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "towlower",
+    "resultType" : "wint_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isdigit_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "towupper",
+    "resultType" : "wint_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isgraph_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ishexnumber_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isideogram_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "tm",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_sec",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_min",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_hour",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_mday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_mon",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_year",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_wday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_yday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_isdst",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_gmtoff",
+      "qualType" : "long",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_zone",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "islower_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isnumber_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isphonogram_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isprint_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ispunct_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isrune_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isspace_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isspecial_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isupper_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isxdigit_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "tolower_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "toupper_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isascii",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "major",
+    "resultType" : "__int32_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "minor",
+    "resultType" : "__int32_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "makedev",
+    "resultType" : "dev_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isalnum",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isalpha",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isblank",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iscntrl",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isdigit",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isgraph",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "islower",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isprint",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ispunct",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isspace",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isupper",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isxdigit",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "toascii",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "tolower",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "toupper",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "digittoint",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ishexnumber",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isideogram",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isnumber",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isphonogram",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isrune",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isspecial",
+    "resultType" : "int"
+  }, {
     "@type" : "AstEnumDecl",
     "name" : "IGFD_FileStyleFlags_",
     "decls" : [ {
@@ -783,25 +1571,29 @@
           "name" : "FIELD_FILENAME",
           "docComment" : "sorted by filename",
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
-          "order" : 1
+          "order" : 1,
+          "evaluatedValue" : "1"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "FIELD_TYPE",
           "docComment" : "sorted by filetype",
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
-          "order" : 2
+          "order" : 2,
+          "evaluatedValue" : "2"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "FIELD_SIZE",
           "docComment" : "sorted by filesize (formated file size)",
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
-          "order" : 3
+          "order" : 3,
+          "evaluatedValue" : "3"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "FIELD_DATE",
           "docComment" : "sorted by filedate",
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
-          "order" : 4
+          "order" : 4,
+          "evaluatedValue" : "4"
         } ]
       }, {
         "@type" : "AstFieldDecl",
@@ -1230,6 +2022,11 @@
         "name" : "SetCurrentDir",
         "resultType" : "void",
         "decls" : [ {
+          "@type" : "AstParmVarDecl",
+          "name" : "vPath",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
           "@type" : "AstFullComment",
           "decls" : [ {
             "@type" : "AstParagraphComment",
@@ -1238,11 +2035,6 @@
               "text" : "depend of dirent.h"
             } ]
           } ]
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1534,10 +2326,6 @@
           } ]
         } ]
       }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator=",
-        "resultType" : "IGFD::FileDialog &"
-      }, {
         "@type" : "AstFieldDecl",
         "name" : "prFileDialogInternal",
         "qualType" : "FileDialogInternal",
@@ -1561,6 +2349,49 @@
         "name" : "OpenDialog",
         "resultType" : "void",
         "decls" : [ {
+          "@type" : "AstParmVarDecl",
+          "name" : "vKey",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vTitle",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vFilters",
+          "qualType" : "const char *",
+          "desugaredQualType" : "const char *"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vPath",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vFileName",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vCountSelectionMax",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &",
+          "defaultValue" : "1"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vUserDatas",
+          "qualType" : "UserDatas",
+          "desugaredQualType" : "void *",
+          "defaultValue" : "nullptr"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vFlags",
+          "qualType" : "ImGuiFileDialogFlags",
+          "desugaredQualType" : "int",
+          "defaultValue" : "0"
+        }, {
           "@type" : "AstFullComment",
           "decls" : [ {
             "@type" : "AstParagraphComment",
@@ -1569,49 +2400,6 @@
               "text" : " standard dialog"
             } ]
           } ]
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vFilters",
-          "qualType" : "const char *",
-          "desugaredQualType" : "const char *"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vCountSelectionMax",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &",
-          "defaultValue" : "1"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vUserDatas",
-          "qualType" : "UserDatas",
-          "desugaredQualType" : "void *",
-          "defaultValue" : "nullptr"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vFlags",
-          "qualType" : "ImGuiFileDialogFlags",
-          "desugaredQualType" : "int",
-          "defaultValue" : "0"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1661,15 +2449,6 @@
         "name" : "OpenDialog",
         "resultType" : "void",
         "decls" : [ {
-          "@type" : "AstFullComment",
-          "decls" : [ {
-            "@type" : "AstParagraphComment",
-            "decls" : [ {
-              "@type" : "AstTextComment",
-              "text" : " with pane"
-            } ]
-          } ]
-        }, {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
           "qualType" : "const int &",
@@ -1723,6 +2502,15 @@
           "qualType" : "ImGuiFileDialogFlags",
           "desugaredQualType" : "int",
           "defaultValue" : "0"
+        }, {
+          "@type" : "AstFullComment",
+          "decls" : [ {
+            "@type" : "AstParagraphComment",
+            "decls" : [ {
+              "@type" : "AstTextComment",
+              "text" : " with pane"
+            } ]
+          } ]
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1783,6 +2571,49 @@
         "name" : "OpenModal",
         "resultType" : "void",
         "decls" : [ {
+          "@type" : "AstParmVarDecl",
+          "name" : "vKey",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vTitle",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vFilters",
+          "qualType" : "const char *",
+          "desugaredQualType" : "const char *"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vPath",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vFileName",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vCountSelectionMax",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &",
+          "defaultValue" : "1"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vUserDatas",
+          "qualType" : "UserDatas",
+          "desugaredQualType" : "void *",
+          "defaultValue" : "nullptr"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "vFlags",
+          "qualType" : "ImGuiFileDialogFlags",
+          "desugaredQualType" : "int",
+          "defaultValue" : "0"
+        }, {
           "@type" : "AstFullComment",
           "decls" : [ {
             "@type" : "AstParagraphComment",
@@ -1791,49 +2622,6 @@
               "text" : " modal dialog"
             } ]
           } ]
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vFilters",
-          "qualType" : "const char *",
-          "desugaredQualType" : "const char *"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vCountSelectionMax",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &",
-          "defaultValue" : "1"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vUserDatas",
-          "qualType" : "UserDatas",
-          "desugaredQualType" : "void *",
-          "defaultValue" : "nullptr"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vFlags",
-          "qualType" : "ImGuiFileDialogFlags",
-          "desugaredQualType" : "int",
-          "defaultValue" : "0"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1883,15 +2671,6 @@
         "name" : "OpenModal",
         "resultType" : "void",
         "decls" : [ {
-          "@type" : "AstFullComment",
-          "decls" : [ {
-            "@type" : "AstParagraphComment",
-            "decls" : [ {
-              "@type" : "AstTextComment",
-              "text" : " with pane"
-            } ]
-          } ]
-        }, {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
           "qualType" : "const int &",
@@ -1945,6 +2724,15 @@
           "qualType" : "ImGuiFileDialogFlags",
           "desugaredQualType" : "int",
           "defaultValue" : "0"
+        }, {
+          "@type" : "AstFullComment",
+          "decls" : [ {
+            "@type" : "AstParagraphComment",
+            "decls" : [ {
+              "@type" : "AstTextComment",
+              "text" : " with pane"
+            } ]
+          } ]
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2005,15 +2793,6 @@
         "name" : "Display",
         "resultType" : "bool",
         "decls" : [ {
-          "@type" : "AstFullComment",
-          "decls" : [ {
-            "@type" : "AstParagraphComment",
-            "decls" : [ {
-              "@type" : "AstTextComment",
-              "text" : " Display / Close dialog form"
-            } ]
-          } ]
-        }, {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
           "qualType" : "const int &",
@@ -2036,6 +2815,15 @@
           "qualType" : "int",
           "desugaredQualType" : "int",
           "defaultValue" : "ImVec2(FLT_MAX, FLT_MAX)"
+        }, {
+          "@type" : "AstFullComment",
+          "decls" : [ {
+            "@type" : "AstParagraphComment",
+            "decls" : [ {
+              "@type" : "AstTextComment",
+              "text" : " Display / Close dialog form"
+            } ]
+          } ]
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2046,6 +2834,11 @@
         "name" : "WasOpenedThisFrame",
         "resultType" : "bool",
         "decls" : [ {
+          "@type" : "AstParmVarDecl",
+          "name" : "vKey",
+          "qualType" : "const int &",
+          "desugaredQualType" : "const int &"
+        }, {
           "@type" : "AstFullComment",
           "decls" : [ {
             "@type" : "AstParagraphComment",
@@ -2054,11 +2847,6 @@
               "text" : " queries"
             } ]
           } ]
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2125,15 +2913,6 @@
         "name" : "SetFileStyle",
         "resultType" : "void",
         "decls" : [ {
-          "@type" : "AstFullComment",
-          "decls" : [ {
-            "@type" : "AstParagraphComment",
-            "decls" : [ {
-              "@type" : "AstTextComment",
-              "text" : " file style by extentions"
-            } ]
-          } ]
-        }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFlags",
           "qualType" : "const IGFD_FileStyleFlags &",
@@ -2148,6 +2927,15 @@
           "name" : "vInfos",
           "qualType" : "const FileStyle &",
           "desugaredQualType" : "const FileStyle &"
+        }, {
+          "@type" : "AstFullComment",
+          "decls" : [ {
+            "@type" : "AstParagraphComment",
+            "decls" : [ {
+              "@type" : "AstTextComment",
+              "text" : " file style by extentions"
+            } ]
+          } ]
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2254,15 +3042,6 @@
         "name" : "prConfirm_Or_OpenOverWriteFileDialog_IfNeeded",
         "resultType" : "bool",
         "decls" : [ {
-          "@type" : "AstFullComment",
-          "decls" : [ {
-            "@type" : "AstParagraphComment",
-            "decls" : [ {
-              "@type" : "AstTextComment",
-              "text" : " others"
-            } ]
-          } ]
-        }, {
           "@type" : "AstParmVarDecl",
           "name" : "vLastAction",
           "qualType" : "bool",
@@ -2272,6 +3051,15 @@
           "name" : "vFlags",
           "qualType" : "int",
           "desugaredQualType" : "int"
+        }, {
+          "@type" : "AstFullComment",
+          "decls" : [ {
+            "@type" : "AstParagraphComment",
+            "decls" : [ {
+              "@type" : "AstTextComment",
+              "text" : " others"
+            } ]
+          } ]
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2300,6 +3088,11 @@
         "name" : "prDrawSidePane",
         "resultType" : "void",
         "decls" : [ {
+          "@type" : "AstParmVarDecl",
+          "name" : "vHeight",
+          "qualType" : "float",
+          "desugaredQualType" : "float"
+        }, {
           "@type" : "AstFullComment",
           "decls" : [ {
             "@type" : "AstParagraphComment",
@@ -2308,11 +3101,6 @@
               "text" : " widgets components"
             } ]
           } ]
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "vHeight",
-          "qualType" : "float",
-          "desugaredQualType" : "float"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2354,24 +3142,6 @@
         "name" : "prBeginFileColorIconStyle",
         "resultType" : "void",
         "decls" : [ {
-          "@type" : "AstFullComment",
-          "decls" : [ {
-            "@type" : "AstParagraphComment",
-            "decls" : [ {
-              "@type" : "AstTextComment",
-              "text" : " to be called only by these function and theirs overrides"
-            }, {
-              "@type" : "AstTextComment",
-              "text" : " - prDrawFileListView"
-            }, {
-              "@type" : "AstTextComment",
-              "text" : " - prDrawThumbnailsListView"
-            }, {
-              "@type" : "AstTextComment",
-              "text" : " - prDrawThumbnailsGridView"
-            } ]
-          } ]
-        }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFileInfos",
           "qualType" : "std::shared_ptr<FileInfos>",
@@ -2391,6 +3161,24 @@
           "name" : "vOutFont",
           "qualType" : "int **",
           "desugaredQualType" : "int **"
+        }, {
+          "@type" : "AstFullComment",
+          "decls" : [ {
+            "@type" : "AstParagraphComment",
+            "decls" : [ {
+              "@type" : "AstTextComment",
+              "text" : " to be called only by these function and theirs overrides"
+            }, {
+              "@type" : "AstTextComment",
+              "text" : " - prDrawFileListView"
+            }, {
+              "@type" : "AstTextComment",
+              "text" : " - prDrawThumbnailsListView"
+            }, {
+              "@type" : "AstTextComment",
+              "text" : " - prDrawThumbnailsGridView"
+            } ]
+          } ]
         } ]
       }, {
         "@type" : "AstFunctionDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-ImGuiFileDialog.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-ImGuiFileDialog.json
@@ -803,7 +803,7 @@
       "qualType" : "IGFD_FileStyleFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "IGFD_FileStyleByTypeFile",
@@ -811,7 +811,7 @@
       "qualType" : "IGFD_FileStyleFlags_",
       "order" : 1,
       "value" : "(1 << 0)",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "IGFD_FileStyleByTypeDir",
@@ -819,7 +819,7 @@
       "qualType" : "IGFD_FileStyleFlags_",
       "order" : 2,
       "value" : "(1 << 1)",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "IGFD_FileStyleByTypeLink",
@@ -827,7 +827,7 @@
       "qualType" : "IGFD_FileStyleFlags_",
       "order" : 3,
       "value" : "(1 << 2)",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "IGFD_FileStyleByExtention",
@@ -835,7 +835,7 @@
       "qualType" : "IGFD_FileStyleFlags_",
       "order" : 4,
       "value" : "(1 << 3)",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "IGFD_FileStyleByFullName",
@@ -843,7 +843,7 @@
       "qualType" : "IGFD_FileStyleFlags_",
       "order" : 5,
       "value" : "(1 << 4)",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "IGFD_FileStyleByContainedInFullName",
@@ -851,7 +851,7 @@
       "qualType" : "IGFD_FileStyleFlags_",
       "order" : 6,
       "value" : "(1 << 5)",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -862,7 +862,7 @@
       "qualType" : "ImGuiFileDialogFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFileDialogFlags_ConfirmOverwrite",
@@ -870,7 +870,7 @@
       "qualType" : "ImGuiFileDialogFlags_",
       "order" : 1,
       "value" : "(1 << 0)",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFileDialogFlags_DontShowHiddenFiles",
@@ -878,7 +878,7 @@
       "qualType" : "ImGuiFileDialogFlags_",
       "order" : 2,
       "value" : "(1 << 1)",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFileDialogFlags_DisableCreateDirectoryButton",
@@ -886,7 +886,7 @@
       "qualType" : "ImGuiFileDialogFlags_",
       "order" : 3,
       "value" : "(1 << 2)",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFileDialogFlags_HideColumnType",
@@ -894,7 +894,7 @@
       "qualType" : "ImGuiFileDialogFlags_",
       "order" : 4,
       "value" : "(1 << 3)",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFileDialogFlags_HideColumnSize",
@@ -902,7 +902,7 @@
       "qualType" : "ImGuiFileDialogFlags_",
       "order" : 5,
       "value" : "(1 << 4)",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFileDialogFlags_HideColumnDate",
@@ -910,14 +910,14 @@
       "qualType" : "ImGuiFileDialogFlags_",
       "order" : 6,
       "value" : "(1 << 5)",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFileDialogFlags_Default",
       "qualType" : "ImGuiFileDialogFlags_",
       "order" : 7,
       "value" : "ImGuiFileDialogFlags_ConfirmOverwrite",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstNamespaceDecl",
@@ -1565,35 +1565,35 @@
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
           "order" : 0,
           "value" : "0",
-          "evaluatedValue" : "0"
+          "evaluatedValue" : 0
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "FIELD_FILENAME",
           "docComment" : "sorted by filename",
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
           "order" : 1,
-          "evaluatedValue" : "1"
+          "evaluatedValue" : 1
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "FIELD_TYPE",
           "docComment" : "sorted by filetype",
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
           "order" : 2,
-          "evaluatedValue" : "2"
+          "evaluatedValue" : 2
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "FIELD_SIZE",
           "docComment" : "sorted by filesize (formated file size)",
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
           "order" : 3,
-          "evaluatedValue" : "3"
+          "evaluatedValue" : 3
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "FIELD_DATE",
           "docComment" : "sorted by filedate",
           "qualType" : "IGFD::FileManager::SortingFieldEnum",
           "order" : 4,
-          "evaluatedValue" : "4"
+          "evaluatedValue" : 4
         } ]
       }, {
         "@type" : "AstFieldDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-ImGuizmo.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-ImGuizmo.json
@@ -345,98 +345,98 @@
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 0,
         "value" : "(1u << 0)",
-        "evaluatedValue" : "1"
+        "evaluatedValue" : 1
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "TRANSLATE_Y",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 1,
         "value" : "(1u << 1)",
-        "evaluatedValue" : "2"
+        "evaluatedValue" : 2
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "TRANSLATE_Z",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 2,
         "value" : "(1u << 2)",
-        "evaluatedValue" : "4"
+        "evaluatedValue" : 4
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "ROTATE_X",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 3,
         "value" : "(1u << 3)",
-        "evaluatedValue" : "8"
+        "evaluatedValue" : 8
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "ROTATE_Y",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 4,
         "value" : "(1u << 4)",
-        "evaluatedValue" : "16"
+        "evaluatedValue" : 16
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "ROTATE_Z",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 5,
         "value" : "(1u << 5)",
-        "evaluatedValue" : "32"
+        "evaluatedValue" : 32
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "ROTATE_SCREEN",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 6,
         "value" : "(1u << 6)",
-        "evaluatedValue" : "64"
+        "evaluatedValue" : 64
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "SCALE_X",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 7,
         "value" : "(1u << 7)",
-        "evaluatedValue" : "128"
+        "evaluatedValue" : 128
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "SCALE_Y",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 8,
         "value" : "(1u << 8)",
-        "evaluatedValue" : "256"
+        "evaluatedValue" : 256
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "SCALE_Z",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 9,
         "value" : "(1u << 9)",
-        "evaluatedValue" : "512"
+        "evaluatedValue" : 512
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "BOUNDS",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 10,
         "value" : "(1u << 10)",
-        "evaluatedValue" : "1024"
+        "evaluatedValue" : 1024
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "TRANSLATE",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 11,
         "value" : "TRANSLATE_X | TRANSLATE_Y | TRANSLATE_Z",
-        "evaluatedValue" : "7"
+        "evaluatedValue" : 7
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "ROTATE",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 12,
         "value" : "ROTATE_X | ROTATE_Y | ROTATE_Z | ROTATE_SCREEN",
-        "evaluatedValue" : "120"
+        "evaluatedValue" : 120
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "SCALE",
         "qualType" : "ImGuizmo::OPERATION",
         "order" : 13,
         "value" : "SCALE_X | SCALE_Y | SCALE_Z",
-        "evaluatedValue" : "896"
+        "evaluatedValue" : 896
       } ]
     }, {
       "@type" : "AstEnumDecl",
@@ -446,13 +446,13 @@
         "name" : "LOCAL",
         "qualType" : "ImGuizmo::MODE",
         "order" : 0,
-        "evaluatedValue" : "0"
+        "evaluatedValue" : 0
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "WORLD",
         "qualType" : "ImGuizmo::MODE",
         "order" : 1,
-        "evaluatedValue" : "1"
+        "evaluatedValue" : 1
       } ]
     }, {
       "@type" : "AstFunctionDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-ImGuizmo.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-ImGuizmo.json
@@ -13,6 +13,12 @@
       "name" : "SetDrawlist",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "drawlist",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -24,12 +30,6 @@
             "text" : " Or pass a specific ImDrawList to draw to (e.g. ImGui::GetForegroundDrawList())."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "drawlist",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -50,6 +50,11 @@
       "name" : "SetImGuiContext",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -67,11 +72,6 @@
             "text" : " expose method to set imgui context"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "ctx",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -106,6 +106,11 @@
       "name" : "Enable",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "enable",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -117,17 +122,32 @@
             "text" : " gizmo is rendered with gray half transparent color when disabled"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "enable",
-        "qualType" : "bool",
-        "desugaredQualType" : "bool"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DecomposeMatrixToComponents",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "matrix",
+        "qualType" : "const float *",
+        "desugaredQualType" : "const float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "translation",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rotation",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -169,26 +189,6 @@
             "text" : " These functions have some numerical stability issues for now. Use with caution."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "matrix",
-        "qualType" : "const float *",
-        "desugaredQualType" : "const float *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "translation",
-        "qualType" : "float *",
-        "desugaredQualType" : "float *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "rotation",
-        "qualType" : "float *",
-        "desugaredQualType" : "float *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "scale",
-        "qualType" : "float *",
-        "desugaredQualType" : "float *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -245,6 +245,11 @@
       "name" : "SetOrthographic",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "isOrthographic",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -253,26 +258,12 @@
             "text" : " default is false"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "isOrthographic",
-        "qualType" : "bool",
-        "desugaredQualType" : "bool"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DrawCubes",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Render a cube with face color corresponding to face normal. Usefull for debug/tests"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "view",
         "qualType" : "const float *",
@@ -292,6 +283,15 @@
         "name" : "matrixCount",
         "qualType" : "int",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Render a cube with face color corresponding to face normal. Usefull for debug/tests"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -439,33 +439,20 @@
         "evaluatedValue" : "896"
       } ]
     }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "operator|",
-      "resultType" : "OPERATION",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "lhs",
-        "qualType" : "OPERATION",
-        "desugaredQualType" : "ImGuizmo::OPERATION"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "rhs",
-        "qualType" : "OPERATION",
-        "desugaredQualType" : "ImGuizmo::OPERATION"
-      } ]
-    }, {
       "@type" : "AstEnumDecl",
       "name" : "MODE",
       "decls" : [ {
         "@type" : "AstEnumConstantDecl",
         "name" : "LOCAL",
         "qualType" : "ImGuizmo::MODE",
-        "order" : 0
+        "order" : 0,
+        "evaluatedValue" : "0"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "WORLD",
         "qualType" : "ImGuizmo::MODE",
-        "order" : 1
+        "order" : 1,
+        "evaluatedValue" : "1"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -526,21 +513,6 @@
       "name" : "ViewManipulate",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Please note that this cubeview is patented by Autodesk : https://patents.google.com/patent/US7782319B2/en"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " It seems to be a defensive patent in the US. I don't think it will bring troubles using it as"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " other software are using the same mechanics. But just in case, you are now warned!"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "view",
         "qualType" : "float *",
@@ -565,6 +537,21 @@
         "name" : "backgroundColor",
         "qualType" : "int",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Please note that this cubeview is patented by Autodesk : https://patents.google.com/patent/US7782319B2/en"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " It seems to be a defensive patent in the US. I don't think it will bring troubles using it as"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " other software are using the same mechanics. But just in case, you are now warned!"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -581,6 +568,11 @@
       "name" : "IsOver",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "op",
+        "qualType" : "OPERATION",
+        "desugaredQualType" : "ImGuizmo::OPERATION"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -589,11 +581,6 @@
             "text" : " return true if the cursor is over the operation's gizmo"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "op",
-        "qualType" : "OPERATION",
-        "desugaredQualType" : "ImGuizmo::OPERATION"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -610,6 +597,11 @@
       "name" : "AllowAxisFlip",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "value",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -624,11 +616,6 @@
             "text" : " When false, they always stay along the positive world/local axis"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "value",
-        "qualType" : "bool",
-        "desugaredQualType" : "bool"
       } ]
     } ]
   } ]

--- a/buildSrc/src/main/resources/generator/api/ast/ast-TextEditor.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-TextEditor.json
@@ -16,133 +16,133 @@
         "name" : "Default",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 0,
-        "evaluatedValue" : "0"
+        "evaluatedValue" : 0
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Keyword",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 1,
-        "evaluatedValue" : "1"
+        "evaluatedValue" : 1
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Number",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 2,
-        "evaluatedValue" : "2"
+        "evaluatedValue" : 2
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "String",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 3,
-        "evaluatedValue" : "3"
+        "evaluatedValue" : 3
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "CharLiteral",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 4,
-        "evaluatedValue" : "4"
+        "evaluatedValue" : 4
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Punctuation",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 5,
-        "evaluatedValue" : "5"
+        "evaluatedValue" : 5
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Preprocessor",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 6,
-        "evaluatedValue" : "6"
+        "evaluatedValue" : 6
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Identifier",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 7,
-        "evaluatedValue" : "7"
+        "evaluatedValue" : 7
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "KnownIdentifier",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 8,
-        "evaluatedValue" : "8"
+        "evaluatedValue" : 8
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "PreprocIdentifier",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 9,
-        "evaluatedValue" : "9"
+        "evaluatedValue" : 9
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Comment",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 10,
-        "evaluatedValue" : "10"
+        "evaluatedValue" : 10
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "MultiLineComment",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 11,
-        "evaluatedValue" : "11"
+        "evaluatedValue" : 11
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Background",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 12,
-        "evaluatedValue" : "12"
+        "evaluatedValue" : 12
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Cursor",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 13,
-        "evaluatedValue" : "13"
+        "evaluatedValue" : 13
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Selection",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 14,
-        "evaluatedValue" : "14"
+        "evaluatedValue" : 14
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "ErrorMarker",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 15,
-        "evaluatedValue" : "15"
+        "evaluatedValue" : 15
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Breakpoint",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 16,
-        "evaluatedValue" : "16"
+        "evaluatedValue" : 16
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "LineNumber",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 17,
-        "evaluatedValue" : "17"
+        "evaluatedValue" : 17
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "CurrentLineFill",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 18,
-        "evaluatedValue" : "18"
+        "evaluatedValue" : 18
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "CurrentLineFillInactive",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 19,
-        "evaluatedValue" : "19"
+        "evaluatedValue" : 19
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "CurrentLineEdge",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 20,
-        "evaluatedValue" : "20"
+        "evaluatedValue" : 20
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Max",
         "qualType" : "TextEditor::PaletteIndex",
         "order" : 21,
-        "evaluatedValue" : "21"
+        "evaluatedValue" : 21
       } ]
     }, {
       "@type" : "AstEnumDecl",
@@ -152,19 +152,19 @@
         "name" : "Normal",
         "qualType" : "TextEditor::SelectionMode",
         "order" : 0,
-        "evaluatedValue" : "0"
+        "evaluatedValue" : 0
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Word",
         "qualType" : "TextEditor::SelectionMode",
         "order" : 1,
-        "evaluatedValue" : "1"
+        "evaluatedValue" : 1
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Line",
         "qualType" : "TextEditor::SelectionMode",
         "order" : 2,
-        "evaluatedValue" : "2"
+        "evaluatedValue" : 2
       } ]
     }, {
       "@type" : "AstRecordDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-TextEditor.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-TextEditor.json
@@ -9,122 +9,140 @@
     "@type" : "AstRecordDecl",
     "name" : "TextEditor",
     "decls" : [ {
-      "@type" : "AstFunctionDecl",
-      "name" : "operator=",
-      "resultType" : "TextEditor &"
-    }, {
       "@type" : "AstEnumDecl",
       "name" : "PaletteIndex",
       "decls" : [ {
         "@type" : "AstEnumConstantDecl",
         "name" : "Default",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 0
+        "order" : 0,
+        "evaluatedValue" : "0"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Keyword",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 1
+        "order" : 1,
+        "evaluatedValue" : "1"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Number",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 2
+        "order" : 2,
+        "evaluatedValue" : "2"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "String",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 3
+        "order" : 3,
+        "evaluatedValue" : "3"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "CharLiteral",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 4
+        "order" : 4,
+        "evaluatedValue" : "4"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Punctuation",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 5
+        "order" : 5,
+        "evaluatedValue" : "5"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Preprocessor",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 6
+        "order" : 6,
+        "evaluatedValue" : "6"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Identifier",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 7
+        "order" : 7,
+        "evaluatedValue" : "7"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "KnownIdentifier",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 8
+        "order" : 8,
+        "evaluatedValue" : "8"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "PreprocIdentifier",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 9
+        "order" : 9,
+        "evaluatedValue" : "9"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Comment",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 10
+        "order" : 10,
+        "evaluatedValue" : "10"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "MultiLineComment",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 11
+        "order" : 11,
+        "evaluatedValue" : "11"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Background",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 12
+        "order" : 12,
+        "evaluatedValue" : "12"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Cursor",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 13
+        "order" : 13,
+        "evaluatedValue" : "13"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Selection",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 14
+        "order" : 14,
+        "evaluatedValue" : "14"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "ErrorMarker",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 15
+        "order" : 15,
+        "evaluatedValue" : "15"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Breakpoint",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 16
+        "order" : 16,
+        "evaluatedValue" : "16"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "LineNumber",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 17
+        "order" : 17,
+        "evaluatedValue" : "17"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "CurrentLineFill",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 18
+        "order" : 18,
+        "evaluatedValue" : "18"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "CurrentLineFillInactive",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 19
+        "order" : 19,
+        "evaluatedValue" : "19"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "CurrentLineEdge",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 20
+        "order" : 20,
+        "evaluatedValue" : "20"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Max",
         "qualType" : "TextEditor::PaletteIndex",
-        "order" : 21
+        "order" : 21,
+        "evaluatedValue" : "21"
       } ]
     }, {
       "@type" : "AstEnumDecl",
@@ -133,26 +151,25 @@
         "@type" : "AstEnumConstantDecl",
         "name" : "Normal",
         "qualType" : "TextEditor::SelectionMode",
-        "order" : 0
+        "order" : 0,
+        "evaluatedValue" : "0"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Word",
         "qualType" : "TextEditor::SelectionMode",
-        "order" : 1
+        "order" : 1,
+        "evaluatedValue" : "1"
       }, {
         "@type" : "AstEnumConstantDecl",
         "name" : "Line",
         "qualType" : "TextEditor::SelectionMode",
-        "order" : 2
+        "order" : 2,
+        "evaluatedValue" : "2"
       } ]
     }, {
       "@type" : "AstRecordDecl",
       "name" : "Breakpoint",
       "decls" : [ {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator=",
-        "resultType" : "TextEditor::Breakpoint &"
-      }, {
         "@type" : "AstFieldDecl",
         "name" : "mLine",
         "qualType" : "int",
@@ -199,10 +216,6 @@
           } ]
         } ]
       }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator=",
-        "resultType" : "TextEditor::Coordinates &"
-      }, {
         "@type" : "AstFieldDecl",
         "name" : "mLine",
         "qualType" : "int",
@@ -216,75 +229,11 @@
         "@type" : "AstFunctionDecl",
         "name" : "Invalid",
         "resultType" : "Coordinates"
-      }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator==",
-        "resultType" : "bool",
-        "decls" : [ {
-          "@type" : "AstParmVarDecl",
-          "name" : "o",
-          "qualType" : "const Coordinates &",
-          "desugaredQualType" : "const Coordinates &"
-        } ]
-      }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator!=",
-        "resultType" : "bool",
-        "decls" : [ {
-          "@type" : "AstParmVarDecl",
-          "name" : "o",
-          "qualType" : "const Coordinates &",
-          "desugaredQualType" : "const Coordinates &"
-        } ]
-      }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator<",
-        "resultType" : "bool",
-        "decls" : [ {
-          "@type" : "AstParmVarDecl",
-          "name" : "o",
-          "qualType" : "const Coordinates &",
-          "desugaredQualType" : "const Coordinates &"
-        } ]
-      }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator>",
-        "resultType" : "bool",
-        "decls" : [ {
-          "@type" : "AstParmVarDecl",
-          "name" : "o",
-          "qualType" : "const Coordinates &",
-          "desugaredQualType" : "const Coordinates &"
-        } ]
-      }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator<=",
-        "resultType" : "bool",
-        "decls" : [ {
-          "@type" : "AstParmVarDecl",
-          "name" : "o",
-          "qualType" : "const Coordinates &",
-          "desugaredQualType" : "const Coordinates &"
-        } ]
-      }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator>=",
-        "resultType" : "bool",
-        "decls" : [ {
-          "@type" : "AstParmVarDecl",
-          "name" : "o",
-          "qualType" : "const Coordinates &",
-          "desugaredQualType" : "const Coordinates &"
-        } ]
       } ]
     }, {
       "@type" : "AstRecordDecl",
       "name" : "Identifier",
       "decls" : [ {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator=",
-        "resultType" : "TextEditor::Identifier &"
-      }, {
         "@type" : "AstFieldDecl",
         "name" : "mLocation",
         "qualType" : "Coordinates",
@@ -328,10 +277,6 @@
       "@type" : "AstRecordDecl",
       "name" : "LanguageDefinition",
       "decls" : [ {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator=",
-        "resultType" : "TextEditor::LanguageDefinition &"
-      }, {
         "@type" : "AstFieldDecl",
         "name" : "mName",
         "qualType" : "std::string",
@@ -913,10 +858,6 @@
       "@type" : "AstRecordDecl",
       "name" : "EditorState",
       "decls" : [ {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator=",
-        "resultType" : "TextEditor::EditorState &"
-      }, {
         "@type" : "AstFieldDecl",
         "name" : "mSelectionStart",
         "qualType" : "Coordinates",
@@ -936,10 +877,6 @@
       "@type" : "AstRecordDecl",
       "name" : "UndoRecord",
       "decls" : [ {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator=",
-        "resultType" : "TextEditor::UndoRecord &"
-      }, {
         "@type" : "AstFunctionDecl",
         "name" : "Undo",
         "resultType" : "void",
@@ -1509,5 +1446,793 @@
       "qualType" : "float",
       "desugaredQualType" : "float"
     } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswalnum_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswblank_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswalpha_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswhexnumber_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "timespec",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "tv_sec",
+      "qualType" : "__darwin_time_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tv_nsec",
+      "qualType" : "long",
+      "desugaredQualType" : "long"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswcntrl_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswideogram_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswctype_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswnumber_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswdigit_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswphonogram_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswgraph_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswrune_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswalnum",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswlower_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswspecial_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswalpha",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswblank",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "lconv",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "decimal_point",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "thousands_sep",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "grouping",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_curr_symbol",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "currency_symbol",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "mon_decimal_point",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "mon_thousands_sep",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "mon_grouping",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "positive_sign",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "negative_sign",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_frac_digits",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "frac_digits",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "p_cs_precedes",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "p_sep_by_space",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "n_cs_precedes",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "n_sep_by_space",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "p_sign_posn",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "n_sign_posn",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_p_cs_precedes",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_n_cs_precedes",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_p_sep_by_space",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_n_sep_by_space",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_p_sign_posn",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "int_n_sign_posn",
+      "qualType" : "char",
+      "desugaredQualType" : "char"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswprint_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswcntrl",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswascii",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswpunct_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswctype",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswhexnumber",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswspace_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswdigit",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswideogram",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswgraph",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswupper_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswnumber",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswlower",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswphonogram",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswxdigit_l",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswprint",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "digittoint_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswrune",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "towlower_l",
+    "resultType" : "wint_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswpunct",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isalnum_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswspecial",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "towupper_l",
+    "resultType" : "wint_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswspace",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isalpha_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswupper",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isblank_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iswxdigit",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iscntrl_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "towlower",
+    "resultType" : "wint_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isdigit_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "towupper",
+    "resultType" : "wint_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isgraph_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ishexnumber_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isideogram_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "tm",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_sec",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_min",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_hour",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_mday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_mon",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_year",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_wday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_yday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_isdst",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_gmtoff",
+      "qualType" : "long",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_zone",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "islower_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isnumber_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isphonogram_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isprint_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ispunct_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isrune_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isspace_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isspecial_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isupper_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isxdigit_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "tolower_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "toupper_l",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "l",
+      "qualType" : "locale_t",
+      "desugaredQualType" : "struct _xlocale *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isascii",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "major",
+    "resultType" : "__int32_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "minor",
+    "resultType" : "__int32_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "makedev",
+    "resultType" : "dev_t"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isalnum",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isalpha",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isblank",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "iscntrl",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isdigit",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isgraph",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "islower",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isprint",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ispunct",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isspace",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isupper",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isxdigit",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "toascii",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "tolower",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "toupper",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "digittoint",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ishexnumber",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isideogram",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isnumber",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isphonogram",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isrune",
+    "resultType" : "int"
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "isspecial",
+    "resultType" : "int"
   } ]
 }

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui-knobs.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui-knobs.json
@@ -14,28 +14,28 @@
       "qualType" : "ImGuiKnobFlags_",
       "order" : 0,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobFlags_NoInput",
       "qualType" : "ImGuiKnobFlags_",
       "order" : 1,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobFlags_ValueTooltip",
       "qualType" : "ImGuiKnobFlags_",
       "order" : 2,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobFlags_DragHorizontal",
       "qualType" : "ImGuiKnobFlags_",
       "order" : 3,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -46,49 +46,49 @@
       "qualType" : "ImGuiKnobVariant_",
       "order" : 0,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobVariant_Dot",
       "qualType" : "ImGuiKnobVariant_",
       "order" : 1,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobVariant_Wiper",
       "qualType" : "ImGuiKnobVariant_",
       "order" : 2,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobVariant_WiperOnly",
       "qualType" : "ImGuiKnobVariant_",
       "order" : 3,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobVariant_WiperDot",
       "qualType" : "ImGuiKnobVariant_",
       "order" : 4,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobVariant_Stepped",
       "qualType" : "ImGuiKnobVariant_",
       "order" : 5,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKnobVariant_Space",
       "qualType" : "ImGuiKnobVariant_",
       "order" : 6,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     } ]
   }, {
     "@type" : "AstNamespaceDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui.json
@@ -7162,7 +7162,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoTitleBar",
@@ -7170,7 +7170,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoResize",
@@ -7178,7 +7178,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoMove",
@@ -7186,7 +7186,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoScrollbar",
@@ -7194,7 +7194,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoScrollWithMouse",
@@ -7202,7 +7202,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoCollapse",
@@ -7210,7 +7210,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_AlwaysAutoResize",
@@ -7218,7 +7218,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoBackground",
@@ -7226,7 +7226,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoSavedSettings",
@@ -7234,7 +7234,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoMouseInputs",
@@ -7242,7 +7242,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_MenuBar",
@@ -7250,7 +7250,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_HorizontalScrollbar",
@@ -7258,7 +7258,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 12,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoFocusOnAppearing",
@@ -7266,7 +7266,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 13,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoBringToFrontOnFocus",
@@ -7274,7 +7274,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 14,
       "value" : "1 << 13",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_AlwaysVerticalScrollbar",
@@ -7282,7 +7282,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 15,
       "value" : "1 << 14",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_AlwaysHorizontalScrollbar",
@@ -7290,7 +7290,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 16,
       "value" : "1<< 15",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_AlwaysUseWindowPadding",
@@ -7298,7 +7298,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 17,
       "value" : "1 << 16",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoNavInputs",
@@ -7306,7 +7306,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 18,
       "value" : "1 << 18",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoNavFocus",
@@ -7314,7 +7314,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 19,
       "value" : "1 << 19",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_UnsavedDocument",
@@ -7322,7 +7322,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 20,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoDocking",
@@ -7330,28 +7330,28 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 21,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoNav",
       "qualType" : "ImGuiWindowFlags_",
       "order" : 22,
       "value" : "ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus",
-      "evaluatedValue" : "786432"
+      "evaluatedValue" : 786432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoDecoration",
       "qualType" : "ImGuiWindowFlags_",
       "order" : 23,
       "value" : "ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse",
-      "evaluatedValue" : "43"
+      "evaluatedValue" : 43
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoInputs",
       "qualType" : "ImGuiWindowFlags_",
       "order" : 24,
       "value" : "ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus",
-      "evaluatedValue" : "786944"
+      "evaluatedValue" : 786944
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NavFlattened",
@@ -7359,7 +7359,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 25,
       "value" : "1 << 23",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_ChildWindow",
@@ -7367,7 +7367,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 26,
       "value" : "1 << 24",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_Tooltip",
@@ -7375,7 +7375,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 27,
       "value" : "1 << 25",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_Popup",
@@ -7383,7 +7383,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 28,
       "value" : "1 << 26",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_Modal",
@@ -7391,7 +7391,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 29,
       "value" : "1 << 27",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_ChildMenu",
@@ -7399,7 +7399,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 30,
       "value" : "1 << 28",
-      "evaluatedValue" : "268435456"
+      "evaluatedValue" : 268435456
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_DockNodeHost",
@@ -7407,7 +7407,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 31,
       "value" : "1 << 29",
-      "evaluatedValue" : "536870912"
+      "evaluatedValue" : 536870912
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -7427,7 +7427,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsDecimal",
@@ -7435,7 +7435,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsHexadecimal",
@@ -7443,7 +7443,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsUppercase",
@@ -7451,7 +7451,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsNoBlank",
@@ -7459,7 +7459,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_AutoSelectAll",
@@ -7467,7 +7467,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_EnterReturnsTrue",
@@ -7475,7 +7475,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackCompletion",
@@ -7483,7 +7483,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackHistory",
@@ -7491,7 +7491,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackAlways",
@@ -7499,7 +7499,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackCharFilter",
@@ -7507,7 +7507,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_AllowTabInput",
@@ -7515,7 +7515,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CtrlEnterForNewLine",
@@ -7523,7 +7523,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 12,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_NoHorizontalScroll",
@@ -7531,7 +7531,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 13,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_AlwaysOverwrite",
@@ -7539,7 +7539,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 14,
       "value" : "1 << 13",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_ReadOnly",
@@ -7547,7 +7547,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 15,
       "value" : "1 << 14",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_Password",
@@ -7555,7 +7555,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 16,
       "value" : "1 << 15",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_NoUndoRedo",
@@ -7563,7 +7563,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 17,
       "value" : "1 << 16",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsScientific",
@@ -7571,7 +7571,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 18,
       "value" : "1 << 17",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackResize",
@@ -7579,7 +7579,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 19,
       "value" : "1 << 18",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackEdit",
@@ -7587,7 +7587,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 20,
       "value" : "1 << 19",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_AlwaysInsertMode",
@@ -7595,7 +7595,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 21,
       "value" : "ImGuiInputTextFlags_AlwaysOverwrite",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -7615,7 +7615,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_Selected",
@@ -7623,7 +7623,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_Framed",
@@ -7631,7 +7631,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_AllowItemOverlap",
@@ -7639,7 +7639,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_NoTreePushOnOpen",
@@ -7647,7 +7647,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_NoAutoOpenOnLog",
@@ -7655,7 +7655,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_DefaultOpen",
@@ -7663,7 +7663,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_OpenOnDoubleClick",
@@ -7671,7 +7671,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_OpenOnArrow",
@@ -7679,7 +7679,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_Leaf",
@@ -7687,7 +7687,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_Bullet",
@@ -7695,7 +7695,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_FramePadding",
@@ -7703,7 +7703,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_SpanAvailWidth",
@@ -7711,7 +7711,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 12,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_SpanFullWidth",
@@ -7719,7 +7719,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 13,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_NavLeftJumpsBackHere",
@@ -7727,7 +7727,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 14,
       "value" : "1 << 13",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_CollapsingHeader",
@@ -7735,7 +7735,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 15,
       "value" : "ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_NoAutoOpenOnLog",
-      "evaluatedValue" : "26"
+      "evaluatedValue" : 26
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -7776,7 +7776,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonLeft",
@@ -7784,7 +7784,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 1,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonRight",
@@ -7792,7 +7792,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 2,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonMiddle",
@@ -7800,21 +7800,21 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 3,
       "value" : "2",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonMask_",
       "qualType" : "ImGuiPopupFlags_",
       "order" : 4,
       "value" : "0x1F",
-      "evaluatedValue" : "31"
+      "evaluatedValue" : 31
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonDefault_",
       "qualType" : "ImGuiPopupFlags_",
       "order" : 5,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_NoOpenOverExistingPopup",
@@ -7822,7 +7822,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_NoOpenOverItems",
@@ -7830,7 +7830,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_AnyPopupId",
@@ -7838,7 +7838,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_AnyPopupLevel",
@@ -7846,14 +7846,14 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_AnyPopup",
       "qualType" : "ImGuiPopupFlags_",
       "order" : 10,
       "value" : "ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel",
-      "evaluatedValue" : "384"
+      "evaluatedValue" : 384
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -7873,7 +7873,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_DontClosePopups",
@@ -7881,7 +7881,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_SpanAllColumns",
@@ -7889,7 +7889,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_AllowDoubleClick",
@@ -7897,7 +7897,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_Disabled",
@@ -7905,7 +7905,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_AllowItemOverlap",
@@ -7913,7 +7913,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -7933,7 +7933,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_PopupAlignLeft",
@@ -7941,7 +7941,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightSmall",
@@ -7949,7 +7949,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightRegular",
@@ -7957,7 +7957,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightLarge",
@@ -7965,7 +7965,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightLargest",
@@ -7973,7 +7973,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_NoArrowButton",
@@ -7981,7 +7981,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_NoPreview",
@@ -7989,14 +7989,14 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightMask_",
       "qualType" : "ImGuiComboFlags_",
       "order" : 8,
       "value" : "ImGuiComboFlags_HeightSmall | ImGuiComboFlags_HeightRegular | ImGuiComboFlags_HeightLarge | ImGuiComboFlags_HeightLargest",
-      "evaluatedValue" : "30"
+      "evaluatedValue" : 30
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -8016,7 +8016,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_Reorderable",
@@ -8024,7 +8024,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_AutoSelectNewTabs",
@@ -8032,7 +8032,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_TabListPopupButton",
@@ -8040,7 +8040,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_NoCloseWithMiddleMouseButton",
@@ -8048,7 +8048,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_NoTabListScrollingButtons",
@@ -8056,7 +8056,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_NoTooltip",
@@ -8064,7 +8064,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_FittingPolicyResizeDown",
@@ -8072,7 +8072,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_FittingPolicyScroll",
@@ -8080,21 +8080,21 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_FittingPolicyMask_",
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 9,
       "value" : "ImGuiTabBarFlags_FittingPolicyResizeDown | ImGuiTabBarFlags_FittingPolicyScroll",
-      "evaluatedValue" : "192"
+      "evaluatedValue" : 192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_FittingPolicyDefault_",
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 10,
       "value" : "ImGuiTabBarFlags_FittingPolicyResizeDown",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -8114,7 +8114,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_UnsavedDocument",
@@ -8122,7 +8122,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_SetSelected",
@@ -8130,7 +8130,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoCloseWithMiddleMouseButton",
@@ -8138,7 +8138,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoPushId",
@@ -8146,7 +8146,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoTooltip",
@@ -8154,7 +8154,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoReorder",
@@ -8162,7 +8162,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_Leading",
@@ -8170,7 +8170,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_Trailing",
@@ -8178,7 +8178,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -8265,7 +8265,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Resizable",
@@ -8273,7 +8273,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Reorderable",
@@ -8281,7 +8281,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Hideable",
@@ -8289,7 +8289,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Sortable",
@@ -8297,7 +8297,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoSavedSettings",
@@ -8305,7 +8305,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_ContextMenuInBody",
@@ -8313,7 +8313,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_RowBg",
@@ -8321,7 +8321,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersInnerH",
@@ -8329,7 +8329,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersOuterH",
@@ -8337,7 +8337,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersInnerV",
@@ -8345,7 +8345,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersOuterV",
@@ -8353,7 +8353,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersH",
@@ -8361,7 +8361,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 12,
       "value" : "ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_BordersOuterH",
-      "evaluatedValue" : "384"
+      "evaluatedValue" : 384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersV",
@@ -8369,7 +8369,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 13,
       "value" : "ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_BordersOuterV",
-      "evaluatedValue" : "1536"
+      "evaluatedValue" : 1536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersInner",
@@ -8377,7 +8377,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 14,
       "value" : "ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_BordersInnerH",
-      "evaluatedValue" : "640"
+      "evaluatedValue" : 640
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersOuter",
@@ -8385,7 +8385,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 15,
       "value" : "ImGuiTableFlags_BordersOuterV | ImGuiTableFlags_BordersOuterH",
-      "evaluatedValue" : "1280"
+      "evaluatedValue" : 1280
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Borders",
@@ -8393,7 +8393,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 16,
       "value" : "ImGuiTableFlags_BordersInner | ImGuiTableFlags_BordersOuter",
-      "evaluatedValue" : "1920"
+      "evaluatedValue" : 1920
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoBordersInBody",
@@ -8401,7 +8401,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 17,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoBordersInBodyUntilResize",
@@ -8409,7 +8409,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 18,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingFixedFit",
@@ -8417,7 +8417,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 19,
       "value" : "1 << 13",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingFixedSame",
@@ -8425,7 +8425,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 20,
       "value" : "2 << 13",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingStretchProp",
@@ -8433,7 +8433,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 21,
       "value" : "3 << 13",
-      "evaluatedValue" : "24576"
+      "evaluatedValue" : 24576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingStretchSame",
@@ -8441,7 +8441,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 22,
       "value" : "4 << 13",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoHostExtendX",
@@ -8449,7 +8449,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 23,
       "value" : "1 << 16",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoHostExtendY",
@@ -8457,7 +8457,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 24,
       "value" : "1 << 17",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoKeepColumnsVisible",
@@ -8465,7 +8465,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 25,
       "value" : "1 << 18",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_PreciseWidths",
@@ -8473,7 +8473,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 26,
       "value" : "1 << 19",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoClip",
@@ -8481,7 +8481,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 27,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_PadOuterX",
@@ -8489,7 +8489,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 28,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoPadOuterX",
@@ -8497,7 +8497,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 29,
       "value" : "1 << 22",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoPadInnerX",
@@ -8505,7 +8505,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 30,
       "value" : "1 << 23",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_ScrollX",
@@ -8513,7 +8513,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 31,
       "value" : "1 << 24",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_ScrollY",
@@ -8521,7 +8521,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 32,
       "value" : "1 << 25",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SortMulti",
@@ -8529,7 +8529,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 33,
       "value" : "1 << 26",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SortTristate",
@@ -8537,7 +8537,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 34,
       "value" : "1 << 27",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingMask_",
@@ -8545,7 +8545,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 35,
       "value" : "ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_SizingFixedSame | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_SizingStretchSame",
-      "evaluatedValue" : "57344"
+      "evaluatedValue" : 57344
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -8566,7 +8566,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_Disabled",
@@ -8574,7 +8574,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_DefaultHide",
@@ -8582,7 +8582,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_DefaultSort",
@@ -8590,7 +8590,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_WidthStretch",
@@ -8598,7 +8598,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_WidthFixed",
@@ -8606,7 +8606,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoResize",
@@ -8614,7 +8614,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoReorder",
@@ -8622,7 +8622,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoHide",
@@ -8630,7 +8630,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoClip",
@@ -8638,7 +8638,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoSort",
@@ -8646,7 +8646,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoSortAscending",
@@ -8654,7 +8654,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoSortDescending",
@@ -8662,7 +8662,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 12,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoHeaderLabel",
@@ -8670,7 +8670,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 13,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoHeaderWidth",
@@ -8678,7 +8678,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 14,
       "value" : "1 << 13",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_PreferSortAscending",
@@ -8686,7 +8686,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 15,
       "value" : "1 << 14",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_PreferSortDescending",
@@ -8694,7 +8694,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 16,
       "value" : "1 << 15",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IndentEnable",
@@ -8702,7 +8702,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 17,
       "value" : "1 << 16",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IndentDisable",
@@ -8710,7 +8710,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 18,
       "value" : "1 << 17",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IsEnabled",
@@ -8718,7 +8718,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 19,
       "value" : "1 << 24",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IsVisible",
@@ -8726,7 +8726,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 20,
       "value" : "1 << 25",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IsSorted",
@@ -8734,7 +8734,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 21,
       "value" : "1 << 26",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IsHovered",
@@ -8742,7 +8742,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 22,
       "value" : "1 << 27",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_WidthMask_",
@@ -8750,7 +8750,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 23,
       "value" : "ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_WidthFixed",
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IndentMask_",
@@ -8758,7 +8758,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 24,
       "value" : "ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_IndentDisable",
-      "evaluatedValue" : "196608"
+      "evaluatedValue" : 196608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_StatusMask_",
@@ -8766,7 +8766,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 25,
       "value" : "ImGuiTableColumnFlags_IsEnabled | ImGuiTableColumnFlags_IsVisible | ImGuiTableColumnFlags_IsSorted | ImGuiTableColumnFlags_IsHovered",
-      "evaluatedValue" : "251658240"
+      "evaluatedValue" : 251658240
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoDirectResize_",
@@ -8774,7 +8774,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 26,
       "value" : "1 << 30",
-      "evaluatedValue" : "1073741824"
+      "evaluatedValue" : 1073741824
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -8794,7 +8794,7 @@
       "qualType" : "ImGuiTableRowFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableRowFlags_Headers",
@@ -8802,7 +8802,7 @@
       "qualType" : "ImGuiTableRowFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -8846,7 +8846,7 @@
       "qualType" : "ImGuiTableBgTarget_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableBgTarget_RowBg0",
@@ -8854,7 +8854,7 @@
       "qualType" : "ImGuiTableBgTarget_",
       "order" : 1,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableBgTarget_RowBg1",
@@ -8862,7 +8862,7 @@
       "qualType" : "ImGuiTableBgTarget_",
       "order" : 2,
       "value" : "2",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableBgTarget_CellBg",
@@ -8870,7 +8870,7 @@
       "qualType" : "ImGuiTableBgTarget_",
       "order" : 3,
       "value" : "3",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -8890,7 +8890,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_ChildWindows",
@@ -8898,7 +8898,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_RootWindow",
@@ -8906,7 +8906,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_AnyWindow",
@@ -8914,7 +8914,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_NoPopupHierarchy",
@@ -8922,7 +8922,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_DockHierarchy",
@@ -8930,14 +8930,14 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_RootAndChildWindows",
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 6,
       "value" : "ImGuiFocusedFlags_RootWindow | ImGuiFocusedFlags_ChildWindows",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -8964,7 +8964,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_ChildWindows",
@@ -8972,7 +8972,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_RootWindow",
@@ -8980,7 +8980,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AnyWindow",
@@ -8988,7 +8988,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_NoPopupHierarchy",
@@ -8996,7 +8996,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_DockHierarchy",
@@ -9004,7 +9004,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AllowWhenBlockedByPopup",
@@ -9012,7 +9012,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AllowWhenBlockedByActiveItem",
@@ -9020,7 +9020,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 7,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AllowWhenOverlapped",
@@ -9028,7 +9028,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 8,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AllowWhenDisabled",
@@ -9036,21 +9036,21 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 9,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_RectOnly",
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 10,
       "value" : "ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem | ImGuiHoveredFlags_AllowWhenOverlapped",
-      "evaluatedValue" : "416"
+      "evaluatedValue" : 416
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_RootAndChildWindows",
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 11,
       "value" : "ImGuiHoveredFlags_RootWindow | ImGuiHoveredFlags_ChildWindows",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9076,7 +9076,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_KeepAliveOnly",
@@ -9084,7 +9084,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoDockingInCentralNode",
@@ -9092,7 +9092,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 2,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_PassthruCentralNode",
@@ -9100,7 +9100,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 3,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoSplit",
@@ -9108,7 +9108,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 4,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoResize",
@@ -9116,7 +9116,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 5,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_AutoHideTabBar",
@@ -9124,7 +9124,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 6,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9144,7 +9144,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceNoPreviewTooltip",
@@ -9152,7 +9152,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceNoDisableHover",
@@ -9160,7 +9160,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceNoHoldToOpenOthers",
@@ -9168,7 +9168,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceAllowNullID",
@@ -9176,7 +9176,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceExtern",
@@ -9184,7 +9184,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceAutoExpirePayload",
@@ -9192,7 +9192,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_AcceptBeforeDelivery",
@@ -9200,7 +9200,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 7,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_AcceptNoDrawDefaultRect",
@@ -9208,7 +9208,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 8,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_AcceptNoPreviewTooltip",
@@ -9216,7 +9216,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 9,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_AcceptPeekOnly",
@@ -9224,7 +9224,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 10,
       "value" : "ImGuiDragDropFlags_AcceptBeforeDelivery | ImGuiDragDropFlags_AcceptNoDrawDefaultRect",
-      "evaluatedValue" : "3072"
+      "evaluatedValue" : 3072
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9244,76 +9244,76 @@
       "docComment" : "signed char / char (with sensible compilers)",
       "qualType" : "ImGuiDataType_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U8",
       "docComment" : "unsigned char",
       "qualType" : "ImGuiDataType_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S16",
       "docComment" : "short",
       "qualType" : "ImGuiDataType_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U16",
       "docComment" : "unsigned short",
       "qualType" : "ImGuiDataType_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S32",
       "docComment" : "int",
       "qualType" : "ImGuiDataType_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U32",
       "docComment" : "unsigned int",
       "qualType" : "ImGuiDataType_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S64",
       "docComment" : "long long / __int64",
       "qualType" : "ImGuiDataType_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U64",
       "docComment" : "unsigned long long / unsigned __int64",
       "qualType" : "ImGuiDataType_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_Float",
       "docComment" : "float",
       "qualType" : "ImGuiDataType_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_Double",
       "docComment" : "double",
       "qualType" : "ImGuiDataType_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_COUNT",
       "qualType" : "ImGuiDataType_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9333,41 +9333,41 @@
       "qualType" : "ImGuiDir_",
       "order" : 0,
       "value" : "-1",
-      "evaluatedValue" : "-1"
+      "evaluatedValue" : -1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Left",
       "qualType" : "ImGuiDir_",
       "order" : 1,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Right",
       "qualType" : "ImGuiDir_",
       "order" : 2,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Up",
       "qualType" : "ImGuiDir_",
       "order" : 3,
       "value" : "2",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Down",
       "qualType" : "ImGuiDir_",
       "order" : 4,
       "value" : "3",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_COUNT",
       "qualType" : "ImGuiDir_",
       "order" : 5,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9387,7 +9387,7 @@
       "qualType" : "ImGuiSortDirection_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSortDirection_Ascending",
@@ -9395,7 +9395,7 @@
       "qualType" : "ImGuiSortDirection_",
       "order" : 1,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSortDirection_Descending",
@@ -9403,7 +9403,7 @@
       "qualType" : "ImGuiSortDirection_",
       "order" : 2,
       "value" : "2",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9422,145 +9422,145 @@
       "name" : "ImGuiKey_Tab",
       "qualType" : "ImGuiKey_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_LeftArrow",
       "qualType" : "ImGuiKey_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_RightArrow",
       "qualType" : "ImGuiKey_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_UpArrow",
       "qualType" : "ImGuiKey_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_DownArrow",
       "qualType" : "ImGuiKey_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_PageUp",
       "qualType" : "ImGuiKey_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_PageDown",
       "qualType" : "ImGuiKey_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Home",
       "qualType" : "ImGuiKey_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_End",
       "qualType" : "ImGuiKey_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Insert",
       "qualType" : "ImGuiKey_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Delete",
       "qualType" : "ImGuiKey_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Backspace",
       "qualType" : "ImGuiKey_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Space",
       "qualType" : "ImGuiKey_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Enter",
       "qualType" : "ImGuiKey_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Escape",
       "qualType" : "ImGuiKey_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_KeyPadEnter",
       "qualType" : "ImGuiKey_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_A",
       "docComment" : "for text edit CTRL+A: select all",
       "qualType" : "ImGuiKey_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_C",
       "docComment" : "for text edit CTRL+C: copy",
       "qualType" : "ImGuiKey_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_V",
       "docComment" : "for text edit CTRL+V: paste",
       "qualType" : "ImGuiKey_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_X",
       "docComment" : "for text edit CTRL+X: cut",
       "qualType" : "ImGuiKey_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Y",
       "docComment" : "for text edit CTRL+Y: redo",
       "qualType" : "ImGuiKey_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Z",
       "docComment" : "for text edit CTRL+Z: undo",
       "qualType" : "ImGuiKey_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_COUNT",
       "qualType" : "ImGuiKey_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9580,35 +9580,35 @@
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKeyModFlags_Ctrl",
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKeyModFlags_Shift",
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKeyModFlags_Alt",
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKeyModFlags_Super",
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9637,147 +9637,147 @@
       "docComment" : "activate / open / toggle / tweak value       // e.g. Cross  (PS4), A (Xbox), A (Switch), Space (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Cancel",
       "docComment" : "cancel / close / exit                        // e.g. Circle (PS4), B (Xbox), B (Switch), Escape (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Input",
       "docComment" : "text input / on-screen keyboard              // e.g. Triang.(PS4), Y (Xbox), X (Switch), Return (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Menu",
       "docComment" : "tap: toggle menu / hold: focus, move, resize // e.g. Square (PS4), X (Xbox), Y (Switch), Alt (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadLeft",
       "docComment" : "move / tweak / resize window (w/ PadMenu)    // e.g. D-pad Left/Right/Up/Down (Gamepads), Arrow keys (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadRight",
       "qualType" : "ImGuiNavInput_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadUp",
       "qualType" : "ImGuiNavInput_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadDown",
       "qualType" : "ImGuiNavInput_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickLeft",
       "docComment" : "scroll / move window (w/ PadMenu)            // e.g. Left Analog Stick Left/Right/Up/Down",
       "qualType" : "ImGuiNavInput_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickRight",
       "qualType" : "ImGuiNavInput_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickUp",
       "qualType" : "ImGuiNavInput_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickDown",
       "qualType" : "ImGuiNavInput_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_FocusPrev",
       "docComment" : "next window (w/ PadMenu)                     // e.g. L1 or L2 (PS4), LB or LT (Xbox), L or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_FocusNext",
       "docComment" : "prev window (w/ PadMenu)                     // e.g. R1 or R2 (PS4), RB or RT (Xbox), R or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_TweakSlow",
       "docComment" : "slower tweaks                                // e.g. L1 or L2 (PS4), LB or LT (Xbox), L or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_TweakFast",
       "docComment" : "faster tweaks                                // e.g. R1 or R2 (PS4), RB or RT (Xbox), R or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyLeft_",
       "docComment" : "move left                                    // = Arrow keys",
       "qualType" : "ImGuiNavInput_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyRight_",
       "docComment" : "move right",
       "qualType" : "ImGuiNavInput_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyUp_",
       "docComment" : "move up",
       "qualType" : "ImGuiNavInput_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyDown_",
       "docComment" : "move down",
       "qualType" : "ImGuiNavInput_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_COUNT",
       "qualType" : "ImGuiNavInput_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_InternalStart_",
       "qualType" : "ImGuiNavInput_",
       "order" : 21,
       "value" : "ImGuiNavInput_KeyLeft_",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9797,7 +9797,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NavEnableKeyboard",
@@ -9805,7 +9805,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NavEnableGamepad",
@@ -9813,7 +9813,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NavEnableSetMousePos",
@@ -9821,7 +9821,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NavNoCaptureKeyboard",
@@ -9829,7 +9829,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NoMouse",
@@ -9837,7 +9837,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NoMouseCursorChange",
@@ -9845,7 +9845,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_DockingEnable",
@@ -9853,7 +9853,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_ViewportsEnable",
@@ -9861,7 +9861,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 8,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_DpiEnableScaleViewports",
@@ -9869,7 +9869,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 9,
       "value" : "1 << 14",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_DpiEnableScaleFonts",
@@ -9877,7 +9877,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 10,
       "value" : "1 << 15",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_IsSRGB",
@@ -9885,7 +9885,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 11,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_IsTouchScreen",
@@ -9893,7 +9893,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 12,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9913,7 +9913,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_HasGamepad",
@@ -9921,7 +9921,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_HasMouseCursors",
@@ -9929,7 +9929,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_HasSetMousePos",
@@ -9937,7 +9937,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_RendererHasVtxOffset",
@@ -9945,7 +9945,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_PlatformHasViewports",
@@ -9953,7 +9953,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 5,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_HasMouseHoveredViewport",
@@ -9961,7 +9961,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 6,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_RendererHasViewports",
@@ -9969,7 +9969,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 7,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9988,353 +9988,353 @@
       "name" : "ImGuiCol_Text",
       "qualType" : "ImGuiCol_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TextDisabled",
       "qualType" : "ImGuiCol_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_WindowBg",
       "docComment" : "Background of normal windows",
       "qualType" : "ImGuiCol_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ChildBg",
       "docComment" : "Background of child windows",
       "qualType" : "ImGuiCol_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PopupBg",
       "docComment" : "Background of popups, menus, tooltips windows",
       "qualType" : "ImGuiCol_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Border",
       "qualType" : "ImGuiCol_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_BorderShadow",
       "qualType" : "ImGuiCol_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBg",
       "docComment" : "Background of checkbox, radio button, plot, slider, text input",
       "qualType" : "ImGuiCol_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBgHovered",
       "qualType" : "ImGuiCol_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBgActive",
       "qualType" : "ImGuiCol_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBg",
       "qualType" : "ImGuiCol_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBgActive",
       "qualType" : "ImGuiCol_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBgCollapsed",
       "qualType" : "ImGuiCol_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_MenuBarBg",
       "qualType" : "ImGuiCol_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarBg",
       "qualType" : "ImGuiCol_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrab",
       "qualType" : "ImGuiCol_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrabHovered",
       "qualType" : "ImGuiCol_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrabActive",
       "qualType" : "ImGuiCol_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_CheckMark",
       "qualType" : "ImGuiCol_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SliderGrab",
       "qualType" : "ImGuiCol_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SliderGrabActive",
       "qualType" : "ImGuiCol_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Button",
       "qualType" : "ImGuiCol_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ButtonHovered",
       "qualType" : "ImGuiCol_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ButtonActive",
       "qualType" : "ImGuiCol_",
       "order" : 23,
-      "evaluatedValue" : "23"
+      "evaluatedValue" : 23
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Header",
       "docComment" : "Header* colors are used for CollapsingHeader, TreeNode, Selectable, MenuItem",
       "qualType" : "ImGuiCol_",
       "order" : 24,
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_HeaderHovered",
       "qualType" : "ImGuiCol_",
       "order" : 25,
-      "evaluatedValue" : "25"
+      "evaluatedValue" : 25
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_HeaderActive",
       "qualType" : "ImGuiCol_",
       "order" : 26,
-      "evaluatedValue" : "26"
+      "evaluatedValue" : 26
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Separator",
       "qualType" : "ImGuiCol_",
       "order" : 27,
-      "evaluatedValue" : "27"
+      "evaluatedValue" : 27
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SeparatorHovered",
       "qualType" : "ImGuiCol_",
       "order" : 28,
-      "evaluatedValue" : "28"
+      "evaluatedValue" : 28
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SeparatorActive",
       "qualType" : "ImGuiCol_",
       "order" : 29,
-      "evaluatedValue" : "29"
+      "evaluatedValue" : 29
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGrip",
       "qualType" : "ImGuiCol_",
       "order" : 30,
-      "evaluatedValue" : "30"
+      "evaluatedValue" : 30
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGripHovered",
       "qualType" : "ImGuiCol_",
       "order" : 31,
-      "evaluatedValue" : "31"
+      "evaluatedValue" : 31
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGripActive",
       "qualType" : "ImGuiCol_",
       "order" : 32,
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Tab",
       "qualType" : "ImGuiCol_",
       "order" : 33,
-      "evaluatedValue" : "33"
+      "evaluatedValue" : 33
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabHovered",
       "qualType" : "ImGuiCol_",
       "order" : 34,
-      "evaluatedValue" : "34"
+      "evaluatedValue" : 34
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabActive",
       "qualType" : "ImGuiCol_",
       "order" : 35,
-      "evaluatedValue" : "35"
+      "evaluatedValue" : 35
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabUnfocused",
       "qualType" : "ImGuiCol_",
       "order" : 36,
-      "evaluatedValue" : "36"
+      "evaluatedValue" : 36
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabUnfocusedActive",
       "qualType" : "ImGuiCol_",
       "order" : 37,
-      "evaluatedValue" : "37"
+      "evaluatedValue" : 37
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DockingPreview",
       "docComment" : "Preview overlay color when about to docking something",
       "qualType" : "ImGuiCol_",
       "order" : 38,
-      "evaluatedValue" : "38"
+      "evaluatedValue" : 38
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DockingEmptyBg",
       "docComment" : "Background color for empty node (e.g. CentralNode with no window docked into it)",
       "qualType" : "ImGuiCol_",
       "order" : 39,
-      "evaluatedValue" : "39"
+      "evaluatedValue" : 39
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotLines",
       "qualType" : "ImGuiCol_",
       "order" : 40,
-      "evaluatedValue" : "40"
+      "evaluatedValue" : 40
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotLinesHovered",
       "qualType" : "ImGuiCol_",
       "order" : 41,
-      "evaluatedValue" : "41"
+      "evaluatedValue" : 41
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotHistogram",
       "qualType" : "ImGuiCol_",
       "order" : 42,
-      "evaluatedValue" : "42"
+      "evaluatedValue" : 42
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotHistogramHovered",
       "qualType" : "ImGuiCol_",
       "order" : 43,
-      "evaluatedValue" : "43"
+      "evaluatedValue" : 43
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableHeaderBg",
       "docComment" : "Table header background",
       "qualType" : "ImGuiCol_",
       "order" : 44,
-      "evaluatedValue" : "44"
+      "evaluatedValue" : 44
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableBorderStrong",
       "docComment" : "Table outer and header borders (prefer using Alpha=1.0 here)",
       "qualType" : "ImGuiCol_",
       "order" : 45,
-      "evaluatedValue" : "45"
+      "evaluatedValue" : 45
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableBorderLight",
       "docComment" : "Table inner borders (prefer using Alpha=1.0 here)",
       "qualType" : "ImGuiCol_",
       "order" : 46,
-      "evaluatedValue" : "46"
+      "evaluatedValue" : 46
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableRowBg",
       "docComment" : "Table row background (even rows)",
       "qualType" : "ImGuiCol_",
       "order" : 47,
-      "evaluatedValue" : "47"
+      "evaluatedValue" : 47
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableRowBgAlt",
       "docComment" : "Table row background (odd rows)",
       "qualType" : "ImGuiCol_",
       "order" : 48,
-      "evaluatedValue" : "48"
+      "evaluatedValue" : 48
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TextSelectedBg",
       "qualType" : "ImGuiCol_",
       "order" : 49,
-      "evaluatedValue" : "49"
+      "evaluatedValue" : 49
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DragDropTarget",
       "qualType" : "ImGuiCol_",
       "order" : 50,
-      "evaluatedValue" : "50"
+      "evaluatedValue" : 50
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavHighlight",
       "docComment" : "Gamepad/keyboard: current highlighted item",
       "qualType" : "ImGuiCol_",
       "order" : 51,
-      "evaluatedValue" : "51"
+      "evaluatedValue" : 51
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavWindowingHighlight",
       "docComment" : "Highlight window when using CTRL+TAB",
       "qualType" : "ImGuiCol_",
       "order" : 52,
-      "evaluatedValue" : "52"
+      "evaluatedValue" : 52
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavWindowingDimBg",
       "docComment" : "Darken/colorize entire screen behind the CTRL+TAB window list, when active",
       "qualType" : "ImGuiCol_",
       "order" : 53,
-      "evaluatedValue" : "53"
+      "evaluatedValue" : 53
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ModalWindowDimBg",
       "docComment" : "Darken/colorize entire screen behind a modal window, when one is active",
       "qualType" : "ImGuiCol_",
       "order" : 54,
-      "evaluatedValue" : "54"
+      "evaluatedValue" : 54
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_COUNT",
       "qualType" : "ImGuiCol_",
       "order" : 55,
-      "evaluatedValue" : "55"
+      "evaluatedValue" : 55
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -10372,181 +10372,181 @@
       "docComment" : "float     Alpha",
       "qualType" : "ImGuiStyleVar_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_DisabledAlpha",
       "docComment" : "float     DisabledAlpha",
       "qualType" : "ImGuiStyleVar_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowPadding",
       "docComment" : "ImVec2    WindowPadding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowRounding",
       "docComment" : "float     WindowRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowBorderSize",
       "docComment" : "float     WindowBorderSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowMinSize",
       "docComment" : "ImVec2    WindowMinSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowTitleAlign",
       "docComment" : "ImVec2    WindowTitleAlign",
       "qualType" : "ImGuiStyleVar_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ChildRounding",
       "docComment" : "float     ChildRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ChildBorderSize",
       "docComment" : "float     ChildBorderSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_PopupRounding",
       "docComment" : "float     PopupRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_PopupBorderSize",
       "docComment" : "float     PopupBorderSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FramePadding",
       "docComment" : "ImVec2    FramePadding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FrameRounding",
       "docComment" : "float     FrameRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FrameBorderSize",
       "docComment" : "float     FrameBorderSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ItemSpacing",
       "docComment" : "ImVec2    ItemSpacing",
       "qualType" : "ImGuiStyleVar_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ItemInnerSpacing",
       "docComment" : "ImVec2    ItemInnerSpacing",
       "qualType" : "ImGuiStyleVar_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_IndentSpacing",
       "docComment" : "float     IndentSpacing",
       "qualType" : "ImGuiStyleVar_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_CellPadding",
       "docComment" : "ImVec2    CellPadding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ScrollbarSize",
       "docComment" : "float     ScrollbarSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ScrollbarRounding",
       "docComment" : "float     ScrollbarRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_GrabMinSize",
       "docComment" : "float     GrabMinSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_GrabRounding",
       "docComment" : "float     GrabRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_TabRounding",
       "docComment" : "float     TabRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ButtonTextAlign",
       "docComment" : "ImVec2    ButtonTextAlign",
       "qualType" : "ImGuiStyleVar_",
       "order" : 23,
-      "evaluatedValue" : "23"
+      "evaluatedValue" : 23
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_SelectableTextAlign",
       "docComment" : "ImVec2    SelectableTextAlign",
       "qualType" : "ImGuiStyleVar_",
       "order" : 24,
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_COUNT",
       "qualType" : "ImGuiStyleVar_",
       "order" : 25,
-      "evaluatedValue" : "25"
+      "evaluatedValue" : 25
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -10566,7 +10566,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonLeft",
@@ -10574,7 +10574,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonRight",
@@ -10582,7 +10582,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonMiddle",
@@ -10590,7 +10590,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonMask_",
@@ -10598,7 +10598,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 4,
       "value" : "ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle",
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonDefault_",
@@ -10606,7 +10606,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 5,
       "value" : "ImGuiButtonFlags_MouseButtonLeft",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -10626,7 +10626,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoAlpha",
@@ -10634,7 +10634,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 1,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoPicker",
@@ -10642,7 +10642,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 2,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoOptions",
@@ -10650,7 +10650,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 3,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoSmallPreview",
@@ -10658,7 +10658,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 4,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoInputs",
@@ -10666,7 +10666,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 5,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoTooltip",
@@ -10674,7 +10674,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 6,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoLabel",
@@ -10682,7 +10682,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 7,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoSidePreview",
@@ -10690,7 +10690,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 8,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoDragDrop",
@@ -10698,7 +10698,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 9,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoBorder",
@@ -10706,7 +10706,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 10,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_AlphaBar",
@@ -10714,7 +10714,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 11,
       "value" : "1 << 16",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_AlphaPreview",
@@ -10722,7 +10722,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 12,
       "value" : "1 << 17",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_AlphaPreviewHalf",
@@ -10730,7 +10730,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 13,
       "value" : "1 << 18",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_HDR",
@@ -10738,7 +10738,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 14,
       "value" : "1 << 19",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DisplayRGB",
@@ -10746,7 +10746,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 15,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DisplayHSV",
@@ -10754,7 +10754,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 16,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DisplayHex",
@@ -10762,7 +10762,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 17,
       "value" : "1 << 22",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_Uint8",
@@ -10770,7 +10770,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 18,
       "value" : "1 << 23",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_Float",
@@ -10778,7 +10778,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 19,
       "value" : "1 << 24",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_PickerHueBar",
@@ -10786,7 +10786,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 20,
       "value" : "1 << 25",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_PickerHueWheel",
@@ -10794,7 +10794,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 21,
       "value" : "1 << 26",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_InputRGB",
@@ -10802,7 +10802,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 22,
       "value" : "1 << 27",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_InputHSV",
@@ -10810,7 +10810,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 23,
       "value" : "1 << 28",
-      "evaluatedValue" : "268435456"
+      "evaluatedValue" : 268435456
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DefaultOptions_",
@@ -10818,7 +10818,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 24,
       "value" : "ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_PickerHueBar",
-      "evaluatedValue" : "177209344"
+      "evaluatedValue" : 177209344
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DisplayMask_",
@@ -10826,7 +10826,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 25,
       "value" : "ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_DisplayHSV | ImGuiColorEditFlags_DisplayHex",
-      "evaluatedValue" : "7340032"
+      "evaluatedValue" : 7340032
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DataTypeMask_",
@@ -10834,7 +10834,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 26,
       "value" : "ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_Float",
-      "evaluatedValue" : "25165824"
+      "evaluatedValue" : 25165824
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_PickerMask_",
@@ -10842,7 +10842,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 27,
       "value" : "ImGuiColorEditFlags_PickerHueWheel | ImGuiColorEditFlags_PickerHueBar",
-      "evaluatedValue" : "100663296"
+      "evaluatedValue" : 100663296
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_InputMask_",
@@ -10850,7 +10850,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 28,
       "value" : "ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_InputHSV",
-      "evaluatedValue" : "402653184"
+      "evaluatedValue" : 402653184
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_RGB",
@@ -10858,7 +10858,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 29,
       "value" : "ImGuiColorEditFlags_DisplayRGB",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_HSV",
@@ -10866,7 +10866,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 30,
       "value" : "ImGuiColorEditFlags_DisplayHSV",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_HEX",
@@ -10874,7 +10874,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 31,
       "value" : "ImGuiColorEditFlags_DisplayHex",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -10897,7 +10897,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_AlwaysClamp",
@@ -10905,7 +10905,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 1,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_Logarithmic",
@@ -10913,7 +10913,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 2,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_NoRoundToFormat",
@@ -10921,7 +10921,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 3,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_NoInput",
@@ -10929,7 +10929,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 4,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_InvalidMask_",
@@ -10937,7 +10937,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 5,
       "value" : "0x7000000F",
-      "evaluatedValue" : "1879048207"
+      "evaluatedValue" : 1879048207
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_ClampOnInput",
@@ -10945,7 +10945,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 6,
       "value" : "ImGuiSliderFlags_AlwaysClamp",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -10968,28 +10968,28 @@
       "qualType" : "ImGuiMouseButton_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseButton_Right",
       "qualType" : "ImGuiMouseButton_",
       "order" : 1,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseButton_Middle",
       "qualType" : "ImGuiMouseButton_",
       "order" : 2,
       "value" : "2",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseButton_COUNT",
       "qualType" : "ImGuiMouseButton_",
       "order" : 3,
       "value" : "5",
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11012,76 +11012,76 @@
       "qualType" : "ImGuiMouseCursor_",
       "order" : 0,
       "value" : "-1",
-      "evaluatedValue" : "-1"
+      "evaluatedValue" : -1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_Arrow",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 1,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_TextInput",
       "docComment" : "When hovering over InputText, etc.",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 2,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeAll",
       "docComment" : "(Unused by Dear ImGui functions)",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 3,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNS",
       "docComment" : "When hovering over an horizontal border",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 4,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeEW",
       "docComment" : "When hovering over a vertical border or a column",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 5,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNESW",
       "docComment" : "When hovering over the bottom-left corner of a window",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 6,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNWSE",
       "docComment" : "When hovering over the bottom-right corner of a window",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 7,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_Hand",
       "docComment" : "(Unused by Dear ImGui functions. Use for e.g. hyperlinks)",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 8,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_NotAllowed",
       "docComment" : "When hovering something with disallowed interaction. Usually a crossed circle.",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 9,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_COUNT",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 10,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11108,7 +11108,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCond_Always",
@@ -11116,7 +11116,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCond_Once",
@@ -11124,7 +11124,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCond_FirstUseEver",
@@ -11132,7 +11132,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCond_Appearing",
@@ -11140,7 +11140,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -13386,7 +13386,7 @@
       "qualType" : "ImDrawFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_Closed",
@@ -13394,7 +13394,7 @@
       "qualType" : "ImDrawFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersTopLeft",
@@ -13402,7 +13402,7 @@
       "qualType" : "ImDrawFlags_",
       "order" : 2,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersTopRight",
@@ -13410,7 +13410,7 @@
       "qualType" : "ImDrawFlags_",
       "order" : 3,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersBottomLeft",
@@ -13418,7 +13418,7 @@
       "qualType" : "ImDrawFlags_",
       "order" : 4,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersBottomRight",
@@ -13426,7 +13426,7 @@
       "qualType" : "ImDrawFlags_",
       "order" : 5,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersNone",
@@ -13434,42 +13434,42 @@
       "qualType" : "ImDrawFlags_",
       "order" : 6,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersTop",
       "qualType" : "ImDrawFlags_",
       "order" : 7,
       "value" : "ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight",
-      "evaluatedValue" : "48"
+      "evaluatedValue" : 48
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersBottom",
       "qualType" : "ImDrawFlags_",
       "order" : 8,
       "value" : "ImDrawFlags_RoundCornersBottomLeft | ImDrawFlags_RoundCornersBottomRight",
-      "evaluatedValue" : "192"
+      "evaluatedValue" : 192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersLeft",
       "qualType" : "ImDrawFlags_",
       "order" : 9,
       "value" : "ImDrawFlags_RoundCornersBottomLeft | ImDrawFlags_RoundCornersTopLeft",
-      "evaluatedValue" : "80"
+      "evaluatedValue" : 80
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersRight",
       "qualType" : "ImDrawFlags_",
       "order" : 10,
       "value" : "ImDrawFlags_RoundCornersBottomRight | ImDrawFlags_RoundCornersTopRight",
-      "evaluatedValue" : "160"
+      "evaluatedValue" : 160
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersAll",
       "qualType" : "ImDrawFlags_",
       "order" : 11,
       "value" : "ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight | ImDrawFlags_RoundCornersBottomLeft | ImDrawFlags_RoundCornersBottomRight",
-      "evaluatedValue" : "240"
+      "evaluatedValue" : 240
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersDefault_",
@@ -13477,14 +13477,14 @@
       "qualType" : "ImDrawFlags_",
       "order" : 12,
       "value" : "ImDrawFlags_RoundCornersAll",
-      "evaluatedValue" : "240"
+      "evaluatedValue" : 240
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersMask_",
       "qualType" : "ImDrawFlags_",
       "order" : 13,
       "value" : "ImDrawFlags_RoundCornersAll | ImDrawFlags_RoundCornersNone",
-      "evaluatedValue" : "496"
+      "evaluatedValue" : 496
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -13507,7 +13507,7 @@
       "qualType" : "ImDrawListFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawListFlags_AntiAliasedLines",
@@ -13515,7 +13515,7 @@
       "qualType" : "ImDrawListFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawListFlags_AntiAliasedLinesUseTex",
@@ -13523,7 +13523,7 @@
       "qualType" : "ImDrawListFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawListFlags_AntiAliasedFill",
@@ -13531,7 +13531,7 @@
       "qualType" : "ImDrawListFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawListFlags_AllowVtxOffset",
@@ -13539,7 +13539,7 @@
       "qualType" : "ImDrawListFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -15379,7 +15379,7 @@
       "qualType" : "ImFontAtlasFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImFontAtlasFlags_NoPowerOfTwoHeight",
@@ -15387,7 +15387,7 @@
       "qualType" : "ImFontAtlasFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImFontAtlasFlags_NoMouseCursors",
@@ -15395,7 +15395,7 @@
       "qualType" : "ImFontAtlasFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImFontAtlasFlags_NoBakedLines",
@@ -15403,7 +15403,7 @@
       "qualType" : "ImFontAtlasFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -16470,7 +16470,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_IsPlatformWindow",
@@ -16478,7 +16478,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_IsPlatformMonitor",
@@ -16486,7 +16486,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_OwnedByApp",
@@ -16494,7 +16494,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoDecoration",
@@ -16502,7 +16502,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoTaskBarIcon",
@@ -16510,7 +16510,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoFocusOnAppearing",
@@ -16518,7 +16518,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoFocusOnClick",
@@ -16526,7 +16526,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoInputs",
@@ -16534,7 +16534,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoRendererClear",
@@ -16542,7 +16542,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_TopMost",
@@ -16550,7 +16550,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_Minimized",
@@ -16558,7 +16558,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoAutoMerge",
@@ -16566,7 +16566,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 12,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_CanHostOtherWindows",
@@ -16574,7 +16574,7 @@
       "qualType" : "ImGuiViewportFlags_",
       "order" : 13,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -17604,7 +17604,7 @@
       "qualType" : "ImDrawCornerFlags_",
       "order" : 0,
       "value" : "ImDrawFlags_RoundCornersNone",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_TopLeft",
@@ -17612,7 +17612,7 @@
       "qualType" : "ImDrawCornerFlags_",
       "order" : 1,
       "value" : "ImDrawFlags_RoundCornersTopLeft",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_TopRight",
@@ -17620,7 +17620,7 @@
       "qualType" : "ImDrawCornerFlags_",
       "order" : 2,
       "value" : "ImDrawFlags_RoundCornersTopRight",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_BotLeft",
@@ -17628,7 +17628,7 @@
       "qualType" : "ImDrawCornerFlags_",
       "order" : 3,
       "value" : "ImDrawFlags_RoundCornersBottomLeft",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_BotRight",
@@ -17636,7 +17636,7 @@
       "qualType" : "ImDrawCornerFlags_",
       "order" : 4,
       "value" : "ImDrawFlags_RoundCornersBottomRight",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_All",
@@ -17644,35 +17644,35 @@
       "qualType" : "ImDrawCornerFlags_",
       "order" : 5,
       "value" : "ImDrawFlags_RoundCornersAll",
-      "evaluatedValue" : "240"
+      "evaluatedValue" : 240
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_Top",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 6,
       "value" : "ImDrawCornerFlags_TopLeft | ImDrawCornerFlags_TopRight",
-      "evaluatedValue" : "48"
+      "evaluatedValue" : 48
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_Bot",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 7,
       "value" : "ImDrawCornerFlags_BotLeft | ImDrawCornerFlags_BotRight",
-      "evaluatedValue" : "192"
+      "evaluatedValue" : 192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_Left",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 8,
       "value" : "ImDrawCornerFlags_TopLeft | ImDrawCornerFlags_BotLeft",
-      "evaluatedValue" : "80"
+      "evaluatedValue" : 80
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_Right",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 9,
       "value" : "ImDrawCornerFlags_TopRight | ImDrawCornerFlags_BotRight",
-      "evaluatedValue" : "160"
+      "evaluatedValue" : 160
     } ]
   } ]
 }

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui.json
@@ -34,10 +34,6 @@
         } ]
       } ]
     }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "operator=",
-      "resultType" : "ImVec2 &"
-    }, {
       "@type" : "AstFieldDecl",
       "name" : "x",
       "qualType" : "float",
@@ -47,26 +43,6 @@
       "name" : "y",
       "qualType" : "float",
       "desugaredQualType" : "float"
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "operator[]",
-      "resultType" : "float",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "idx",
-        "qualType" : "size_t",
-        "desugaredQualType" : "unsigned long"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "operator[]",
-      "resultType" : "float &",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "idx",
-        "qualType" : "size_t",
-        "desugaredQualType" : "unsigned long"
-      } ]
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -80,10 +56,6 @@
           "text" : " ImVec4: 4D vector used to store clipping rectangles, colors etc. [Compile-time configurable type]"
         } ]
       } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "operator=",
-      "resultType" : "ImVec4 &"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "x",
@@ -131,6 +103,12 @@
       "name" : "CreateContext",
       "resultType" : "ImGuiContext *",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "shared_font_atlas",
+        "qualType" : "ImFontAtlas *",
+        "desugaredQualType" : "ImFontAtlas *",
+        "defaultValue" : "NULL"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -148,12 +126,6 @@
             "text" : "   for each static/DLL boundary you are calling from. Read \"Context and Memory Allocators\" section of imgui.cpp for details."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "shared_font_atlas",
-        "qualType" : "ImFontAtlas *",
-        "desugaredQualType" : "ImFontAtlas *",
-        "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -219,6 +191,12 @@
       "name" : "ShowDemoWindow",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "NULL"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -227,12 +205,6 @@
             "text" : " Demo, Debug, Information"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "p_open",
-        "qualType" : "bool *",
-        "desugaredQualType" : "bool *",
-        "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -311,6 +283,12 @@
       "name" : "StyleColorsDark",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImGuiStyle *",
+        "desugaredQualType" : "ImGuiStyle *",
+        "defaultValue" : "NULL"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -319,12 +297,6 @@
             "text" : " Styles"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "dst",
-        "qualType" : "ImGuiStyle *",
-        "desugaredQualType" : "ImGuiStyle *",
-        "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -353,6 +325,23 @@
       "name" : "Begin",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -394,23 +383,6 @@
             "text" : " - Note that the bottom of window stack always contains a window called \"Debug\"."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "name",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "p_open",
-        "qualType" : "bool *",
-        "desugaredQualType" : "bool *",
-        "defaultValue" : "NULL"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiWindowFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -421,6 +393,29 @@
       "name" : "BeginChild",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "ImVec2(0, 0)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "border",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "false"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -456,29 +451,6 @@
             "text" : "    returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.]"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "str_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &",
-        "defaultValue" : "ImVec2(0, 0)"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "border",
-        "qualType" : "bool",
-        "desugaredQualType" : "bool",
-        "defaultValue" : "false"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiWindowFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -588,18 +560,6 @@
       "name" : "SetNextWindowPos",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Window manipulation"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin)."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
         "qualType" : "const ImVec2 &",
@@ -616,6 +576,18 @@
         "qualType" : "const ImVec2 &",
         "desugaredQualType" : "const ImVec2 &",
         "defaultValue" : "ImVec2(0, 0)"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Window manipulation"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin)."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -982,6 +954,11 @@
       "name" : "PushFont",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "font",
+        "qualType" : "ImFont *",
+        "desugaredQualType" : "ImFont *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -990,11 +967,6 @@
             "text" : " Parameters stacks (shared)"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "font",
-        "qualType" : "ImFont *",
-        "desugaredQualType" : "ImFont *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1115,6 +1087,11 @@
       "name" : "PushItemWidth",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "item_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1123,11 +1100,6 @@
             "text" : " Parameters stacks (current window)"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "item_width",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1415,6 +1387,11 @@
       "name" : "PushID",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1453,11 +1430,6 @@
             "text" : "   whereas \"str_id\" denote a string that is only used as an ID and not normally displayed."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "str_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1538,15 +1510,6 @@
       "name" : "TextUnformatted",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Widgets: Text"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
         "qualType" : "const char *",
@@ -1557,6 +1520,15 @@
         "qualType" : "const char *",
         "desugaredQualType" : "const char *",
         "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Text"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1793,6 +1765,17 @@
       "name" : "Button",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "ImVec2(0, 0)"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1807,17 +1790,6 @@
             "text" : " - You may also use one of the many IsItemXXX functions (e.g. IsItemActive, IsItemHovered, etc.) to query widget state."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &",
-        "defaultValue" : "ImVec2(0, 0)"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2070,21 +2042,6 @@
       "name" : "BeginCombo",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Widgets: Combo Box"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - The BeginCombo()/EndCombo() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() items."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -2100,6 +2057,21 @@
         "qualType" : "ImGuiComboFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Combo Box"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - The BeginCombo()/EndCombo() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() items."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2203,6 +2175,46 @@
       "name" : "DragFloat",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "1.0f"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "0.0f"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "0.0f"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "\"%.3f\""
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2253,46 +2265,6 @@
             "text" : "   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "v",
-        "qualType" : "float *",
-        "desugaredQualType" : "float *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "v_speed",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "1.0f"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "v_min",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "0.0f"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "v_max",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "0.0f"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "format",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "\"%.3f\""
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiSliderFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2831,30 +2803,6 @@
       "name" : "SliderFloat",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Widgets: Regular Sliders"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - CTRL+Click on any slider to turn them into an input box. Manually input values aren't clamped by default and can go off-bounds. Use ImGuiSliderFlags_AlwaysClamp to always clamp."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Adjust format string to decorate the value with a prefix, a suffix, or adapt the editing and display precision e.g. \"%.3f\" -> 1.234; \"%5.2f secs\" -> 01.23 secs; \"Biscuit: %.0f\" -> Biscuit: 1; etc."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Format string may also be set to NULL or use the default format (\"%f\" or \"%d\")."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Legacy: Pre-1.78 there are SliderXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : "   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -2886,6 +2834,30 @@
         "qualType" : "ImGuiSliderFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Regular Sliders"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - CTRL+Click on any slider to turn them into an input box. Manually input values aren't clamped by default and can go off-bounds. Use ImGuiSliderFlags_AlwaysClamp to always clamp."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Adjust format string to decorate the value with a prefix, a suffix, or adapt the editing and display precision e.g. \"%.3f\" -> 1.234; \"%5.2f secs\" -> 01.23 secs; \"Biscuit: %.0f\" -> Biscuit: 1; etc."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Format string may also be set to NULL or use the default format (\"%f\" or \"%d\")."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Legacy: Pre-1.78 there are SliderXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3410,21 +3382,6 @@
       "name" : "InputText",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Widgets: Input with Keyboard"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - If you want to use InputText() with std::string or any custom dynamic string type, see misc/cpp/imgui_stdlib.h and comments in imgui_demo.cpp."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Most of the ImGuiInputTextFlags flags are only useful for InputText() and not for InputFloatX, InputIntX, InputDouble etc."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -3457,6 +3414,21 @@
         "qualType" : "void *",
         "desugaredQualType" : "void *",
         "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Input with Keyboard"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - If you want to use InputText() with std::string or any custom dynamic string type, see misc/cpp/imgui_stdlib.h and comments in imgui_demo.cpp."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Most of the ImGuiInputTextFlags flags are only useful for InputText() and not for InputFloatX, InputIntX, InputDouble etc."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3898,6 +3870,22 @@
       "name" : "ColorEdit3",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiColorEditFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3918,22 +3906,6 @@
             "text" : ".x"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "col",
-        "qualType" : "float *",
-        "desugaredQualType" : "float *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiColorEditFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4046,6 +4018,11 @@
       "name" : "TreeNode",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4057,11 +4034,6 @@
             "text" : " - TreeNode functions return true when the node is open, in which case you need to also call TreePop() when you are finished displaying the tree node contents."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4366,21 +4338,6 @@
       "name" : "Selectable",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Widgets: Selectables"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - A selectable highlights when hovered, and can display another color when selected."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Neighbors selectable extend their highlight bounds in order to leave no gap between them. This is so a series of selected Selectable appear contiguous."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -4403,6 +4360,21 @@
         "qualType" : "const ImVec2 &",
         "desugaredQualType" : "const ImVec2 &",
         "defaultValue" : "ImVec2(0, 0)"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Selectables"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - A selectable highlights when hovered, and can display another color when selected."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Neighbors selectable extend their highlight bounds in order to leave no gap between them. This is so a series of selected Selectable appear contiguous."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4436,6 +4408,17 @@
       "name" : "BeginListBox",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "ImVec2(0, 0)"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4471,17 +4454,6 @@
             "text" : " 0.0f or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &",
-        "defaultValue" : "ImVec2(0, 0)"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4559,18 +4531,6 @@
       "name" : "PlotLines",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Widgets: Data Plotting"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Consider using ImPlot (https://github.com/epezent/implot) which is much better!"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -4621,6 +4581,18 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "sizeof(float)"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Data Plotting"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Consider using ImPlot (https://github.com/epezent/implot) which is much better!"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4793,6 +4765,16 @@
       "name" : "Value",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "prefix",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "b",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4804,16 +4786,6 @@
             "text" : " - Those are merely shortcut to calling Text() with a format string. Output single value in \"name: value\" format (tip: freely declare more in your code to handle your types. you can add functions to the ImGui namespace)"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "prefix",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "b",
-        "qualType" : "bool",
-        "desugaredQualType" : "bool"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5039,6 +5011,17 @@
       "name" : "BeginPopup",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5053,17 +5036,6 @@
             "text" : "  - BeginPopupModal(): block every interactions behind the window, cannot be closed by user, add a dimming background, has a title bar."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "str_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiWindowFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5096,6 +5068,17 @@
       "name" : "OpenPopup",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5122,17 +5105,6 @@
             "text" : "  - Use IsWindowAppearing() after BeginPopup() to tell if a window just opened."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "str_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "popup_flags",
-        "qualType" : "ImGuiPopupFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5176,6 +5148,18 @@
       "name" : "BeginPopupContextItem",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "1"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5196,18 +5180,6 @@
             "text" : "  - IMPORTANT: we exceptionally default their flags to 1 (== ImGuiPopupFlags_MouseButtonRight) for backward compatibility with older API taking 'int mouse_button = 1' parameter, so if you add other flags remember to re-add the ImGuiPopupFlags_MouseButtonRight."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "str_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "NULL"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "popup_flags",
-        "qualType" : "ImGuiPopupFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "1"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5248,6 +5220,17 @@
       "name" : "IsPopupOpen",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5265,23 +5248,40 @@
             "text" : "  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId + ImGuiPopupFlags_AnyPopupLevel: return true if any popup is open."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "str_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiPopupFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginTable",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTableFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "outer_size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "ImVec2(0.0f, 0.0f)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "inner_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "0.0f"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5362,34 +5362,6 @@
             "text" : " - 5. Call EndTable()"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "str_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "column",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiTableFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "outer_size",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &",
-        "defaultValue" : "ImVec2(0.0f, 0.0f)"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "inner_width",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "0.0f"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5431,6 +5403,29 @@
       "name" : "TableSetupColumn",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTableColumnFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "init_width_or_weight",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "0.0f"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5466,29 +5461,6 @@
             "text" : " - Use TableSetupScrollFreeze() to lock columns/rows so they stay visible when scrolled."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiTableColumnFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "init_width_or_weight",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "0.0f"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "user_id",
-        "qualType" : "ImGuiID",
-        "desugaredQualType" : "unsigned int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5636,18 +5608,6 @@
       "name" : "Columns",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Legacy Columns API (prefer using Tables!)"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - You can also use SameLine(pos_x) to mimic simplified columns."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "count",
         "qualType" : "int",
@@ -5665,6 +5625,18 @@
         "qualType" : "bool",
         "desugaredQualType" : "bool",
         "defaultValue" : "true"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Legacy Columns API (prefer using Tables!)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You can also use SameLine(pos_x) to mimic simplified columns."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5735,6 +5707,17 @@
       "name" : "BeginTabBar",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTabBarFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5746,17 +5729,6 @@
             "text" : " Note: Tabs are automatically created by the docking system. Use this to create tab bars/tabs yourself without docking being involved."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "str_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiTabBarFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5819,6 +5791,29 @@
       "name" : "DockSpace",
       "resultType" : "ImGuiID",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "ImVec2(0, 0)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiDockNodeFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "window_class",
+        "qualType" : "const ImGuiWindowClass *",
+        "desugaredQualType" : "const ImGuiWindowClass *",
+        "defaultValue" : "NULL"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5863,29 +5858,6 @@
             "text" : "   e.g. if you have multiple tabs with a dockspace inside each tab: submit the non-visible dockspaces with ImGuiDockNodeFlags_KeepAliveOnly."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "id",
-        "qualType" : "ImGuiID",
-        "desugaredQualType" : "unsigned int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &",
-        "defaultValue" : "ImVec2(0, 0)"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiDockNodeFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "window_class",
-        "qualType" : "const ImGuiWindowClass *",
-        "desugaredQualType" : "const ImGuiWindowClass *",
-        "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -5949,6 +5921,12 @@
       "name" : "LogToTTY",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "auto_open_depth",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "-1"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5960,12 +5938,6 @@
             "text" : " - All text output from the interface can be captured into tty/file/clipboard. By default, tree nodes are automatically opened during logging."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "auto_open_depth",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "-1"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6043,6 +6015,12 @@
       "name" : "BeginDragDropSource",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiDragDropFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6063,12 +6041,6 @@
             "text" : " - An item can be both drag source and drop target."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiDragDropFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6133,6 +6105,12 @@
       "name" : "BeginDisabled",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "disabled",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "true"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6150,12 +6128,6 @@
             "text" : " - BeginDisabled(false) essentially does nothing useful but is provided to facilitate use of boolean expressions. If you can avoid calling BeginDisabled(False)/EndDisabled() best to avoid it."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "disabled",
-        "qualType" : "bool",
-        "desugaredQualType" : "bool",
-        "defaultValue" : "true"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6166,18 +6138,6 @@
       "name" : "PushClipRect",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Clipping"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Mouse hovering is affected by ImGui::PushClipRect() calls, unlike direct calls to ImDrawList::PushClipRect() which are render only."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "clip_rect_min",
         "qualType" : "const ImVec2 &",
@@ -6192,6 +6152,18 @@
         "name" : "intersect_with_current_clip_rect",
         "qualType" : "bool",
         "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Clipping"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Mouse hovering is affected by ImGui::PushClipRect() calls, unlike direct calls to ImDrawList::PushClipRect() which are render only."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6230,6 +6202,12 @@
       "name" : "IsItemHovered",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiHoveredFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6244,12 +6222,6 @@
             "text" : " - See Demo Window under \"Widgets->Querying Status\" for an interactive visualization of most of those functions."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImGuiHoveredFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6350,6 +6322,11 @@
       "name" : "IsRectVisible",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6358,11 +6335,6 @@
             "text" : " Miscellaneous Utilities"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6473,15 +6445,6 @@
       "name" : "CalcTextSize",
       "resultType" : "ImVec2",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Text Utilities"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
         "qualType" : "const char *",
@@ -6504,12 +6467,26 @@
         "qualType" : "float",
         "desugaredQualType" : "float",
         "defaultValue" : "-1.0f"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Text Utilities"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ColorConvertU32ToFloat4",
       "resultType" : "ImVec4",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "in",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6518,11 +6495,6 @@
             "text" : " Color Utilities"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "in",
-        "qualType" : "ImU32",
-        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6609,6 +6581,11 @@
       "name" : "GetKeyIndex",
       "resultType" : "int",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "imgui_key",
+        "qualType" : "ImGuiKey",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6623,11 +6600,6 @@
             "text" : " - We don't know the meaning of those value. You can use GetKeyIndex() to map a ImGuiKey_ value into the user index."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "imgui_key",
-        "qualType" : "ImGuiKey",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6701,6 +6673,11 @@
       "name" : "IsMouseDown",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6718,11 +6695,6 @@
             "text" : " - Dragging operations are only reported after mouse has moved a certain distance away from the initial clicking position (see 'lock_threshold' and 'io.MouseDraggingThreshold')"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "button",
-        "qualType" : "ImGuiMouseButton",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6915,6 +6887,11 @@
       "name" : "LoadIniSettingsFromDisk",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ini_filename",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6932,11 +6909,6 @@
             "text" : " - Important: default value \"imgui.ini\" is relative to current working dir! Most apps will want to lock this to an absolute path (e.g. same path as executables)."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "ini_filename",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -6980,18 +6952,6 @@
       "name" : "DebugCheckVersionAndDataLayout",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Debug Utilities"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - This is used by the IMGUI_CHECKVERSION() macro."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "version_str",
         "qualType" : "const char *",
@@ -7026,12 +6986,40 @@
         "name" : "sz_drawidx",
         "qualType" : "size_t",
         "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Debug Utilities"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - This is used by the IMGUI_CHECKVERSION() macro."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetAllocatorFunctions",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "alloc_func",
+        "qualType" : "ImGuiMemAllocFunc",
+        "desugaredQualType" : "void *(*)(size_t, void *)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "free_func",
+        "qualType" : "ImGuiMemFreeFunc",
+        "desugaredQualType" : "void (*)(void *, void *)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *",
+        "defaultValue" : "NULL"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -7049,22 +7037,6 @@
             "text" : "   for each static/DLL boundary you are calling from. Read \"Context and Memory Allocators\" section of imgui.cpp for more details."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "alloc_func",
-        "qualType" : "ImGuiMemAllocFunc",
-        "desugaredQualType" : "void *(*)(size_t, void *)"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "free_func",
-        "qualType" : "ImGuiMemFreeFunc",
-        "desugaredQualType" : "void (*)(void *, void *)"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "user_data",
-        "qualType" : "void *",
-        "desugaredQualType" : "void *",
-        "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -9271,66 +9243,77 @@
       "name" : "ImGuiDataType_S8",
       "docComment" : "signed char / char (with sensible compilers)",
       "qualType" : "ImGuiDataType_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U8",
       "docComment" : "unsigned char",
       "qualType" : "ImGuiDataType_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S16",
       "docComment" : "short",
       "qualType" : "ImGuiDataType_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U16",
       "docComment" : "unsigned short",
       "qualType" : "ImGuiDataType_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S32",
       "docComment" : "int",
       "qualType" : "ImGuiDataType_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U32",
       "docComment" : "unsigned int",
       "qualType" : "ImGuiDataType_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S64",
       "docComment" : "long long / __int64",
       "qualType" : "ImGuiDataType_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U64",
       "docComment" : "unsigned long long / unsigned __int64",
       "qualType" : "ImGuiDataType_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_Float",
       "docComment" : "float",
       "qualType" : "ImGuiDataType_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_Double",
       "docComment" : "double",
       "qualType" : "ImGuiDataType_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_COUNT",
       "qualType" : "ImGuiDataType_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9348,42 +9331,43 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_None",
       "qualType" : "ImGuiDir_",
-      "order" : -1,
+      "order" : 0,
       "value" : "-1",
       "evaluatedValue" : "-1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Left",
       "qualType" : "ImGuiDir_",
-      "order" : 0,
+      "order" : 1,
       "value" : "0",
       "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Right",
       "qualType" : "ImGuiDir_",
-      "order" : 1,
+      "order" : 2,
       "value" : "1",
       "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Up",
       "qualType" : "ImGuiDir_",
-      "order" : 2,
+      "order" : 3,
       "value" : "2",
       "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Down",
       "qualType" : "ImGuiDir_",
-      "order" : 3,
+      "order" : 4,
       "value" : "3",
       "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_COUNT",
       "qualType" : "ImGuiDir_",
-      "order" : 4
+      "order" : 5,
+      "evaluatedValue" : "4"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9437,123 +9421,146 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Tab",
       "qualType" : "ImGuiKey_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_LeftArrow",
       "qualType" : "ImGuiKey_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_RightArrow",
       "qualType" : "ImGuiKey_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_UpArrow",
       "qualType" : "ImGuiKey_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_DownArrow",
       "qualType" : "ImGuiKey_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_PageUp",
       "qualType" : "ImGuiKey_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_PageDown",
       "qualType" : "ImGuiKey_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Home",
       "qualType" : "ImGuiKey_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_End",
       "qualType" : "ImGuiKey_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Insert",
       "qualType" : "ImGuiKey_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Delete",
       "qualType" : "ImGuiKey_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Backspace",
       "qualType" : "ImGuiKey_",
-      "order" : 11
+      "order" : 11,
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Space",
       "qualType" : "ImGuiKey_",
-      "order" : 12
+      "order" : 12,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Enter",
       "qualType" : "ImGuiKey_",
-      "order" : 13
+      "order" : 13,
+      "evaluatedValue" : "13"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Escape",
       "qualType" : "ImGuiKey_",
-      "order" : 14
+      "order" : 14,
+      "evaluatedValue" : "14"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_KeyPadEnter",
       "qualType" : "ImGuiKey_",
-      "order" : 15
+      "order" : 15,
+      "evaluatedValue" : "15"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_A",
       "docComment" : "for text edit CTRL+A: select all",
       "qualType" : "ImGuiKey_",
-      "order" : 16
+      "order" : 16,
+      "evaluatedValue" : "16"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_C",
       "docComment" : "for text edit CTRL+C: copy",
       "qualType" : "ImGuiKey_",
-      "order" : 17
+      "order" : 17,
+      "evaluatedValue" : "17"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_V",
       "docComment" : "for text edit CTRL+V: paste",
       "qualType" : "ImGuiKey_",
-      "order" : 18
+      "order" : 18,
+      "evaluatedValue" : "18"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_X",
       "docComment" : "for text edit CTRL+X: cut",
       "qualType" : "ImGuiKey_",
-      "order" : 19
+      "order" : 19,
+      "evaluatedValue" : "19"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Y",
       "docComment" : "for text edit CTRL+Y: redo",
       "qualType" : "ImGuiKey_",
-      "order" : 20
+      "order" : 20,
+      "evaluatedValue" : "20"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Z",
       "docComment" : "for text edit CTRL+Z: undo",
       "qualType" : "ImGuiKey_",
-      "order" : 21
+      "order" : 21,
+      "evaluatedValue" : "21"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_COUNT",
       "qualType" : "ImGuiKey_",
-      "order" : 22
+      "order" : 22,
+      "evaluatedValue" : "22"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9629,120 +9636,141 @@
       "name" : "ImGuiNavInput_Activate",
       "docComment" : "activate / open / toggle / tweak value       // e.g. Cross  (PS4), A (Xbox), A (Switch), Space (Keyboard)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Cancel",
       "docComment" : "cancel / close / exit                        // e.g. Circle (PS4), B (Xbox), B (Switch), Escape (Keyboard)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Input",
       "docComment" : "text input / on-screen keyboard              // e.g. Triang.(PS4), Y (Xbox), X (Switch), Return (Keyboard)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Menu",
       "docComment" : "tap: toggle menu / hold: focus, move, resize // e.g. Square (PS4), X (Xbox), Y (Switch), Alt (Keyboard)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadLeft",
       "docComment" : "move / tweak / resize window (w/ PadMenu)    // e.g. D-pad Left/Right/Up/Down (Gamepads), Arrow keys (Keyboard)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadRight",
       "qualType" : "ImGuiNavInput_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadUp",
       "qualType" : "ImGuiNavInput_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadDown",
       "qualType" : "ImGuiNavInput_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickLeft",
       "docComment" : "scroll / move window (w/ PadMenu)            // e.g. Left Analog Stick Left/Right/Up/Down",
       "qualType" : "ImGuiNavInput_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickRight",
       "qualType" : "ImGuiNavInput_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickUp",
       "qualType" : "ImGuiNavInput_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickDown",
       "qualType" : "ImGuiNavInput_",
-      "order" : 11
+      "order" : 11,
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_FocusPrev",
       "docComment" : "next window (w/ PadMenu)                     // e.g. L1 or L2 (PS4), LB or LT (Xbox), L or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 12
+      "order" : 12,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_FocusNext",
       "docComment" : "prev window (w/ PadMenu)                     // e.g. R1 or R2 (PS4), RB or RT (Xbox), R or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 13
+      "order" : 13,
+      "evaluatedValue" : "13"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_TweakSlow",
       "docComment" : "slower tweaks                                // e.g. L1 or L2 (PS4), LB or LT (Xbox), L or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 14
+      "order" : 14,
+      "evaluatedValue" : "14"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_TweakFast",
       "docComment" : "faster tweaks                                // e.g. R1 or R2 (PS4), RB or RT (Xbox), R or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
-      "order" : 15
+      "order" : 15,
+      "evaluatedValue" : "15"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyLeft_",
       "docComment" : "move left                                    // = Arrow keys",
       "qualType" : "ImGuiNavInput_",
-      "order" : 16
+      "order" : 16,
+      "evaluatedValue" : "16"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyRight_",
       "docComment" : "move right",
       "qualType" : "ImGuiNavInput_",
-      "order" : 17
+      "order" : 17,
+      "evaluatedValue" : "17"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyUp_",
       "docComment" : "move up",
       "qualType" : "ImGuiNavInput_",
-      "order" : 18
+      "order" : 18,
+      "evaluatedValue" : "18"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyDown_",
       "docComment" : "move down",
       "qualType" : "ImGuiNavInput_",
-      "order" : 19
+      "order" : 19,
+      "evaluatedValue" : "19"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_COUNT",
       "qualType" : "ImGuiNavInput_",
-      "order" : 20
+      "order" : 20,
+      "evaluatedValue" : "20"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_InternalStart_",
@@ -9959,298 +9987,354 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Text",
       "qualType" : "ImGuiCol_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TextDisabled",
       "qualType" : "ImGuiCol_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_WindowBg",
       "docComment" : "Background of normal windows",
       "qualType" : "ImGuiCol_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ChildBg",
       "docComment" : "Background of child windows",
       "qualType" : "ImGuiCol_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PopupBg",
       "docComment" : "Background of popups, menus, tooltips windows",
       "qualType" : "ImGuiCol_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Border",
       "qualType" : "ImGuiCol_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_BorderShadow",
       "qualType" : "ImGuiCol_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBg",
       "docComment" : "Background of checkbox, radio button, plot, slider, text input",
       "qualType" : "ImGuiCol_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBgHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBgActive",
       "qualType" : "ImGuiCol_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBg",
       "qualType" : "ImGuiCol_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBgActive",
       "qualType" : "ImGuiCol_",
-      "order" : 11
+      "order" : 11,
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBgCollapsed",
       "qualType" : "ImGuiCol_",
-      "order" : 12
+      "order" : 12,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_MenuBarBg",
       "qualType" : "ImGuiCol_",
-      "order" : 13
+      "order" : 13,
+      "evaluatedValue" : "13"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarBg",
       "qualType" : "ImGuiCol_",
-      "order" : 14
+      "order" : 14,
+      "evaluatedValue" : "14"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrab",
       "qualType" : "ImGuiCol_",
-      "order" : 15
+      "order" : 15,
+      "evaluatedValue" : "15"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrabHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 16
+      "order" : 16,
+      "evaluatedValue" : "16"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrabActive",
       "qualType" : "ImGuiCol_",
-      "order" : 17
+      "order" : 17,
+      "evaluatedValue" : "17"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_CheckMark",
       "qualType" : "ImGuiCol_",
-      "order" : 18
+      "order" : 18,
+      "evaluatedValue" : "18"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SliderGrab",
       "qualType" : "ImGuiCol_",
-      "order" : 19
+      "order" : 19,
+      "evaluatedValue" : "19"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SliderGrabActive",
       "qualType" : "ImGuiCol_",
-      "order" : 20
+      "order" : 20,
+      "evaluatedValue" : "20"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Button",
       "qualType" : "ImGuiCol_",
-      "order" : 21
+      "order" : 21,
+      "evaluatedValue" : "21"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ButtonHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 22
+      "order" : 22,
+      "evaluatedValue" : "22"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ButtonActive",
       "qualType" : "ImGuiCol_",
-      "order" : 23
+      "order" : 23,
+      "evaluatedValue" : "23"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Header",
       "docComment" : "Header* colors are used for CollapsingHeader, TreeNode, Selectable, MenuItem",
       "qualType" : "ImGuiCol_",
-      "order" : 24
+      "order" : 24,
+      "evaluatedValue" : "24"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_HeaderHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 25
+      "order" : 25,
+      "evaluatedValue" : "25"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_HeaderActive",
       "qualType" : "ImGuiCol_",
-      "order" : 26
+      "order" : 26,
+      "evaluatedValue" : "26"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Separator",
       "qualType" : "ImGuiCol_",
-      "order" : 27
+      "order" : 27,
+      "evaluatedValue" : "27"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SeparatorHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 28
+      "order" : 28,
+      "evaluatedValue" : "28"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SeparatorActive",
       "qualType" : "ImGuiCol_",
-      "order" : 29
+      "order" : 29,
+      "evaluatedValue" : "29"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGrip",
       "qualType" : "ImGuiCol_",
-      "order" : 30
+      "order" : 30,
+      "evaluatedValue" : "30"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGripHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 31
+      "order" : 31,
+      "evaluatedValue" : "31"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGripActive",
       "qualType" : "ImGuiCol_",
-      "order" : 32
+      "order" : 32,
+      "evaluatedValue" : "32"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Tab",
       "qualType" : "ImGuiCol_",
-      "order" : 33
+      "order" : 33,
+      "evaluatedValue" : "33"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 34
+      "order" : 34,
+      "evaluatedValue" : "34"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabActive",
       "qualType" : "ImGuiCol_",
-      "order" : 35
+      "order" : 35,
+      "evaluatedValue" : "35"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabUnfocused",
       "qualType" : "ImGuiCol_",
-      "order" : 36
+      "order" : 36,
+      "evaluatedValue" : "36"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabUnfocusedActive",
       "qualType" : "ImGuiCol_",
-      "order" : 37
+      "order" : 37,
+      "evaluatedValue" : "37"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DockingPreview",
       "docComment" : "Preview overlay color when about to docking something",
       "qualType" : "ImGuiCol_",
-      "order" : 38
+      "order" : 38,
+      "evaluatedValue" : "38"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DockingEmptyBg",
       "docComment" : "Background color for empty node (e.g. CentralNode with no window docked into it)",
       "qualType" : "ImGuiCol_",
-      "order" : 39
+      "order" : 39,
+      "evaluatedValue" : "39"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotLines",
       "qualType" : "ImGuiCol_",
-      "order" : 40
+      "order" : 40,
+      "evaluatedValue" : "40"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotLinesHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 41
+      "order" : 41,
+      "evaluatedValue" : "41"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotHistogram",
       "qualType" : "ImGuiCol_",
-      "order" : 42
+      "order" : 42,
+      "evaluatedValue" : "42"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotHistogramHovered",
       "qualType" : "ImGuiCol_",
-      "order" : 43
+      "order" : 43,
+      "evaluatedValue" : "43"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableHeaderBg",
       "docComment" : "Table header background",
       "qualType" : "ImGuiCol_",
-      "order" : 44
+      "order" : 44,
+      "evaluatedValue" : "44"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableBorderStrong",
       "docComment" : "Table outer and header borders (prefer using Alpha=1.0 here)",
       "qualType" : "ImGuiCol_",
-      "order" : 45
+      "order" : 45,
+      "evaluatedValue" : "45"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableBorderLight",
       "docComment" : "Table inner borders (prefer using Alpha=1.0 here)",
       "qualType" : "ImGuiCol_",
-      "order" : 46
+      "order" : 46,
+      "evaluatedValue" : "46"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableRowBg",
       "docComment" : "Table row background (even rows)",
       "qualType" : "ImGuiCol_",
-      "order" : 47
+      "order" : 47,
+      "evaluatedValue" : "47"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableRowBgAlt",
       "docComment" : "Table row background (odd rows)",
       "qualType" : "ImGuiCol_",
-      "order" : 48
+      "order" : 48,
+      "evaluatedValue" : "48"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TextSelectedBg",
       "qualType" : "ImGuiCol_",
-      "order" : 49
+      "order" : 49,
+      "evaluatedValue" : "49"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DragDropTarget",
       "qualType" : "ImGuiCol_",
-      "order" : 50
+      "order" : 50,
+      "evaluatedValue" : "50"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavHighlight",
       "docComment" : "Gamepad/keyboard: current highlighted item",
       "qualType" : "ImGuiCol_",
-      "order" : 51
+      "order" : 51,
+      "evaluatedValue" : "51"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavWindowingHighlight",
       "docComment" : "Highlight window when using CTRL+TAB",
       "qualType" : "ImGuiCol_",
-      "order" : 52
+      "order" : 52,
+      "evaluatedValue" : "52"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavWindowingDimBg",
       "docComment" : "Darken/colorize entire screen behind the CTRL+TAB window list, when active",
       "qualType" : "ImGuiCol_",
-      "order" : 53
+      "order" : 53,
+      "evaluatedValue" : "53"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ModalWindowDimBg",
       "docComment" : "Darken/colorize entire screen behind a modal window, when one is active",
       "qualType" : "ImGuiCol_",
-      "order" : 54
+      "order" : 54,
+      "evaluatedValue" : "54"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_COUNT",
       "qualType" : "ImGuiCol_",
-      "order" : 55
+      "order" : 55,
+      "evaluatedValue" : "55"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -10287,156 +10371,182 @@
       "name" : "ImGuiStyleVar_Alpha",
       "docComment" : "float     Alpha",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_DisabledAlpha",
       "docComment" : "float     DisabledAlpha",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowPadding",
       "docComment" : "ImVec2    WindowPadding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowRounding",
       "docComment" : "float     WindowRounding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowBorderSize",
       "docComment" : "float     WindowBorderSize",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowMinSize",
       "docComment" : "ImVec2    WindowMinSize",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowTitleAlign",
       "docComment" : "ImVec2    WindowTitleAlign",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ChildRounding",
       "docComment" : "float     ChildRounding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ChildBorderSize",
       "docComment" : "float     ChildBorderSize",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_PopupRounding",
       "docComment" : "float     PopupRounding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_PopupBorderSize",
       "docComment" : "float     PopupBorderSize",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FramePadding",
       "docComment" : "ImVec2    FramePadding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 11
+      "order" : 11,
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FrameRounding",
       "docComment" : "float     FrameRounding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 12
+      "order" : 12,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FrameBorderSize",
       "docComment" : "float     FrameBorderSize",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 13
+      "order" : 13,
+      "evaluatedValue" : "13"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ItemSpacing",
       "docComment" : "ImVec2    ItemSpacing",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 14
+      "order" : 14,
+      "evaluatedValue" : "14"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ItemInnerSpacing",
       "docComment" : "ImVec2    ItemInnerSpacing",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 15
+      "order" : 15,
+      "evaluatedValue" : "15"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_IndentSpacing",
       "docComment" : "float     IndentSpacing",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 16
+      "order" : 16,
+      "evaluatedValue" : "16"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_CellPadding",
       "docComment" : "ImVec2    CellPadding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 17
+      "order" : 17,
+      "evaluatedValue" : "17"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ScrollbarSize",
       "docComment" : "float     ScrollbarSize",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 18
+      "order" : 18,
+      "evaluatedValue" : "18"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ScrollbarRounding",
       "docComment" : "float     ScrollbarRounding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 19
+      "order" : 19,
+      "evaluatedValue" : "19"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_GrabMinSize",
       "docComment" : "float     GrabMinSize",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 20
+      "order" : 20,
+      "evaluatedValue" : "20"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_GrabRounding",
       "docComment" : "float     GrabRounding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 21
+      "order" : 21,
+      "evaluatedValue" : "21"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_TabRounding",
       "docComment" : "float     TabRounding",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 22
+      "order" : 22,
+      "evaluatedValue" : "22"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ButtonTextAlign",
       "docComment" : "ImVec2    ButtonTextAlign",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 23
+      "order" : 23,
+      "evaluatedValue" : "23"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_SelectableTextAlign",
       "docComment" : "ImVec2    SelectableTextAlign",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 24
+      "order" : 24,
+      "evaluatedValue" : "24"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_COUNT",
       "qualType" : "ImGuiStyleVar_",
-      "order" : 25
+      "order" : 25,
+      "evaluatedValue" : "25"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -10900,14 +11010,14 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_None",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : -1,
+      "order" : 0,
       "value" : "-1",
       "evaluatedValue" : "-1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_Arrow",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 0,
+      "order" : 1,
       "value" : "0",
       "evaluatedValue" : "0"
     }, {
@@ -10915,54 +11025,63 @@
       "name" : "ImGuiMouseCursor_TextInput",
       "docComment" : "When hovering over InputText, etc.",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 1
+      "order" : 2,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeAll",
       "docComment" : "(Unused by Dear ImGui functions)",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 2
+      "order" : 3,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNS",
       "docComment" : "When hovering over an horizontal border",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 3
+      "order" : 4,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeEW",
       "docComment" : "When hovering over a vertical border or a column",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 4
+      "order" : 5,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNESW",
       "docComment" : "When hovering over the bottom-left corner of a window",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 5
+      "order" : 6,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNWSE",
       "docComment" : "When hovering over the bottom-right corner of a window",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 6
+      "order" : 7,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_Hand",
       "docComment" : "(Unused by Dear ImGui functions. Use for e.g. hyperlinks)",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 7
+      "order" : 8,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_NotAllowed",
       "docComment" : "When hovering something with disallowed interaction. Usually a crossed circle.",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 8
+      "order" : 9,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_COUNT",
       "qualType" : "ImGuiMouseCursor_",
-      "order" : 9
+      "order" : 10,
+      "evaluatedValue" : "9"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11597,6 +11716,11 @@
       "name" : "AddInputCharacter",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "unsigned int",
+        "desugaredQualType" : "unsigned int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -11605,11 +11729,6 @@
             "text" : " Functions"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "c",
-        "qualType" : "unsigned int",
-        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -12400,16 +12519,6 @@
       "desugaredQualType" : "ImVector<char>"
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "operator[]",
-      "resultType" : "char",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "i",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
       "name" : "begin",
       "resultType" : "const char *"
     }, {
@@ -12693,6 +12802,17 @@
       "name" : "GetIntRef",
       "resultType" : "int *",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_val",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -12716,17 +12836,6 @@
             "text" : "      float* pvar = ImGui::GetFloatRef(key); ImGui::SliderFloat(\"var\", pvar, 0, 100.0f); some_var += *pvar;"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "key",
-        "qualType" : "ImGuiID",
-        "desugaredQualType" : "unsigned int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "default_val",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -12781,6 +12890,11 @@
       "name" : "SetAllInt",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "val",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -12789,11 +12903,6 @@
             "text" : " Use on your own storage if you know only integer are being stored (open/close all tree nodes)"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "val",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -12944,15 +13053,6 @@
       "name" : "ForceDisplayRangeByIndices",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Call ForceDisplayRangeByIndices() before first call to Step() if you need a range of items to be displayed regardless of visibility."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "item_min",
         "qualType" : "int",
@@ -12962,6 +13062,15 @@
         "name" : "item_max",
         "qualType" : "int",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Call ForceDisplayRangeByIndices() before first call to Step() if you need a range of items to be displayed regardless of visibility."
+          } ]
+        } ]
       } ]
     } ]
   }, {
@@ -12995,15 +13104,6 @@
       "name" : "SetHSV",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " FIXME-OBSOLETE: May need to obsolete/cleanup those helpers."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "h",
         "qualType" : "float",
@@ -13024,6 +13124,15 @@
         "qualType" : "float",
         "desugaredQualType" : "float",
         "defaultValue" : "1.0f"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " FIXME-OBSOLETE: May need to obsolete/cleanup those helpers."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -13191,16 +13300,6 @@
           "text" : " [Internal] For use by ImDrawListSplitter"
         } ]
       } ]
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_CmdBuffer",
-      "qualType" : "ImVector<ImDrawCmd>",
-      "desugaredQualType" : "ImVector<ImDrawCmd>"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_IdxBuffer",
-      "qualType" : "ImVector<ImDrawIdx>",
-      "desugaredQualType" : "ImVector<unsigned short>"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -13217,21 +13316,6 @@
           "text" : " This is used by the Columns/Tables API, so items of each column can be batched together in a same draw call."
         } ]
       } ]
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_Current",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_Count",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_Channels",
-      "qualType" : "ImVector<ImDrawChannel>",
-      "desugaredQualType" : "ImVector<ImDrawChannel>"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "Clear",
@@ -13514,61 +13598,6 @@
       "qualType" : "ImDrawListFlags",
       "desugaredQualType" : "int"
     }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_VtxCurrentIdx",
-      "qualType" : "unsigned int",
-      "desugaredQualType" : "unsigned int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_Data",
-      "qualType" : "const ImDrawListSharedData *",
-      "desugaredQualType" : "const ImDrawListSharedData *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_OwnerName",
-      "qualType" : "const char *",
-      "desugaredQualType" : "const char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_VtxWritePtr",
-      "qualType" : "ImDrawVert *",
-      "desugaredQualType" : "ImDrawVert *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_IdxWritePtr",
-      "qualType" : "ImDrawIdx *",
-      "desugaredQualType" : "ImDrawIdx *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_ClipRectStack",
-      "qualType" : "ImVector<ImVec4>",
-      "desugaredQualType" : "ImVector<ImVec4>"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_TextureIdStack",
-      "qualType" : "ImVector<ImTextureID>",
-      "desugaredQualType" : "ImVector<void *>"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_Path",
-      "qualType" : "ImVector<ImVec2>",
-      "desugaredQualType" : "ImVector<ImVec2>"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_CmdHeader",
-      "qualType" : "ImDrawCmdHeader",
-      "desugaredQualType" : "ImDrawCmdHeader"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_Splitter",
-      "qualType" : "ImDrawListSplitter",
-      "desugaredQualType" : "ImDrawListSplitter"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "_FringeScale",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
-    }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushClipRect",
       "resultType" : "void",
@@ -13624,6 +13653,27 @@
       "name" : "AddLine",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "1.0f"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -13647,27 +13697,6 @@
             "text" : "   Use AddNgon() and AddNgonFilled() functions if you need to guaranteed a specific number of sides."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "p1",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "p2",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "col",
-        "qualType" : "ImU32",
-        "desugaredQualType" : "unsigned int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "thickness",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "1.0f"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -14216,24 +14245,6 @@
       "name" : "AddImage",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Image primitives"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - Read FAQ to understand what ImTextureID is."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - \"p_min\" and \"p_max\" represent the upper-left and lower-right corners of the rectangle."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " - \"uv_min\" and \"uv_max\" represent the normalized texture coordinates to use for those corners. Using (0,0)->(1,1) texture coordinates will generally display the entire texture."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "user_texture_id",
         "qualType" : "ImTextureID",
@@ -14266,6 +14277,24 @@
         "qualType" : "ImU32",
         "desugaredQualType" : "unsigned int",
         "defaultValue" : "IM_COL32_WHITE"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Image primitives"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Read FAQ to understand what ImTextureID is."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - \"p_min\" and \"p_max\" represent the upper-left and lower-right corners of the rectangle."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - \"uv_min\" and \"uv_max\" represent the normalized texture coordinates to use for those corners. Using (0,0)->(1,1) texture coordinates will generally display the entire texture."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -14574,15 +14603,6 @@
       "name" : "AddCallback",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Advanced"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "callback",
         "qualType" : "ImDrawCallback",
@@ -14592,6 +14612,15 @@
         "name" : "callback_data",
         "qualType" : "void *",
         "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Advanced"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -14606,6 +14635,11 @@
       "name" : "ChannelsSplit",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -14629,11 +14663,6 @@
             "text" : "   Using the ImDrawList::ChannelsXXXX you cannot stack a split over another."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "count",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -14654,6 +14683,16 @@
       "name" : "PrimReserve",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "vtx_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -14668,16 +14707,6 @@
             "text" : " - All primitives needs to be reserved via PrimReserve() beforehand."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "idx_count",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "vtx_count",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -14910,114 +14939,6 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_ResetForNewFrame",
-      "resultType" : "void",
-      "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " [Internal helpers]"
-          } ]
-        } ]
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_ClearFreeMemory",
-      "resultType" : "void"
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_PopUnusedDrawCmd",
-      "resultType" : "void"
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_TryMergeDrawCmds",
-      "resultType" : "void"
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_OnChangedClipRect",
-      "resultType" : "void"
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_OnChangedTextureID",
-      "resultType" : "void"
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_OnChangedVtxOffset",
-      "resultType" : "void"
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_CalcCircleAutoSegmentCount",
-      "resultType" : "int",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "radius",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_PathArcToFastEx",
-      "resultType" : "void",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "center",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "radius",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "a_min_sample",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "a_max_sample",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "a_step",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "_PathArcToN",
-      "resultType" : "void",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "center",
-        "qualType" : "const ImVec2 &",
-        "desugaredQualType" : "const ImVec2 &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "radius",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "a_min",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "a_max",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "num_segments",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     } ]
   }, {
@@ -15844,6 +15765,16 @@
       "name" : "AddCustomRectRegular",
       "resultType" : "int",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "width",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "height",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -15870,16 +15801,6 @@
             "text" : " - Note: this API may be redesigned later in order to support multi-monitor varying DPI settings."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "width",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "height",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -15932,15 +15853,6 @@
       "name" : "CalcCustomRectUV",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " [Internal]"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "rect",
         "qualType" : "const ImFontAtlasCustomRect *",
@@ -15955,6 +15867,15 @@
         "name" : "out_uv_max",
         "qualType" : "ImVec2 *",
         "desugaredQualType" : "ImVec2 *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " [Internal]"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -16240,18 +16161,6 @@
       "name" : "CalcTextSizeA",
       "resultType" : "ImVec2",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "size",
         "qualType" : "float",
@@ -16283,6 +16192,18 @@
         "qualType" : "const char **",
         "desugaredQualType" : "const char **",
         "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -16976,15 +16897,6 @@
       "name" : "CalcListClipping",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " OBSOLETED in 1.86 (from November 2021)"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "items_count",
         "qualType" : "int",
@@ -17004,6 +16916,15 @@
         "name" : "out_items_display_end",
         "qualType" : "int *",
         "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.86 (from November 2021)"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -17024,15 +16945,6 @@
       "name" : "ListBoxHeader",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " OBSOLETED in 1.81 (from February 2021)"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -17048,6 +16960,15 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "-1"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.81 (from February 2021)"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -17074,15 +16995,6 @@
       "name" : "OpenPopupContextItem",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " OBSOLETED in 1.79 (from August 2020)"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "str_id",
         "qualType" : "const char *",
@@ -17094,27 +17006,21 @@
         "qualType" : "ImGuiMouseButton",
         "desugaredQualType" : "int",
         "defaultValue" : "1"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.79 (from August 2020)"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DragScalar",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " OBSOLETED in 1.78 (from June 2020)"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " Old drag/sliders functions that took a 'float power = 1.0' argument instead of flags."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " For shared code, you can version check at compile-time with `#if IMGUI_VERSION_NUM >= 17704`."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -17154,6 +17060,21 @@
         "name" : "power",
         "qualType" : "float",
         "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.78 (from June 2020)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Old drag/sliders functions that took a 'float power = 1.0' argument instead of flags."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " For shared code, you can version check at compile-time with `#if IMGUI_VERSION_NUM >= 17704`."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -17595,15 +17516,6 @@
       "name" : "BeginPopupContextWindow",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " OBSOLETED in 1.77 (from June 2020)"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "str_id",
         "qualType" : "const char *",
@@ -17618,6 +17530,15 @@
         "name" : "over_items",
         "qualType" : "bool",
         "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.77 (from June 2020)"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -17638,15 +17559,6 @@
       "name" : "SetNextTreeNodeOpen",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " OBSOLETED in 1.71 (from June 2019)"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "open",
         "qualType" : "bool",
@@ -17657,6 +17569,15 @@
         "qualType" : "ImGuiCond",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.71 (from June 2019)"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui_internal.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui_internal.json
@@ -9127,7 +9127,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_NoTabStop",
@@ -9135,7 +9135,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_ButtonRepeat",
@@ -9143,7 +9143,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_Disabled",
@@ -9151,7 +9151,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_NoNav",
@@ -9159,7 +9159,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_NoNavDefaultFocus",
@@ -9167,7 +9167,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_SelectableDontClosePopup",
@@ -9175,7 +9175,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_MixedValue",
@@ -9183,7 +9183,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_ReadOnly",
@@ -9191,7 +9191,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemFlags_Inputable",
@@ -9199,7 +9199,7 @@
       "qualType" : "ImGuiItemFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9219,7 +9219,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_HoveredRect",
@@ -9227,7 +9227,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_HasDisplayRect",
@@ -9235,7 +9235,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_Edited",
@@ -9243,7 +9243,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_ToggledSelection",
@@ -9251,7 +9251,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_ToggledOpen",
@@ -9259,7 +9259,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_HasDeactivated",
@@ -9267,7 +9267,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_Deactivated",
@@ -9275,7 +9275,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_HoveredWindow",
@@ -9283,7 +9283,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiItemStatusFlags_FocusedByTabbing",
@@ -9291,7 +9291,7 @@
       "qualType" : "ImGuiItemStatusFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9312,7 +9312,7 @@
       "qualType" : "ImGuiInputTextFlagsPrivate_",
       "order" : 0,
       "value" : "1 << 26",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_NoMarkEdited",
@@ -9320,7 +9320,7 @@
       "qualType" : "ImGuiInputTextFlagsPrivate_",
       "order" : 1,
       "value" : "1 << 27",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_MergedItem",
@@ -9328,7 +9328,7 @@
       "qualType" : "ImGuiInputTextFlagsPrivate_",
       "order" : 2,
       "value" : "1 << 28",
-      "evaluatedValue" : "268435456"
+      "evaluatedValue" : 268435456
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9349,7 +9349,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 0,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_PressedOnClickRelease",
@@ -9357,7 +9357,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 1,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_PressedOnClickReleaseAnywhere",
@@ -9365,7 +9365,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 2,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_PressedOnRelease",
@@ -9373,7 +9373,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 3,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_PressedOnDoubleClick",
@@ -9381,7 +9381,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 4,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_PressedOnDragDropHold",
@@ -9389,7 +9389,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 5,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_Repeat",
@@ -9397,7 +9397,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 6,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_FlattenChildren",
@@ -9405,7 +9405,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 7,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_AllowItemOverlap",
@@ -9413,7 +9413,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 8,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_DontClosePopups",
@@ -9421,7 +9421,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 9,
       "value" : "1 << 13",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_AlignTextBaseLine",
@@ -9429,7 +9429,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 10,
       "value" : "1 << 15",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_NoKeyModifiers",
@@ -9437,7 +9437,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 11,
       "value" : "1 << 16",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_NoHoldingActiveId",
@@ -9445,7 +9445,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 12,
       "value" : "1 << 17",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_NoNavFocus",
@@ -9453,7 +9453,7 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 13,
       "value" : "1 << 18",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_NoHoveredOnFocus",
@@ -9461,21 +9461,21 @@
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 14,
       "value" : "1 << 19",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_PressedOnMask_",
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 15,
       "value" : "ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnClickReleaseAnywhere | ImGuiButtonFlags_PressedOnRelease | ImGuiButtonFlags_PressedOnDoubleClick | ImGuiButtonFlags_PressedOnDragDropHold",
-      "evaluatedValue" : "1008"
+      "evaluatedValue" : 1008
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_PressedOnDefault_",
       "qualType" : "ImGuiButtonFlagsPrivate_",
       "order" : 16,
       "value" : "ImGuiButtonFlags_PressedOnClickRelease",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9496,7 +9496,7 @@
       "qualType" : "ImGuiComboFlagsPrivate_",
       "order" : 0,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9517,14 +9517,14 @@
       "qualType" : "ImGuiSliderFlagsPrivate_",
       "order" : 0,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_ReadOnly",
       "qualType" : "ImGuiSliderFlagsPrivate_",
       "order" : 1,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9545,7 +9545,7 @@
       "qualType" : "ImGuiSelectableFlagsPrivate_",
       "order" : 0,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_SelectOnNav",
@@ -9553,7 +9553,7 @@
       "qualType" : "ImGuiSelectableFlagsPrivate_",
       "order" : 1,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_SelectOnClick",
@@ -9561,7 +9561,7 @@
       "qualType" : "ImGuiSelectableFlagsPrivate_",
       "order" : 2,
       "value" : "1 << 22",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_SelectOnRelease",
@@ -9569,7 +9569,7 @@
       "qualType" : "ImGuiSelectableFlagsPrivate_",
       "order" : 3,
       "value" : "1 << 23",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_SpanAvailWidth",
@@ -9577,7 +9577,7 @@
       "qualType" : "ImGuiSelectableFlagsPrivate_",
       "order" : 4,
       "value" : "1 << 24",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_DrawHoveredWhenHeld",
@@ -9585,7 +9585,7 @@
       "qualType" : "ImGuiSelectableFlagsPrivate_",
       "order" : 5,
       "value" : "1 << 25",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_SetNavIdOnHover",
@@ -9593,7 +9593,7 @@
       "qualType" : "ImGuiSelectableFlagsPrivate_",
       "order" : 6,
       "value" : "1 << 26",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_NoPadWithHalfSpacing",
@@ -9601,7 +9601,7 @@
       "qualType" : "ImGuiSelectableFlagsPrivate_",
       "order" : 7,
       "value" : "1 << 27",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9621,7 +9621,7 @@
       "qualType" : "ImGuiTreeNodeFlagsPrivate_",
       "order" : 0,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9632,7 +9632,7 @@
       "qualType" : "ImGuiSeparatorFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSeparatorFlags_Horizontal",
@@ -9640,21 +9640,21 @@
       "qualType" : "ImGuiSeparatorFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSeparatorFlags_Vertical",
       "qualType" : "ImGuiSeparatorFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSeparatorFlags_SpanAllColumns",
       "qualType" : "ImGuiSeparatorFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9665,14 +9665,14 @@
       "qualType" : "ImGuiTextFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTextFlags_NoWidthForLargeClippedText",
       "qualType" : "ImGuiTextFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9683,7 +9683,7 @@
       "qualType" : "ImGuiTooltipFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTooltipFlags_OverridePreviousTooltip",
@@ -9691,7 +9691,7 @@
       "qualType" : "ImGuiTooltipFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9714,14 +9714,14 @@
       "qualType" : "ImGuiLayoutType_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLayoutType_Vertical",
       "qualType" : "ImGuiLayoutType_",
       "order" : 1,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9732,31 +9732,31 @@
       "qualType" : "ImGuiLogType",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLogType_TTY",
       "qualType" : "ImGuiLogType",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLogType_File",
       "qualType" : "ImGuiLogType",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLogType_Buffer",
       "qualType" : "ImGuiLogType",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLogType_Clipboard",
       "qualType" : "ImGuiLogType",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9776,21 +9776,21 @@
       "qualType" : "ImGuiAxis",
       "order" : 0,
       "value" : "-1",
-      "evaluatedValue" : "-1"
+      "evaluatedValue" : -1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiAxis_X",
       "qualType" : "ImGuiAxis",
       "order" : 1,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiAxis_Y",
       "qualType" : "ImGuiAxis",
       "order" : 2,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9800,13 +9800,13 @@
       "name" : "ImGuiPlotType_Lines",
       "qualType" : "ImGuiPlotType",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPlotType_Histogram",
       "qualType" : "ImGuiPlotType",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9817,45 +9817,45 @@
       "qualType" : "ImGuiInputSource",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Mouse",
       "qualType" : "ImGuiInputSource",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Keyboard",
       "qualType" : "ImGuiInputSource",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Gamepad",
       "qualType" : "ImGuiInputSource",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Nav",
       "docComment" : "Stored in g.ActiveIdSource only",
       "qualType" : "ImGuiInputSource",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Clipboard",
       "docComment" : "Currently only used by InputText()",
       "qualType" : "ImGuiInputSource",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_COUNT",
       "qualType" : "ImGuiInputSource",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9874,37 +9874,37 @@
       "name" : "ImGuiInputReadMode_Down",
       "qualType" : "ImGuiInputReadMode",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_Pressed",
       "qualType" : "ImGuiInputReadMode",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_Released",
       "qualType" : "ImGuiInputReadMode",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_Repeat",
       "qualType" : "ImGuiInputReadMode",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_RepeatSlow",
       "qualType" : "ImGuiInputReadMode",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_RepeatFast",
       "qualType" : "ImGuiInputReadMode",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -9914,19 +9914,19 @@
       "name" : "ImGuiPopupPositionPolicy_Default",
       "qualType" : "ImGuiPopupPositionPolicy",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupPositionPolicy_ComboBox",
       "qualType" : "ImGuiPopupPositionPolicy",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupPositionPolicy_Tooltip",
       "qualType" : "ImGuiPopupPositionPolicy",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -9988,19 +9988,19 @@
       "qualType" : "ImGuiDataTypePrivate_",
       "order" : 0,
       "value" : "ImGuiDataType_COUNT + 1",
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_Pointer",
       "qualType" : "ImGuiDataTypePrivate_",
       "order" : 1,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_ID",
       "qualType" : "ImGuiDataTypePrivate_",
       "order" : 2,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -10479,84 +10479,84 @@
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasPos",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasSize",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasContentSize",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasCollapsed",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasSizeConstraint",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasFocus",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasBgAlpha",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasScroll",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasViewport",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasDock",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextWindowDataFlags_HasWindowClass",
       "qualType" : "ImGuiNextWindowDataFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -10684,21 +10684,21 @@
       "qualType" : "ImGuiNextItemDataFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextItemDataFlags_HasWidth",
       "qualType" : "ImGuiNextItemDataFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNextItemDataFlags_HasOpen",
       "qualType" : "ImGuiNextItemDataFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -11045,7 +11045,7 @@
       "qualType" : "ImGuiActivateFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiActivateFlags_PreferInput",
@@ -11053,7 +11053,7 @@
       "qualType" : "ImGuiActivateFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiActivateFlags_PreferTweak",
@@ -11061,7 +11061,7 @@
       "qualType" : "ImGuiActivateFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiActivateFlags_TryToPreserveState",
@@ -11069,7 +11069,7 @@
       "qualType" : "ImGuiActivateFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11089,7 +11089,7 @@
       "qualType" : "ImGuiScrollFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_KeepVisibleEdgeX",
@@ -11097,7 +11097,7 @@
       "qualType" : "ImGuiScrollFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_KeepVisibleEdgeY",
@@ -11105,7 +11105,7 @@
       "qualType" : "ImGuiScrollFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_KeepVisibleCenterX",
@@ -11113,7 +11113,7 @@
       "qualType" : "ImGuiScrollFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_KeepVisibleCenterY",
@@ -11121,7 +11121,7 @@
       "qualType" : "ImGuiScrollFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_AlwaysCenterX",
@@ -11129,7 +11129,7 @@
       "qualType" : "ImGuiScrollFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_AlwaysCenterY",
@@ -11137,7 +11137,7 @@
       "qualType" : "ImGuiScrollFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_NoScrollParent",
@@ -11145,21 +11145,21 @@
       "qualType" : "ImGuiScrollFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_MaskX_",
       "qualType" : "ImGuiScrollFlags_",
       "order" : 8,
       "value" : "ImGuiScrollFlags_KeepVisibleEdgeX | ImGuiScrollFlags_KeepVisibleCenterX | ImGuiScrollFlags_AlwaysCenterX",
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiScrollFlags_MaskY_",
       "qualType" : "ImGuiScrollFlags_",
       "order" : 9,
       "value" : "ImGuiScrollFlags_KeepVisibleEdgeY | ImGuiScrollFlags_KeepVisibleCenterY | ImGuiScrollFlags_AlwaysCenterY",
-      "evaluatedValue" : "42"
+      "evaluatedValue" : 42
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11170,21 +11170,21 @@
       "qualType" : "ImGuiNavHighlightFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavHighlightFlags_TypeDefault",
       "qualType" : "ImGuiNavHighlightFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavHighlightFlags_TypeThin",
       "qualType" : "ImGuiNavHighlightFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavHighlightFlags_AlwaysDraw",
@@ -11192,14 +11192,14 @@
       "qualType" : "ImGuiNavHighlightFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavHighlightFlags_NoRounding",
       "qualType" : "ImGuiNavHighlightFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11210,7 +11210,7 @@
       "qualType" : "ImGuiNavDirSourceFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavDirSourceFlags_RawKeyboard",
@@ -11218,28 +11218,28 @@
       "qualType" : "ImGuiNavDirSourceFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavDirSourceFlags_Keyboard",
       "qualType" : "ImGuiNavDirSourceFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavDirSourceFlags_PadDPad",
       "qualType" : "ImGuiNavDirSourceFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavDirSourceFlags_PadLStick",
       "qualType" : "ImGuiNavDirSourceFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11250,7 +11250,7 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_LoopX",
@@ -11258,14 +11258,14 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_LoopY",
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_WrapX",
@@ -11273,7 +11273,7 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_WrapY",
@@ -11281,7 +11281,7 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_AllowCurrentNavId",
@@ -11289,7 +11289,7 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_AlsoScoreVisibleSet",
@@ -11297,7 +11297,7 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_ScrollToEdgeY",
@@ -11305,14 +11305,14 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_Forwarded",
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_DebugNoResult",
@@ -11320,14 +11320,14 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_FocusApi",
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_Tabbing",
@@ -11335,14 +11335,14 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_Activate",
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 12,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavMoveFlags_DontSetNavHighlight",
@@ -11350,7 +11350,7 @@
       "qualType" : "ImGuiNavMoveFlags_",
       "order" : 13,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11362,7 +11362,7 @@
       "qualType" : "ImGuiNavLayer",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavLayer_Menu",
@@ -11370,13 +11370,13 @@
       "qualType" : "ImGuiNavLayer",
       "order" : 1,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavLayer_COUNT",
       "qualType" : "ImGuiNavLayer",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -11444,7 +11444,7 @@
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiOldColumnFlags_NoBorder",
@@ -11452,7 +11452,7 @@
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiOldColumnFlags_NoResize",
@@ -11460,7 +11460,7 @@
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiOldColumnFlags_NoPreserveWidths",
@@ -11468,7 +11468,7 @@
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiOldColumnFlags_NoForceWithinWindow",
@@ -11476,7 +11476,7 @@
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiOldColumnFlags_GrowParentContentsSize",
@@ -11484,49 +11484,49 @@
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColumnsFlags_None",
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 6,
       "value" : "ImGuiOldColumnFlags_None",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColumnsFlags_NoBorder",
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 7,
       "value" : "ImGuiOldColumnFlags_NoBorder",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColumnsFlags_NoResize",
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 8,
       "value" : "ImGuiOldColumnFlags_NoResize",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColumnsFlags_NoPreserveWidths",
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 9,
       "value" : "ImGuiOldColumnFlags_NoPreserveWidths",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColumnsFlags_NoForceWithinWindow",
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 10,
       "value" : "ImGuiOldColumnFlags_NoForceWithinWindow",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColumnsFlags_GrowParentContentsSize",
       "qualType" : "ImGuiOldColumnFlags_",
       "order" : 11,
       "value" : "ImGuiOldColumnFlags_GrowParentContentsSize",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -11660,7 +11660,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 0,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_CentralNode",
@@ -11668,7 +11668,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 1,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoTabBar",
@@ -11676,7 +11676,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 2,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_HiddenTabBar",
@@ -11684,7 +11684,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 3,
       "value" : "1 << 13",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoWindowMenuButton",
@@ -11692,7 +11692,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 4,
       "value" : "1 << 14",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoCloseButton",
@@ -11700,7 +11700,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 5,
       "value" : "1 << 15",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoDocking",
@@ -11708,7 +11708,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 6,
       "value" : "1 << 16",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoDockingSplitMe",
@@ -11716,7 +11716,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 7,
       "value" : "1 << 17",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoDockingSplitOther",
@@ -11724,7 +11724,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 8,
       "value" : "1 << 18",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoDockingOverMe",
@@ -11732,7 +11732,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 9,
       "value" : "1 << 19",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoDockingOverOther",
@@ -11740,7 +11740,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 10,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoDockingOverEmpty",
@@ -11748,7 +11748,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 11,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoResizeX",
@@ -11756,7 +11756,7 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 12,
       "value" : "1 << 22",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoResizeY",
@@ -11764,28 +11764,28 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 13,
       "value" : "1 << 23",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_SharedFlagsInheritMask_",
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 14,
       "value" : "~0",
-      "evaluatedValue" : "-1"
+      "evaluatedValue" : -1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoResizeFlagsMask_",
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 15,
       "value" : "ImGuiDockNodeFlags_NoResize | ImGuiDockNodeFlags_NoResizeX | ImGuiDockNodeFlags_NoResizeY",
-      "evaluatedValue" : "12582944"
+      "evaluatedValue" : 12582944
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_LocalFlagsMask_",
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 16,
       "value" : "ImGuiDockNodeFlags_NoSplit | ImGuiDockNodeFlags_NoResizeFlagsMask_ | ImGuiDockNodeFlags_AutoHideTabBar | ImGuiDockNodeFlags_DockSpace | ImGuiDockNodeFlags_CentralNode | ImGuiDockNodeFlags_NoTabBar | ImGuiDockNodeFlags_HiddenTabBar | ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_NoCloseButton | ImGuiDockNodeFlags_NoDocking",
-      "evaluatedValue" : "12713072"
+      "evaluatedValue" : 12713072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_LocalFlagsTransferMask_",
@@ -11793,14 +11793,14 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 17,
       "value" : "ImGuiDockNodeFlags_LocalFlagsMask_ & ~ImGuiDockNodeFlags_DockSpace",
-      "evaluatedValue" : "12712048"
+      "evaluatedValue" : 12712048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_SavedFlagsMask_",
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 18,
       "value" : "ImGuiDockNodeFlags_NoResizeFlagsMask_ | ImGuiDockNodeFlags_DockSpace | ImGuiDockNodeFlags_CentralNode | ImGuiDockNodeFlags_NoTabBar | ImGuiDockNodeFlags_HiddenTabBar | ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_NoCloseButton | ImGuiDockNodeFlags_NoDocking",
-      "evaluatedValue" : "12712992"
+      "evaluatedValue" : 12712992
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11819,19 +11819,19 @@
       "name" : "ImGuiDataAuthority_Auto",
       "qualType" : "ImGuiDataAuthority_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataAuthority_DockNode",
       "qualType" : "ImGuiDataAuthority_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataAuthority_Window",
       "qualType" : "ImGuiDataAuthority_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -11841,25 +11841,25 @@
       "name" : "ImGuiDockNodeState_Unknown",
       "qualType" : "ImGuiDockNodeState",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeState_HostWindowHiddenBecauseSingleWindow",
       "qualType" : "ImGuiDockNodeState",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeState_HostWindowHiddenBecauseWindowsAreResizing",
       "qualType" : "ImGuiDockNodeState",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeState_HostWindowVisible",
       "qualType" : "ImGuiDockNodeState",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -12159,43 +12159,43 @@
       "name" : "ImGuiWindowDockStyleCol_Text",
       "qualType" : "ImGuiWindowDockStyleCol",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_Tab",
       "qualType" : "ImGuiWindowDockStyleCol",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_TabHovered",
       "qualType" : "ImGuiWindowDockStyleCol",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_TabActive",
       "qualType" : "ImGuiWindowDockStyleCol",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_TabUnfocused",
       "qualType" : "ImGuiWindowDockStyleCol",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_TabUnfocusedActive",
       "qualType" : "ImGuiWindowDockStyleCol",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_COUNT",
       "qualType" : "ImGuiWindowDockStyleCol",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -12666,49 +12666,49 @@
       "name" : "ImGuiContextHookType_NewFramePre",
       "qualType" : "ImGuiContextHookType",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_NewFramePost",
       "qualType" : "ImGuiContextHookType",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_EndFramePre",
       "qualType" : "ImGuiContextHookType",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_EndFramePost",
       "qualType" : "ImGuiContextHookType",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_RenderPre",
       "qualType" : "ImGuiContextHookType",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_RenderPost",
       "qualType" : "ImGuiContextHookType",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_Shutdown",
       "qualType" : "ImGuiContextHookType",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_PendingRemoval_",
       "qualType" : "ImGuiContextHookType",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -13911,7 +13911,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 0,
       "value" : "a",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoTitleBar",
@@ -13919,7 +13919,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 1,
       "value" : "emFlag",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoResize",
@@ -13927,7 +13927,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 2,
       "value" : "upStac",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoMove",
@@ -13935,7 +13935,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 3,
       "value" : "or<ImG",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoScrollbar",
@@ -13943,7 +13943,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 4,
       "value" : ")\n    ",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoScrollWithMouse",
@@ -13951,7 +13951,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 5,
       "value" : "      ",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoCollapse",
@@ -13959,7 +13959,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 6,
       "value" : "ach vi",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_AlwaysAutoResize",
@@ -13967,7 +13967,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 7,
       "value" : "      ",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoBackground",
@@ -13975,7 +13975,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 8,
       "value" : "Viewpo",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoSavedSettings",
@@ -13983,7 +13983,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 9,
       "value" : "f we a",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoMouseInputs",
@@ -13991,7 +13991,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 10,
       "value" : "      ",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_MenuBar",
@@ -13999,7 +13999,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 11,
       "value" : "itor us",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_HorizontalScrollbar",
@@ -14007,7 +14007,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 12,
       "value" : "int    ",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoFocusOnAppearing",
@@ -14015,7 +14015,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 13,
       "value" : "navigat",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoBringToFrontOnFocus",
@@ -14023,7 +14023,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 14,
       "value" : "vigatio",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_AlwaysVerticalScrollbar",
@@ -14031,7 +14031,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 15,
       "value" : "n an it",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_AlwaysHorizontalScrollbar",
@@ -14039,7 +14039,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 16,
       "value" : "sNavIn",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_AlwaysUseWindowPadding",
@@ -14047,7 +14047,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 17,
       "value" : "tivateD",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoNavInputs",
@@ -14055,7 +14055,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 18,
       "value" : "e) ? Na",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoNavFocus",
@@ -14063,7 +14063,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 19,
       "value" : "NavInpu",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_UnsavedDocument",
@@ -14071,7 +14071,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 20,
       "value" : " ImGuiI",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoDocking",
@@ -14079,28 +14079,28 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 21,
       "value" : "NavNext",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoNav",
       "qualType" : "ImGuiWindowFlags_",
       "order" : 22,
       "value" : "ImGuiActivateFlags      NavNextActivateFlags;\n    ImGuiInp",
-      "evaluatedValue" : "786432"
+      "evaluatedValue" : 786432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoDecoration",
       "qualType" : "ImGuiWindowFlags_",
       "order" : 23,
       "value" : "    // Keyboard or Gamepad mode? THIS WILL ONLY BE None or NavGamepad or NavKeyboard.\n    ImGuiNavLayer           Na",
-      "evaluatedValue" : "43"
+      "evaluatedValue" : 43
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NoInputs",
       "qualType" : "ImGuiWindowFlags_",
       "order" : 24,
       "value" : "e navigating on. For now the system is hard-coded for 0=main contents and 1=menu/title bar,",
-      "evaluatedValue" : "786944"
+      "evaluatedValue" : 786944
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_NavFlattened",
@@ -14108,7 +14108,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 25,
       "value" : "       ",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_ChildWindow",
@@ -14116,7 +14116,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 26,
       "value" : " (io.Co",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_Tooltip",
@@ -14124,7 +14124,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 27,
       "value" : "bool   ",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_Popup",
@@ -14132,7 +14132,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 28,
       "value" : "pad/key",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_Modal",
@@ -14140,7 +14140,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 29,
       "value" : " != Nav",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_ChildMenu",
@@ -14148,7 +14148,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 30,
       "value" : "s using",
-      "evaluatedValue" : "268435456"
+      "evaluatedValue" : 268435456
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowFlags_DockNodeHost",
@@ -14156,7 +14156,7 @@
       "qualType" : "ImGuiWindowFlags_",
       "order" : 31,
       "value" : "ation: ",
-      "evaluatedValue" : "536870912"
+      "evaluatedValue" : 536870912
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -14176,7 +14176,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 0,
       "value" : " ",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsDecimal",
@@ -14184,7 +14184,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 1,
       "value" : " windo",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsHexadecimal",
@@ -14192,7 +14192,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 2,
       "value" : "      ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsUppercase",
@@ -14200,7 +14200,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 3,
       "value" : " paren",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsNoBlank",
@@ -14208,7 +14208,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 4,
       "value" : " // Mo",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_AutoSelectAll",
@@ -14216,7 +14216,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 5,
       "value" : "      ",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_EnterReturnsTrue",
@@ -14224,7 +14224,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 6,
       "value" : "bool  ",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackCompletion",
@@ -14232,7 +14232,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 7,
       "value" : "    Na",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackHistory",
@@ -14240,7 +14240,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 8,
       "value" : "      ",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackAlways",
@@ -14248,7 +14248,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 9,
       "value" : " the p",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackCharFilter",
@@ -14256,7 +14256,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 10,
       "value" : ", in s",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_AllowTabInput",
@@ -14264,7 +14264,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 11,
       "value" : "eUp/Pag",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CtrlEnterForNewLine",
@@ -14272,7 +14272,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 12,
       "value" : "coringD",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_NoHorizontalScroll",
@@ -14280,7 +14280,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 13,
       "value" : "       ",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_AlwaysOverwrite",
@@ -14288,7 +14288,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 14,
       "value" : "       ",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_ReadOnly",
@@ -14296,7 +14296,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 15,
       "value" : " within",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_Password",
@@ -14304,7 +14304,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 16,
       "value" : "       ",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_NoUndoRedo",
@@ -14312,7 +14312,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 17,
       "value" : "Flags_A",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CharsScientific",
@@ -14320,7 +14320,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 18,
       "value" : "mGuiNav",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackResize",
@@ -14328,7 +14328,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 19,
       "value" : "and fla",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_CallbackEdit",
@@ -14336,7 +14336,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 20,
       "value" : "id NavW",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputTextFlags_AlwaysInsertMode",
@@ -14344,7 +14344,7 @@
       "qualType" : "ImGuiInputTextFlags_",
       "order" : 21,
       "value" : "  NavWindowingHighlightAlpha;\n    b",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -14364,7 +14364,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 0,
       "value" : "o",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_Selected",
@@ -14372,7 +14372,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 1,
       "value" : " Mouse",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_Framed",
@@ -14380,7 +14380,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 2,
       "value" : "ve;\n  ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_AllowItemOverlap",
@@ -14388,7 +14388,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 3,
       "value" : "ropXXX",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_NoTreePushOnOpen",
@@ -14396,7 +14396,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 4,
       "value" : "ginDra",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_NoAutoOpenOnLog",
@@ -14404,7 +14404,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 5,
       "value" : " int  ",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_DefaultOpen",
@@ -14412,7 +14412,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 6,
       "value" : " targe",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_OpenOnDoubleClick",
@@ -14420,7 +14420,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 7,
       "value" : "     D",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_OpenOnArrow",
@@ -14428,7 +14428,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 8,
       "value" : "      ",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_Leaf",
@@ -14436,7 +14436,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 9,
       "value" : "rget i",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_Bullet",
@@ -14444,7 +14444,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 10,
       "value" : " Targe",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_FramePadding",
@@ -14452,7 +14452,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 11,
       "value" : "drop ta",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_SpanAvailWidth",
@@ -14460,7 +14460,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 12,
       "value" : "lding a",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_SpanFullWidth",
@@ -14468,7 +14468,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 13,
       "value" : "       ",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_NavLeftJumpsBackHere",
@@ -14476,7 +14476,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 14,
       "value" : "       ",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTreeNodeFlags_CollapsingHeader",
@@ -14484,7 +14484,7 @@
       "qualType" : "ImGuiTreeNodeFlags_",
       "order" : 15,
       "value" : "es, support nesting)\n    ImPool<ImGuiTable>              Tables;                     // Persistent t",
-      "evaluatedValue" : "26"
+      "evaluatedValue" : 26
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -14525,7 +14525,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 0,
       "value" : ",",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonLeft",
@@ -14533,7 +14533,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 1,
       "value" : "r",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonRight",
@@ -14541,7 +14541,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 2,
       "value" : "d",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonMiddle",
@@ -14549,21 +14549,21 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 3,
       "value" : "t",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonMask_",
       "qualType" : "ImGuiPopupFlags_",
       "order" : 4,
       "value" : "umul",
-      "evaluatedValue" : "31"
+      "evaluatedValue" : 31
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_MouseButtonDefault_",
       "qualType" : "ImGuiPopupFlags_",
       "order" : 5,
       "value" : ".",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_NoOpenOverExistingPopup",
@@ -14571,7 +14571,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 6,
       "value" : "irty; ",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_NoOpenOverItems",
@@ -14579,7 +14579,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 7,
       "value" : "    Dr",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_AnyPopupId",
@@ -14587,7 +14587,7 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 8,
       "value" : "      ",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_AnyPopupLevel",
@@ -14595,14 +14595,14 @@
       "qualType" : "ImGuiPopupFlags_",
       "order" : 9,
       "value" : "      ",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupFlags_AnyPopup",
       "qualType" : "ImGuiPopupFlags_",
       "order" : 10,
       "value" : "      DisabledAlphaBackup;                // Backup for st",
-      "evaluatedValue" : "384"
+      "evaluatedValue" : 384
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -14622,7 +14622,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 0,
       "value" : "v",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_DontClosePopups",
@@ -14630,7 +14630,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 1,
       "value" : "SlowDe",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_SpanAllColumns",
@@ -14638,7 +14638,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 2,
       "value" : "e in t",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_AllowDoubleClick",
@@ -14646,7 +14646,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 3,
       "value" : "fined\n",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_Disabled",
@@ -14654,7 +14654,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 4,
       "value" : "render",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSelectableFlags_AllowItemOverlap",
@@ -14662,7 +14662,7 @@
       "qualType" : "ImGuiSelectableFlags_",
       "order" : 5,
       "value" : "      ",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -14682,7 +14682,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 0,
       "value" : "a",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_PopupAlignLeft",
@@ -14690,7 +14690,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 1,
       "value" : "      ",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightSmall",
@@ -14698,7 +14698,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 2,
       "value" : "PI to ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightRegular",
@@ -14706,7 +14706,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 3,
       "value" : "      ",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightLarge",
@@ -14714,7 +14714,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 4,
       "value" : "      ",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightLargest",
@@ -14722,7 +14722,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 5,
       "value" : "r<ImGu",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_NoArrowButton",
@@ -14730,7 +14730,7 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 6,
       "value" : "ChunkS",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_NoPreview",
@@ -14738,14 +14738,14 @@
       "qualType" : "ImGuiComboFlags_",
       "order" : 7,
       "value" : "TableS",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiComboFlags_HeightMask_",
       "qualType" : "ImGuiComboFlags_",
       "order" : 8,
       "value" : "iContextHook>          Hooks;                  // Hooks for extensions (e.g. test engine)\n    ImGuiID                    ",
-      "evaluatedValue" : "30"
+      "evaluatedValue" : 30
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -14765,7 +14765,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 0,
       "value" : "e",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_Reorderable",
@@ -14773,7 +14773,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 1,
       "value" : "GuiLog",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_AutoSelectNewTabs",
@@ -14781,7 +14781,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 2,
       "value" : "g to s",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_TabListPopupButton",
@@ -14789,7 +14789,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 3,
       "value" : "to cli",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_NoCloseWithMiddleMouseButton",
@@ -14797,7 +14797,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 4,
       "value" : "      ",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_NoTabListScrollingButtons",
@@ -14805,7 +14805,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 5,
       "value" : "oExpan",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_NoTooltip",
@@ -14813,7 +14813,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 6,
       "value" : "      ",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_FittingPolicyResizeDown",
@@ -14821,7 +14821,7 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 7,
       "value" : "\n    I",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_FittingPolicyScroll",
@@ -14829,21 +14829,21 @@
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 8,
       "value" : " encou",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_FittingPolicyMask_",
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 9,
       "value" : "ckTool;\n\n    // Misc\n    float                   FramerateSecPerFrame[120];    ",
-      "evaluatedValue" : "192"
+      "evaluatedValue" : 192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_FittingPolicyDefault_",
       "qualType" : "ImGuiTabBarFlags_",
       "order" : 10,
       "value" : "he last 2 seconds.\n    int              ",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -14863,7 +14863,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 0,
       "value" : "r",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_UnsavedDocument",
@@ -14871,7 +14871,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 1,
       "value" : "tureMo",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_SetSelected",
@@ -14879,7 +14879,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 2,
       "value" : "ontext",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoCloseWithMiddleMouseButton",
@@ -14887,7 +14887,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 3,
       "value" : "\n     ",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoPushId",
@@ -14895,7 +14895,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 4,
       "value" : " = Fra",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoTooltip",
@@ -14903,7 +14903,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 5,
       "value" : "= fals",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoReorder",
@@ -14911,7 +14911,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 6,
       "value" : ";\n\n   ",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_Leading",
@@ -14919,7 +14919,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 7,
       "value" : "ULL;\n ",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_Trailing",
@@ -14927,7 +14927,7 @@
       "qualType" : "ImGuiTabItemFlags_",
       "order" : 8,
       "value" : "Info =",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -15014,7 +15014,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 0,
       "value" : "d",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Resizable",
@@ -15022,7 +15022,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 1,
       "value" : "MoveDi",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Reorderable",
@@ -15030,7 +15030,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 2,
       "value" : "     N",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Hideable",
@@ -15038,7 +15038,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 3,
       "value" : "dowing",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Sortable",
@@ -15046,7 +15046,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 4,
       "value" : "Cursor",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoSavedSettings",
@@ -15054,7 +15054,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 5,
       "value" : "Count ",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_ContextMenuInBody",
@@ -15062,7 +15062,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 6,
       "value" : " DragD",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_RowBg",
@@ -15070,7 +15070,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 7,
       "value" : "ayload",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersInnerH",
@@ -15078,7 +15078,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 8,
       "value" : "ditOpt",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersOuterH",
@@ -15086,7 +15086,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 9,
       "value" : ";\n    ",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersInnerV",
@@ -15094,7 +15094,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 10,
       "value" : "\n     ",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersOuterV",
@@ -15102,7 +15102,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 11,
       "value" : "o = 1.0",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersH",
@@ -15110,7 +15110,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 12,
       "value" : "ToGrabCenter = 0.0f;\n        TooltipOverrideCount = 0;\n      ",
-      "evaluatedValue" : "384"
+      "evaluatedValue" : 384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersV",
@@ -15118,7 +15118,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 13,
       "value" : "c2(FLT_MAX, FLT_MAX);\n        PlatformImePosViewport = 0;\n   ",
-      "evaluatedValue" : "1536"
+      "evaluatedValue" : 1536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersInner",
@@ -15126,7 +15126,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 14,
       "value" : "   SettingsDirtyTimer = 0.0f;\n        HookIdNext = 0;\n\n      ",
-      "evaluatedValue" : "640"
+      "evaluatedValue" : 640
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_BordersOuter",
@@ -15134,7 +15134,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 15,
       "value" : "Prefix = LogNextSuffix = NULL;\n        LogFile = NULL;\n      ",
-      "evaluatedValue" : "1280"
+      "evaluatedValue" : 1280
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_Borders",
@@ -15142,7 +15142,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 16,
       "value" : "hRef = 0;\n        LogDepthToExpand = LogDepthToExpandDefaul",
-      "evaluatedValue" : "1920"
+      "evaluatedValue" : 1920
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoBordersInBody",
@@ -15150,7 +15150,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 17,
       "value" : "kId = 0",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoBordersInBodyUntilResize",
@@ -15158,7 +15158,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 18,
       "value" : "Accum =",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingFixedFit",
@@ -15166,7 +15166,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 19,
       "value" : "----\n//",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingFixedSame",
@@ -15174,7 +15174,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 20,
       "value" : "et at t",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingStretchProp",
@@ -15182,7 +15182,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 21,
       "value" : "ered..)",
-      "evaluatedValue" : "24576"
+      "evaluatedValue" : 24576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingStretchSame",
@@ -15190,7 +15190,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 22,
       "value" : "iWindow",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoHostExtendX",
@@ -15198,7 +15198,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 23,
       "value" : "       ",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoHostExtendY",
@@ -15206,7 +15206,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 24,
       "value" : "ize at ",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoKeepColumnsVisible",
@@ -15214,7 +15214,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 25,
       "value" : " Always",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_PreciseWidths",
@@ -15222,7 +15222,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 26,
       "value" : "default",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoClip",
@@ -15230,7 +15230,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 27,
       "value" : "lumnsOf",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_PadOuterX",
@@ -15238,7 +15238,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 28,
       "value" : "StartPo",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoPadOuterX",
@@ -15246,7 +15246,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 29,
       "value" : "t commo",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_NoPadInnerX",
@@ -15254,7 +15254,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 30,
       "value" : "     //",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_ScrollX",
@@ -15262,7 +15262,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 31,
       "value" : "ersActi",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_ScrollY",
@@ -15270,7 +15270,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 32,
       "value" : "scrolli",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SortMulti",
@@ -15278,7 +15278,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 33,
       "value" : "       ",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SortTristate",
@@ -15286,7 +15286,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 34,
       "value" : "aPaddin",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableFlags_SizingMask_",
@@ -15294,7 +15294,7 @@
       "qualType" : "ImGuiTableFlags_",
       "order" : 35,
       "value" : " // Current tree depth.\n    ImU32                   TreeJumpToParentOnPopMask; // Store a copy of !g.NavIdIsAlive for TreeDepth 0..31.. ",
-      "evaluatedValue" : "57344"
+      "evaluatedValue" : 57344
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -15504,7 +15504,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 0,
       "value" : "i",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_Disabled",
@@ -15512,7 +15512,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 1,
       "value" : "ty (re",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_DefaultHide",
@@ -15520,7 +15520,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 2,
       "value" : " item ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_DefaultSort",
@@ -15528,7 +15528,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 3,
       "value" : "      ",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_WidthStretch",
@@ -15536,7 +15536,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 4,
       "value" : "mWidth",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_WidthFixed",
@@ -15544,7 +15544,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 5,
       "value" : "= Text",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoResize",
@@ -15552,7 +15552,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 6,
       "value" : "      ",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoReorder",
@@ -15560,7 +15560,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 7,
       "value" : " Flags",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoHide",
@@ -15568,7 +15568,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 8,
       "value" : "lass()",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoClip",
@@ -15576,7 +15576,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 9,
       "value" : "ve win",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoSort",
@@ -15584,7 +15584,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 10,
       "value" : "y disa",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoSortAscending",
@@ -15592,7 +15592,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 11,
       "value" : " (since",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoSortDescending",
@@ -15600,7 +15600,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 12,
       "value" : "ortAllo",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoHeaderLabel",
@@ -15608,7 +15608,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 13,
       "value" : "e), onl",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoHeaderWidth",
@@ -15616,7 +15616,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 14,
       "value" : "arest p",
-      "evaluatedValue" : "8192"
+      "evaluatedValue" : 8192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_PreferSortAscending",
@@ -15624,7 +15624,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 15,
       "value" : "ize)\n  ",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_PreferSortDescending",
@@ -15632,7 +15632,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 16,
       "value" : "       ",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IndentEnable",
@@ -15640,7 +15640,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 17,
       "value" : "window ",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IndentDisable",
@@ -15648,7 +15648,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 18,
       "value" : "       ",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IsEnabled",
@@ -15656,7 +15656,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 19,
       "value" : "ounding",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IsVisible",
@@ -15664,7 +15664,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 20,
       "value" : "       ",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IsSorted",
@@ -15672,7 +15672,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 21,
       "value" : "eBufLen",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IsHovered",
@@ -15680,7 +15680,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 22,
       "value" : "ID     ",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_WidthMask_",
@@ -15688,7 +15688,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 23,
       "value" : "               // ID of corresponding item in parent window (for navi",
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_IndentMask_",
@@ -15696,7 +15696,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 24,
       "value" : "\n    ImVec2                  Scroll;\n    ImVec2                  ScrollM",
-      "evaluatedValue" : "196608"
+      "evaluatedValue" : 196608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_StatusMask_",
@@ -15704,7 +15704,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 25,
       "value" : "                // target scroll position. stored as cursor position with scrolling canceled out, so the highest point is always 0.0",
-      "evaluatedValue" : "251658240"
+      "evaluatedValue" : 251658240
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableColumnFlags_NoDirectResize_",
@@ -15712,7 +15712,7 @@
       "qualType" : "ImGuiTableColumnFlags_",
       "order" : 26,
       "value" : "   Scro",
-      "evaluatedValue" : "1073741824"
+      "evaluatedValue" : 1073741824
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -16401,7 +16401,7 @@
       "qualType" : "ImGuiTableRowFlags_",
       "order" : 0,
       "value" : "b",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableRowFlags_Headers",
@@ -16409,7 +16409,7 @@
       "qualType" : "ImGuiTableRowFlags_",
       "order" : 1,
       "value" : "    bo",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -16453,7 +16453,7 @@
       "qualType" : "ImGuiTableBgTarget_",
       "order" : 0,
       "value" : " ",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableBgTarget_RowBg0",
@@ -16461,7 +16461,7 @@
       "qualType" : "ImGuiTableBgTarget_",
       "order" : 1,
       "value" : " ",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableBgTarget_RowBg1",
@@ -16469,7 +16469,7 @@
       "qualType" : "ImGuiTableBgTarget_",
       "order" : 2,
       "value" : "o",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTableBgTarget_CellBg",
@@ -16477,7 +16477,7 @@
       "qualType" : "ImGuiTableBgTarget_",
       "order" : 3,
       "value" : "r",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -16497,7 +16497,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 0,
       "value" : " ",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_ChildWindows",
@@ -16505,7 +16505,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 1,
       "value" : "t;    ",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_RootWindow",
@@ -16513,7 +16513,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 2,
       "value" : "      ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_AnyWindow",
@@ -16521,7 +16521,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 3,
       "value" : "ssion ",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_NoPopupHierarchy",
@@ -16529,7 +16529,7 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 4,
       "value" : "en thi",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_DockHierarchy",
@@ -16537,14 +16537,14 @@
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 5,
       "value" : "\n    b",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiFocusedFlags_RootAndChildWindows",
       "qualType" : "ImGuiFocusedFlags_",
       "order" : 6,
       "value" : "es\n    ImS8                    HiddenFramesCannotSkipItems;  ",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -16571,7 +16571,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 0,
       "value" : "n",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_ChildWindows",
@@ -16579,7 +16579,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 1,
       "value" : "llowFl",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_RootWindow",
@@ -16587,7 +16587,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 2,
       "value" : "      ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AnyWindow",
@@ -16595,7 +16595,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 3,
       "value" : "tion w",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_NoPopupHierarchy",
@@ -16603,7 +16603,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 4,
       "value" : "etWind",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_DockHierarchy",
@@ -16611,7 +16611,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 5,
       "value" : "   IDS",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AllowWhenBlockedByPopup",
@@ -16619,7 +16619,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 6,
       "value" : "      ",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AllowWhenBlockedByActiveItem",
@@ -16627,7 +16627,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 7,
       "value" : "w->Rec",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AllowWhenOverlapped",
@@ -16635,7 +16635,7 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 8,
       "value" : "      ",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_AllowWhenDisabled",
@@ -16643,21 +16643,21 @@
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 9,
       "value" : " // ==",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_RectOnly",
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 10,
       "value" : "   WorkRect;                           // Initially covers the whole scrolling region. Reduced by containers e.g columns/tables wh",
-      "evaluatedValue" : "416"
+      "evaluatedValue" : 416
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiHoveredFlags_RootAndChildWindows",
       "qualType" : "ImGuiHoveredFlags_",
       "order" : 11,
       "value" : "is is meant to replace ContentRegionRect over time (from 1.71",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -16683,7 +16683,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 0,
       "value" : " ",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_KeepAliveOnly",
@@ -16691,7 +16691,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 1,
       "value" : "/sciss",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoDockingInCentralNode",
@@ -16699,7 +16699,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 2,
       "value" : " opera",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_PassthruCentralNode",
@@ -16707,7 +16707,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 3,
       "value" : " pass-",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoSplit",
@@ -16715,7 +16715,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 4,
       "value" : "   flo",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoResize",
@@ -16723,7 +16723,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 5,
       "value" : "      ",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_AutoHideTabBar",
@@ -16731,7 +16731,7 @@
       "qualType" : "ImGuiDockNodeFlags_",
       "order" : 6,
       "value" : "DrawLi",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -16751,7 +16751,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 0,
       "value" : " ",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceNoPreviewTooltip",
@@ -16759,7 +16759,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 1,
       "value" : "GuiWin",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceNoDisableHover",
@@ -16767,7 +16767,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 2,
       "value" : "      ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceNoHoldToOpenOthers",
@@ -16775,7 +16775,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 3,
       "value" : " dock ",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceAllowNullID",
@@ -16783,7 +16783,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 4,
       "value" : "indow*",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceExtern",
@@ -16791,7 +16791,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 5,
       "value" : "ows so",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_SourceAutoExpirePayload",
@@ -16799,7 +16799,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 6,
       "value" : "erence",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_AcceptBeforeDelivery",
@@ -16807,7 +16807,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 7,
       "value" : "       ",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_AcceptNoDrawDefaultRect",
@@ -16815,7 +16815,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 8,
       "value" : "e      ",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_AcceptNoPreviewTooltip",
@@ -16823,7 +16823,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 9,
       "value" : "ode != ",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDragDropFlags_AcceptPeekOnly",
@@ -16831,7 +16831,7 @@
       "qualType" : "ImGuiDragDropFlags_",
       "order" : 10,
       "value" : "             // Is our window visible this frame? ~~ is the corresponding tab select",
-      "evaluatedValue" : "3072"
+      "evaluatedValue" : 3072
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -16851,76 +16851,76 @@
       "docComment" : "signed char / char (with sensible compilers)",
       "qualType" : "ImGuiDataType_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U8",
       "docComment" : "unsigned char",
       "qualType" : "ImGuiDataType_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S16",
       "docComment" : "short",
       "qualType" : "ImGuiDataType_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U16",
       "docComment" : "unsigned short",
       "qualType" : "ImGuiDataType_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S32",
       "docComment" : "int",
       "qualType" : "ImGuiDataType_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U32",
       "docComment" : "unsigned int",
       "qualType" : "ImGuiDataType_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_S64",
       "docComment" : "long long / __int64",
       "qualType" : "ImGuiDataType_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_U64",
       "docComment" : "unsigned long long / unsigned __int64",
       "qualType" : "ImGuiDataType_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_Float",
       "docComment" : "float",
       "qualType" : "ImGuiDataType_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_Double",
       "docComment" : "double",
       "qualType" : "ImGuiDataType_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_COUNT",
       "qualType" : "ImGuiDataType_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -16940,41 +16940,41 @@
       "qualType" : "ImGuiDir_",
       "order" : 0,
       "value" : "Ge",
-      "evaluatedValue" : "-1"
+      "evaluatedValue" : -1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Left",
       "qualType" : "ImGuiDir_",
       "order" : 1,
       "value" : "t",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Right",
       "qualType" : "ImGuiDir_",
       "order" : 2,
       "value" : " ",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Up",
       "qualType" : "ImGuiDir_",
       "order" : 3,
       "value" : " ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_Down",
       "qualType" : "ImGuiDir_",
       "order" : 4,
       "value" : " ",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDir_COUNT",
       "qualType" : "ImGuiDir_",
       "order" : 5,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -16994,7 +16994,7 @@
       "qualType" : "ImGuiSortDirection_",
       "order" : 0,
       "value" : "t",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSortDirection_Ascending",
@@ -17002,7 +17002,7 @@
       "qualType" : "ImGuiSortDirection_",
       "order" : 1,
       "value" : "i",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSortDirection_Descending",
@@ -17010,7 +17010,7 @@
       "qualType" : "ImGuiSortDirection_",
       "order" : 2,
       "value" : "m",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -17029,145 +17029,145 @@
       "name" : "ImGuiKey_Tab",
       "qualType" : "ImGuiKey_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_LeftArrow",
       "qualType" : "ImGuiKey_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_RightArrow",
       "qualType" : "ImGuiKey_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_UpArrow",
       "qualType" : "ImGuiKey_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_DownArrow",
       "qualType" : "ImGuiKey_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_PageUp",
       "qualType" : "ImGuiKey_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_PageDown",
       "qualType" : "ImGuiKey_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Home",
       "qualType" : "ImGuiKey_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_End",
       "qualType" : "ImGuiKey_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Insert",
       "qualType" : "ImGuiKey_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Delete",
       "qualType" : "ImGuiKey_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Backspace",
       "qualType" : "ImGuiKey_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Space",
       "qualType" : "ImGuiKey_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Enter",
       "qualType" : "ImGuiKey_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Escape",
       "qualType" : "ImGuiKey_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_KeyPadEnter",
       "qualType" : "ImGuiKey_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_A",
       "docComment" : "for text edit CTRL+A: select all",
       "qualType" : "ImGuiKey_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_C",
       "docComment" : "for text edit CTRL+C: copy",
       "qualType" : "ImGuiKey_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_V",
       "docComment" : "for text edit CTRL+V: paste",
       "qualType" : "ImGuiKey_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_X",
       "docComment" : "for text edit CTRL+X: cut",
       "qualType" : "ImGuiKey_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Y",
       "docComment" : "for text edit CTRL+Y: redo",
       "qualType" : "ImGuiKey_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_Z",
       "docComment" : "for text edit CTRL+Z: undo",
       "qualType" : "ImGuiKey_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKey_COUNT",
       "qualType" : "ImGuiKey_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -17187,35 +17187,35 @@
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 0,
       "value" : "-",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKeyModFlags_Ctrl",
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 1,
       "value" : "-----\n",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKeyModFlags_Shift",
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 2,
       "value" : "rt\n//-",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKeyModFlags_Alt",
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 3,
       "value" : "------",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiKeyModFlags_Super",
       "qualType" : "ImGuiKeyModFlags_",
       "order" : 4,
       "value" : "// Ext",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -17236,14 +17236,14 @@
       "qualType" : "ImGuiTabBarFlagsPrivate_",
       "order" : 0,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_IsFocused",
       "qualType" : "ImGuiTabBarFlagsPrivate_",
       "order" : 1,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabBarFlags_SaveSettings",
@@ -17251,7 +17251,7 @@
       "qualType" : "ImGuiTabBarFlagsPrivate_",
       "order" : 2,
       "value" : "1 << 22",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -17271,7 +17271,7 @@
       "qualType" : "ImGuiTabItemFlagsPrivate_",
       "order" : 0,
       "value" : "ImGuiTabItemFlags_Leading | ImGuiTabItemFlags_Trailing",
-      "evaluatedValue" : "192"
+      "evaluatedValue" : 192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoCloseButton",
@@ -17279,7 +17279,7 @@
       "qualType" : "ImGuiTabItemFlagsPrivate_",
       "order" : 1,
       "value" : "1 << 20",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_Button",
@@ -17287,7 +17287,7 @@
       "qualType" : "ImGuiTabItemFlagsPrivate_",
       "order" : 2,
       "value" : "1 << 21",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_Unsorted",
@@ -17295,7 +17295,7 @@
       "qualType" : "ImGuiTabItemFlagsPrivate_",
       "order" : 3,
       "value" : "1 << 22",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_Preview",
@@ -17303,7 +17303,7 @@
       "qualType" : "ImGuiTabItemFlagsPrivate_",
       "order" : 4,
       "value" : "1 << 23",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -17332,147 +17332,147 @@
       "docComment" : "activate / open / toggle / tweak value       // e.g. Cross  (PS4), A (Xbox), A (Switch), Space (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Cancel",
       "docComment" : "cancel / close / exit                        // e.g. Circle (PS4), B (Xbox), B (Switch), Escape (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Input",
       "docComment" : "text input / on-screen keyboard              // e.g. Triang.(PS4), Y (Xbox), X (Switch), Return (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_Menu",
       "docComment" : "tap: toggle menu / hold: focus, move, resize // e.g. Square (PS4), X (Xbox), Y (Switch), Alt (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadLeft",
       "docComment" : "move / tweak / resize window (w/ PadMenu)    // e.g. D-pad Left/Right/Up/Down (Gamepads), Arrow keys (Keyboard)",
       "qualType" : "ImGuiNavInput_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadRight",
       "qualType" : "ImGuiNavInput_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadUp",
       "qualType" : "ImGuiNavInput_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_DpadDown",
       "qualType" : "ImGuiNavInput_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickLeft",
       "docComment" : "scroll / move window (w/ PadMenu)            // e.g. Left Analog Stick Left/Right/Up/Down",
       "qualType" : "ImGuiNavInput_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickRight",
       "qualType" : "ImGuiNavInput_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickUp",
       "qualType" : "ImGuiNavInput_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_LStickDown",
       "qualType" : "ImGuiNavInput_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_FocusPrev",
       "docComment" : "next window (w/ PadMenu)                     // e.g. L1 or L2 (PS4), LB or LT (Xbox), L or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_FocusNext",
       "docComment" : "prev window (w/ PadMenu)                     // e.g. R1 or R2 (PS4), RB or RT (Xbox), R or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_TweakSlow",
       "docComment" : "slower tweaks                                // e.g. L1 or L2 (PS4), LB or LT (Xbox), L or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_TweakFast",
       "docComment" : "faster tweaks                                // e.g. R1 or R2 (PS4), RB or RT (Xbox), R or ZL (Switch)",
       "qualType" : "ImGuiNavInput_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyLeft_",
       "docComment" : "move left                                    // = Arrow keys",
       "qualType" : "ImGuiNavInput_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyRight_",
       "docComment" : "move right",
       "qualType" : "ImGuiNavInput_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyUp_",
       "docComment" : "move up",
       "qualType" : "ImGuiNavInput_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_KeyDown_",
       "docComment" : "move down",
       "qualType" : "ImGuiNavInput_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_COUNT",
       "qualType" : "ImGuiNavInput_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavInput_InternalStart_",
       "qualType" : "ImGuiNavInput_",
       "order" : 21,
       "value" : "-bars used by docking\n",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -17753,7 +17753,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 0,
       "value" : "l",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NavEnableKeyboard",
@@ -17761,7 +17761,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 1,
       "value" : "      ",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NavEnableGamepad",
@@ -17769,7 +17769,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 2,
       "value" : "   int",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NavEnableSetMousePos",
@@ -17777,7 +17777,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 3,
       "value" : "ab bar",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NavNoCaptureKeyboard",
@@ -17785,7 +17785,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 4,
       "value" : "    fl",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NoMouse",
@@ -17793,7 +17793,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 5,
       "value" : "      ",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_NoMouseCursorChange",
@@ -17801,7 +17801,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 6,
       "value" : "w;    ",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_DockingEnable",
@@ -17809,7 +17809,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 7,
       "value" : " Frame",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_ViewportsEnable",
@@ -17817,7 +17817,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 8,
       "value" : "       ",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_DpiEnableScaleViewports",
@@ -17825,7 +17825,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 9,
       "value" : "return ",
-      "evaluatedValue" : "16384"
+      "evaluatedValue" : 16384
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_DpiEnableScaleFonts",
@@ -17833,7 +17833,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 10,
       "value" : "-------",
-      "evaluatedValue" : "32768"
+      "evaluatedValue" : 32768
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_IsSRGB",
@@ -17841,7 +17841,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 11,
       "value" : "ture.\nt",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiConfigFlags_IsTouchScreen",
@@ -17849,7 +17849,7 @@
       "qualType" : "ImGuiConfigFlags_",
       "order" : 12,
       "value" : "ternal]",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -17869,7 +17869,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 0,
       "value" : " ",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_HasGamepad",
@@ -17877,7 +17877,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 1,
       "value" : ") / Is",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_HasMouseCursors",
@@ -17885,7 +17885,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 2,
       "value" : "      ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_HasSetMousePos",
@@ -17893,7 +17893,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 3,
       "value" : "WidthG",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_RendererHasVtxOffset",
@@ -17901,7 +17901,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 4,
       "value" : " in ti",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_PlatformHasViewports",
@@ -17909,7 +17909,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 5,
       "value" : "value w",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_HasMouseHoveredViewport",
@@ -17917,7 +17917,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 6,
       "value" : "UpdateL",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiBackendFlags_RendererHasViewports",
@@ -17925,7 +17925,7 @@
       "qualType" : "ImGuiBackendFlags_",
       "order" : 7,
       "value" : "  ImGui",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -18171,353 +18171,353 @@
       "name" : "ImGuiCol_Text",
       "qualType" : "ImGuiCol_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TextDisabled",
       "qualType" : "ImGuiCol_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_WindowBg",
       "docComment" : "Background of normal windows",
       "qualType" : "ImGuiCol_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ChildBg",
       "docComment" : "Background of child windows",
       "qualType" : "ImGuiCol_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PopupBg",
       "docComment" : "Background of popups, menus, tooltips windows",
       "qualType" : "ImGuiCol_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Border",
       "qualType" : "ImGuiCol_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_BorderShadow",
       "qualType" : "ImGuiCol_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBg",
       "docComment" : "Background of checkbox, radio button, plot, slider, text input",
       "qualType" : "ImGuiCol_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBgHovered",
       "qualType" : "ImGuiCol_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_FrameBgActive",
       "qualType" : "ImGuiCol_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBg",
       "qualType" : "ImGuiCol_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBgActive",
       "qualType" : "ImGuiCol_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TitleBgCollapsed",
       "qualType" : "ImGuiCol_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_MenuBarBg",
       "qualType" : "ImGuiCol_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarBg",
       "qualType" : "ImGuiCol_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrab",
       "qualType" : "ImGuiCol_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrabHovered",
       "qualType" : "ImGuiCol_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ScrollbarGrabActive",
       "qualType" : "ImGuiCol_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_CheckMark",
       "qualType" : "ImGuiCol_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SliderGrab",
       "qualType" : "ImGuiCol_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SliderGrabActive",
       "qualType" : "ImGuiCol_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Button",
       "qualType" : "ImGuiCol_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ButtonHovered",
       "qualType" : "ImGuiCol_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ButtonActive",
       "qualType" : "ImGuiCol_",
       "order" : 23,
-      "evaluatedValue" : "23"
+      "evaluatedValue" : 23
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Header",
       "docComment" : "Header* colors are used for CollapsingHeader, TreeNode, Selectable, MenuItem",
       "qualType" : "ImGuiCol_",
       "order" : 24,
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_HeaderHovered",
       "qualType" : "ImGuiCol_",
       "order" : 25,
-      "evaluatedValue" : "25"
+      "evaluatedValue" : 25
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_HeaderActive",
       "qualType" : "ImGuiCol_",
       "order" : 26,
-      "evaluatedValue" : "26"
+      "evaluatedValue" : 26
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Separator",
       "qualType" : "ImGuiCol_",
       "order" : 27,
-      "evaluatedValue" : "27"
+      "evaluatedValue" : 27
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SeparatorHovered",
       "qualType" : "ImGuiCol_",
       "order" : 28,
-      "evaluatedValue" : "28"
+      "evaluatedValue" : 28
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_SeparatorActive",
       "qualType" : "ImGuiCol_",
       "order" : 29,
-      "evaluatedValue" : "29"
+      "evaluatedValue" : 29
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGrip",
       "qualType" : "ImGuiCol_",
       "order" : 30,
-      "evaluatedValue" : "30"
+      "evaluatedValue" : 30
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGripHovered",
       "qualType" : "ImGuiCol_",
       "order" : 31,
-      "evaluatedValue" : "31"
+      "evaluatedValue" : 31
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ResizeGripActive",
       "qualType" : "ImGuiCol_",
       "order" : 32,
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_Tab",
       "qualType" : "ImGuiCol_",
       "order" : 33,
-      "evaluatedValue" : "33"
+      "evaluatedValue" : 33
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabHovered",
       "qualType" : "ImGuiCol_",
       "order" : 34,
-      "evaluatedValue" : "34"
+      "evaluatedValue" : 34
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabActive",
       "qualType" : "ImGuiCol_",
       "order" : 35,
-      "evaluatedValue" : "35"
+      "evaluatedValue" : 35
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabUnfocused",
       "qualType" : "ImGuiCol_",
       "order" : 36,
-      "evaluatedValue" : "36"
+      "evaluatedValue" : 36
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TabUnfocusedActive",
       "qualType" : "ImGuiCol_",
       "order" : 37,
-      "evaluatedValue" : "37"
+      "evaluatedValue" : 37
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DockingPreview",
       "docComment" : "Preview overlay color when about to docking something",
       "qualType" : "ImGuiCol_",
       "order" : 38,
-      "evaluatedValue" : "38"
+      "evaluatedValue" : 38
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DockingEmptyBg",
       "docComment" : "Background color for empty node (e.g. CentralNode with no window docked into it)",
       "qualType" : "ImGuiCol_",
       "order" : 39,
-      "evaluatedValue" : "39"
+      "evaluatedValue" : 39
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotLines",
       "qualType" : "ImGuiCol_",
       "order" : 40,
-      "evaluatedValue" : "40"
+      "evaluatedValue" : 40
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotLinesHovered",
       "qualType" : "ImGuiCol_",
       "order" : 41,
-      "evaluatedValue" : "41"
+      "evaluatedValue" : 41
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotHistogram",
       "qualType" : "ImGuiCol_",
       "order" : 42,
-      "evaluatedValue" : "42"
+      "evaluatedValue" : 42
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_PlotHistogramHovered",
       "qualType" : "ImGuiCol_",
       "order" : 43,
-      "evaluatedValue" : "43"
+      "evaluatedValue" : 43
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableHeaderBg",
       "docComment" : "Table header background",
       "qualType" : "ImGuiCol_",
       "order" : 44,
-      "evaluatedValue" : "44"
+      "evaluatedValue" : 44
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableBorderStrong",
       "docComment" : "Table outer and header borders (prefer using Alpha=1.0 here)",
       "qualType" : "ImGuiCol_",
       "order" : 45,
-      "evaluatedValue" : "45"
+      "evaluatedValue" : 45
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableBorderLight",
       "docComment" : "Table inner borders (prefer using Alpha=1.0 here)",
       "qualType" : "ImGuiCol_",
       "order" : 46,
-      "evaluatedValue" : "46"
+      "evaluatedValue" : 46
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableRowBg",
       "docComment" : "Table row background (even rows)",
       "qualType" : "ImGuiCol_",
       "order" : 47,
-      "evaluatedValue" : "47"
+      "evaluatedValue" : 47
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TableRowBgAlt",
       "docComment" : "Table row background (odd rows)",
       "qualType" : "ImGuiCol_",
       "order" : 48,
-      "evaluatedValue" : "48"
+      "evaluatedValue" : 48
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_TextSelectedBg",
       "qualType" : "ImGuiCol_",
       "order" : 49,
-      "evaluatedValue" : "49"
+      "evaluatedValue" : 49
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_DragDropTarget",
       "qualType" : "ImGuiCol_",
       "order" : 50,
-      "evaluatedValue" : "50"
+      "evaluatedValue" : 50
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavHighlight",
       "docComment" : "Gamepad/keyboard: current highlighted item",
       "qualType" : "ImGuiCol_",
       "order" : 51,
-      "evaluatedValue" : "51"
+      "evaluatedValue" : 51
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavWindowingHighlight",
       "docComment" : "Highlight window when using CTRL+TAB",
       "qualType" : "ImGuiCol_",
       "order" : 52,
-      "evaluatedValue" : "52"
+      "evaluatedValue" : 52
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_NavWindowingDimBg",
       "docComment" : "Darken/colorize entire screen behind the CTRL+TAB window list, when active",
       "qualType" : "ImGuiCol_",
       "order" : 53,
-      "evaluatedValue" : "53"
+      "evaluatedValue" : 53
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_ModalWindowDimBg",
       "docComment" : "Darken/colorize entire screen behind a modal window, when one is active",
       "qualType" : "ImGuiCol_",
       "order" : 54,
-      "evaluatedValue" : "54"
+      "evaluatedValue" : 54
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCol_COUNT",
       "qualType" : "ImGuiCol_",
       "order" : 55,
-      "evaluatedValue" : "55"
+      "evaluatedValue" : 55
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -18555,181 +18555,181 @@
       "docComment" : "float     Alpha",
       "qualType" : "ImGuiStyleVar_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_DisabledAlpha",
       "docComment" : "float     DisabledAlpha",
       "qualType" : "ImGuiStyleVar_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowPadding",
       "docComment" : "ImVec2    WindowPadding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowRounding",
       "docComment" : "float     WindowRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowBorderSize",
       "docComment" : "float     WindowBorderSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowMinSize",
       "docComment" : "ImVec2    WindowMinSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_WindowTitleAlign",
       "docComment" : "ImVec2    WindowTitleAlign",
       "qualType" : "ImGuiStyleVar_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ChildRounding",
       "docComment" : "float     ChildRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ChildBorderSize",
       "docComment" : "float     ChildBorderSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_PopupRounding",
       "docComment" : "float     PopupRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_PopupBorderSize",
       "docComment" : "float     PopupBorderSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FramePadding",
       "docComment" : "ImVec2    FramePadding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FrameRounding",
       "docComment" : "float     FrameRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_FrameBorderSize",
       "docComment" : "float     FrameBorderSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ItemSpacing",
       "docComment" : "ImVec2    ItemSpacing",
       "qualType" : "ImGuiStyleVar_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ItemInnerSpacing",
       "docComment" : "ImVec2    ItemInnerSpacing",
       "qualType" : "ImGuiStyleVar_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_IndentSpacing",
       "docComment" : "float     IndentSpacing",
       "qualType" : "ImGuiStyleVar_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_CellPadding",
       "docComment" : "ImVec2    CellPadding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ScrollbarSize",
       "docComment" : "float     ScrollbarSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ScrollbarRounding",
       "docComment" : "float     ScrollbarRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_GrabMinSize",
       "docComment" : "float     GrabMinSize",
       "qualType" : "ImGuiStyleVar_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_GrabRounding",
       "docComment" : "float     GrabRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_TabRounding",
       "docComment" : "float     TabRounding",
       "qualType" : "ImGuiStyleVar_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_ButtonTextAlign",
       "docComment" : "ImVec2    ButtonTextAlign",
       "qualType" : "ImGuiStyleVar_",
       "order" : 23,
-      "evaluatedValue" : "23"
+      "evaluatedValue" : 23
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_SelectableTextAlign",
       "docComment" : "ImVec2    SelectableTextAlign",
       "qualType" : "ImGuiStyleVar_",
       "order" : 24,
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiStyleVar_COUNT",
       "qualType" : "ImGuiStyleVar_",
       "order" : 25,
-      "evaluatedValue" : "25"
+      "evaluatedValue" : 25
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -19303,7 +19303,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 0,
       "value" : "C",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonLeft",
@@ -19311,7 +19311,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 1,
       "value" : "      ",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonRight",
@@ -19319,7 +19319,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 2,
       "value" : "by use",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonMiddle",
@@ -19327,7 +19327,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 3,
       "value" : "mU64  ",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonMask_",
@@ -19335,7 +19335,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 4,
       "value" : " hidden by user/api && not hidden by scrolling/cliprect)\n    ImU64                       RequestOutputMas",
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiButtonFlags_MouseButtonDefault_",
@@ -19343,7 +19343,7 @@
       "qualType" : "ImGuiButtonFlags_",
       "order" : 5,
       "value" : "Fit (== expect user to submit it",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -19363,7 +19363,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 0,
       "value" : " ",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoAlpha",
@@ -19371,7 +19371,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 1,
       "value" : "      ",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoPicker",
@@ -19379,7 +19379,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 2,
       "value" : "eginTa",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoOptions",
@@ -19387,7 +19387,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 3,
       "value" : "      ",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoSmallPreview",
@@ -19395,7 +19395,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 4,
       "value" : "r a wi",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoInputs",
@@ -19403,7 +19403,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 5,
       "value" : " (gene",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoTooltip",
@@ -19411,7 +19411,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 6,
       "value" : ";     ",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoLabel",
@@ -19419,7 +19419,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 7,
       "value" : ";\n    ",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoSidePreview",
@@ -19427,7 +19427,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 8,
       "value" : " RowBg",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoDragDrop",
@@ -19435,7 +19435,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 9,
       "value" : "this.\n",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_NoBorder",
@@ -19443,7 +19443,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 10,
       "value" : "Strong;",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_AlphaBar",
@@ -19451,7 +19451,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 11,
       "value" : "       ",
-      "evaluatedValue" : "65536"
+      "evaluatedValue" : 65536
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_AlphaPreview",
@@ -19459,7 +19459,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 12,
       "value" : "    // ",
-      "evaluatedValue" : "131072"
+      "evaluatedValue" : 131072
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_AlphaPreviewHalf",
@@ -19467,7 +19467,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 13,
       "value" : "       ",
-      "evaluatedValue" : "262144"
+      "evaluatedValue" : 262144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_HDR",
@@ -19475,7 +19475,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 14,
       "value" : "stRowHe",
-      "evaluatedValue" : "524288"
+      "evaluatedValue" : 524288
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DisplayRGB",
@@ -19483,7 +19483,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 15,
       "value" : "at     ",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DisplayHSV",
@@ -19491,7 +19491,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 16,
       "value" : " clippe",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DisplayHex",
@@ -19499,7 +19499,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 17,
       "value" : "dow\n   ",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_Uint8",
@@ -19507,7 +19507,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 18,
       "value" : "       ",
-      "evaluatedValue" : "8388608"
+      "evaluatedValue" : 8388608
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_Float",
@@ -19515,7 +19515,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 19,
       "value" : "low gro",
-      "evaluatedValue" : "16777216"
+      "evaluatedValue" : 16777216
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_PickerHueBar",
@@ -19523,7 +19523,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 20,
       "value" : " for no",
-      "evaluatedValue" : "33554432"
+      "evaluatedValue" : 33554432
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_PickerHueWheel",
@@ -19531,7 +19531,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 21,
       "value" : "ble().\n",
-      "evaluatedValue" : "67108864"
+      "evaluatedValue" : 67108864
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_InputRGB",
@@ -19539,7 +19539,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 22,
       "value" : "for non",
-      "evaluatedValue" : "134217728"
+      "evaluatedValue" : 134217728
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_InputHSV",
@@ -19547,7 +19547,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 23,
       "value" : ";\n    I",
-      "evaluatedValue" : "268435456"
+      "evaluatedValue" : 268435456
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DefaultOptions_",
@@ -19555,7 +19555,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 24,
       "value" : "lip rect for BG2 channel. This tends to be a correct, tight-fit, because output to BG2 are done by widgets relying on regula",
-      "evaluatedValue" : "177209344"
+      "evaluatedValue" : 177209344
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DisplayMask_",
@@ -19563,7 +19563,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 25,
       "value" : "   // This is used to check if we can eventually merge our columns draw calls into the current d",
-      "evaluatedValue" : "7340032"
+      "evaluatedValue" : 7340032
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_DataTypeMask_",
@@ -19571,7 +19571,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 26,
       "value" : "                    HostBackupInnerClipRect;    // Ba",
-      "evaluatedValue" : "25165824"
+      "evaluatedValue" : 25165824
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_PickerMask_",
@@ -19579,7 +19579,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 27,
       "value" : "leBackground()/PopTableBackground()\n    ImGuiWindow*                O",
-      "evaluatedValue" : "100663296"
+      "evaluatedValue" : 100663296
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_InputMask_",
@@ -19587,7 +19587,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 28,
       "value" : "for the table\n    ImGuiWindow*                InnerWindow; ",
-      "evaluatedValue" : "402653184"
+      "evaluatedValue" : 402653184
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_RGB",
@@ -19595,7 +19595,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 29,
       "value" : "ColumnsNames;               //",
-      "evaluatedValue" : "1048576"
+      "evaluatedValue" : 1048576
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_HSV",
@@ -19603,7 +19603,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 30,
       "value" : "olumns names\n    ImDrawListSpl",
-      "evaluatedValue" : "2097152"
+      "evaluatedValue" : 2097152
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiColorEditFlags_HEX",
@@ -19611,7 +19611,7 @@
       "qualType" : "ImGuiColorEditFlags_",
       "order" : 31,
       "value" : "               // Shortcut to ",
-      "evaluatedValue" : "4194304"
+      "evaluatedValue" : 4194304
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -19634,7 +19634,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 0,
       "value" : "o",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_AlwaysClamp",
@@ -19642,7 +19642,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 1,
       "value" : " specs",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_Logarithmic",
@@ -19650,7 +19650,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 2,
       "value" : "ed col",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_NoRoundToFormat",
@@ -19658,7 +19658,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 3,
       "value" : "pColum",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_NoInput",
@@ -19666,7 +19666,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 4,
       "value" : "ght-mo",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_InvalidMask_",
@@ -19674,7 +19674,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 5,
       "value" : "ng).\n    I",
-      "evaluatedValue" : "1879048207"
+      "evaluatedValue" : 1879048207
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiSliderFlags_ClampOnInput",
@@ -19682,7 +19682,7 @@
       "qualType" : "ImGuiSliderFlags_",
       "order" : 6,
       "value" : " being resized from previous",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -19705,28 +19705,28 @@
       "qualType" : "ImGuiMouseButton_",
       "order" : 0,
       "value" : "l",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseButton_Right",
       "qualType" : "ImGuiMouseButton_",
       "order" : 1,
       "value" : ";",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseButton_Middle",
       "qualType" : "ImGuiMouseButton_",
       "order" : 2,
       "value" : "T",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseButton_COUNT",
       "qualType" : "ImGuiMouseButton_",
       "order" : 3,
       "value" : "n",
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -19749,76 +19749,76 @@
       "qualType" : "ImGuiMouseCursor_",
       "order" : 0,
       "value" : " s",
-      "evaluatedValue" : "-1"
+      "evaluatedValue" : -1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_Arrow",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 1,
       "value" : "C",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_TextInput",
       "docComment" : "When hovering over InputText, etc.",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 2,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeAll",
       "docComment" : "(Unused by Dear ImGui functions)",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 3,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNS",
       "docComment" : "When hovering over an horizontal border",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 4,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeEW",
       "docComment" : "When hovering over a vertical border or a column",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 5,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNESW",
       "docComment" : "When hovering over the bottom-left corner of a window",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 6,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_ResizeNWSE",
       "docComment" : "When hovering over the bottom-right corner of a window",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 7,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_Hand",
       "docComment" : "(Unused by Dear ImGui functions. Use for e.g. hyperlinks)",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 8,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_NotAllowed",
       "docComment" : "When hovering something with disallowed interaction. Usually a crossed circle.",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 9,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiMouseCursor_COUNT",
       "qualType" : "ImGuiMouseCursor_",
       "order" : 10,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -19845,7 +19845,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 0,
       "value" : "]",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCond_Always",
@@ -19853,7 +19853,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 1,
       "value" : "ocked;",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCond_Once",
@@ -19861,7 +19861,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 2,
       "value" : "e firs",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCond_FirstUseEver",
@@ -19869,7 +19869,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 3,
       "value" : ").\n   ",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiCond_Appearing",
@@ -19877,7 +19877,7 @@
       "qualType" : "ImGuiCond_",
       "order" : 4,
       "value" : "singHe",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -28249,92 +28249,92 @@
       "name" : "ImDrawFlags_None",
       "qualType" : "ImDrawFlags_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_Closed",
       "docComment" : "PathStroke(), AddPolyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason)",
       "qualType" : "ImDrawFlags_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersTopLeft",
       "docComment" : "AddRect(), AddRectFilled(), PathRect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01.",
       "qualType" : "ImDrawFlags_",
       "order" : 2,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersTopRight",
       "docComment" : "AddRect(), AddRectFilled(), PathRect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02.",
       "qualType" : "ImDrawFlags_",
       "order" : 3,
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersBottomLeft",
       "docComment" : "AddRect(), AddRectFilled(), PathRect(): enable rounding bottom-left corner only (when rounding > 0.0f, we default to all corners). Was 0x04.",
       "qualType" : "ImDrawFlags_",
       "order" : 4,
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersBottomRight",
       "docComment" : "AddRect(), AddRectFilled(), PathRect(): enable rounding bottom-right corner only (when rounding > 0.0f, we default to all corners). Wax 0x08.",
       "qualType" : "ImDrawFlags_",
       "order" : 5,
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersNone",
       "docComment" : "AddRect(), AddRectFilled(), PathRect(): disable rounding on all corners (when rounding > 0.0f). This is NOT zero, NOT an implicit flag!",
       "qualType" : "ImDrawFlags_",
       "order" : 6,
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersTop",
       "qualType" : "ImDrawFlags_",
       "order" : 7,
-      "evaluatedValue" : "48"
+      "evaluatedValue" : 48
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersBottom",
       "qualType" : "ImDrawFlags_",
       "order" : 8,
-      "evaluatedValue" : "192"
+      "evaluatedValue" : 192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersLeft",
       "qualType" : "ImDrawFlags_",
       "order" : 9,
-      "evaluatedValue" : "80"
+      "evaluatedValue" : 80
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersRight",
       "qualType" : "ImDrawFlags_",
       "order" : 10,
-      "evaluatedValue" : "160"
+      "evaluatedValue" : 160
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersAll",
       "qualType" : "ImDrawFlags_",
       "order" : 11,
-      "evaluatedValue" : "240"
+      "evaluatedValue" : 240
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersDefault_",
       "docComment" : "Default to ALL corners if none of the _RoundCornersXX flags are specified.",
       "qualType" : "ImDrawFlags_",
       "order" : 12,
-      "evaluatedValue" : "240"
+      "evaluatedValue" : 240
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawFlags_RoundCornersMask_",
       "qualType" : "ImDrawFlags_",
       "order" : 13,
-      "evaluatedValue" : "496"
+      "evaluatedValue" : 496
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -28356,35 +28356,35 @@
       "name" : "ImDrawListFlags_None",
       "qualType" : "ImDrawListFlags_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawListFlags_AntiAliasedLines",
       "docComment" : "Enable anti-aliased lines/borders (*2 the number of triangles for 1.0f wide line or lines thin enough to be drawn using textures, otherwise *3 the number of triangles)",
       "qualType" : "ImDrawListFlags_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawListFlags_AntiAliasedLinesUseTex",
       "docComment" : "Enable anti-aliased lines/borders using textures when possible. Require backend to render with bilinear filtering.",
       "qualType" : "ImDrawListFlags_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawListFlags_AntiAliasedFill",
       "docComment" : "Enable anti-aliased edge around filled shapes (rounded rectangles, circles).",
       "qualType" : "ImDrawListFlags_",
       "order" : 3,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawListFlags_AllowVtxOffset",
       "docComment" : "Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled.",
       "qualType" : "ImDrawListFlags_",
       "order" : 4,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -30185,28 +30185,28 @@
       "name" : "ImFontAtlasFlags_None",
       "qualType" : "ImFontAtlasFlags_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImFontAtlasFlags_NoPowerOfTwoHeight",
       "docComment" : "Don't round the height to next power of two",
       "qualType" : "ImFontAtlasFlags_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImFontAtlasFlags_NoMouseCursors",
       "docComment" : "Don't build software mouse cursors into the atlas (save a little texture memory)",
       "qualType" : "ImFontAtlasFlags_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImFontAtlasFlags_NoBakedLines",
       "docComment" : "Don't build thick line textures into the atlas (save a little texture memory). The AntiAliasedLinesUseTex features uses them, otherwise they will be rendered using polygons (more expensive for CPU/GPU).",
       "qualType" : "ImFontAtlasFlags_",
       "order" : 3,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -31255,98 +31255,98 @@
       "name" : "ImGuiViewportFlags_None",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_IsPlatformWindow",
       "docComment" : "Represent a Platform Window",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_IsPlatformMonitor",
       "docComment" : "Represent a Platform Monitor (unused yet)",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_OwnedByApp",
       "docComment" : "Platform Window: is created/managed by the application (rather than a dear imgui backend)",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 3,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoDecoration",
       "docComment" : "Platform Window: Disable platform decorations: title bar, borders, etc. (generally set all windows, but if ImGuiConfigFlags_ViewportsDecoration is set we only set this on popups/tooltips)",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 4,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoTaskBarIcon",
       "docComment" : "Platform Window: Disable platform task bar icon (generally set on popups/tooltips, or all windows if ImGuiConfigFlags_ViewportsNoTaskBarIcon is set)",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 5,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoFocusOnAppearing",
       "docComment" : "Platform Window: Don't take focus when created.",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 6,
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoFocusOnClick",
       "docComment" : "Platform Window: Don't take focus when clicked on.",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 7,
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoInputs",
       "docComment" : "Platform Window: Make mouse pass through so we can drag this window while peaking behind it.",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 8,
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoRendererClear",
       "docComment" : "Platform Window: Renderer doesn't need to clear the framebuffer ahead (because we will fill it entirely).",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 9,
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_TopMost",
       "docComment" : "Platform Window: Display on top (for tooltips only).",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 10,
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_Minimized",
       "docComment" : "Platform Window: Window is minimized, can skip render. When minimized we tend to avoid using the viewport pos/size for clipping window or testing if they are contained in the viewport.",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 11,
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_NoAutoMerge",
       "docComment" : "Platform Window: Avoid merging this window into another host window. This can only be set via ImGuiWindowClass viewport flags override (because we need to now ahead if we are going to create a viewport in the first place!).",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 12,
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiViewportFlags_CanHostOtherWindows",
       "docComment" : "Main viewport: can host multiple imgui windows (secondary viewports are associated to a single window).",
       "qualType" : "ImGuiViewportFlags_",
       "order" : 13,
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -32370,66 +32370,66 @@
       "docComment" : "Was == 0 prior to 1.82, this is now == ImDrawFlags_RoundCornersNone which is != 0 and not implicit",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 0,
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_TopLeft",
       "docComment" : "Was == 0x01 (1 < < 0) prior to 1.82. Order matches ImDrawFlags_NoRoundCorner* flag (we exploit this internally).",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 1,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_TopRight",
       "docComment" : "Was == 0x02 (1 < < 1) prior to 1.82.",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 2,
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_BotLeft",
       "docComment" : "Was == 0x04 (1 < < 2) prior to 1.82.",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 3,
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_BotRight",
       "docComment" : "Was == 0x08 (1 < < 3) prior to 1.82.",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 4,
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_All",
       "docComment" : "Was == 0x0F prior to 1.82",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 5,
-      "evaluatedValue" : "240"
+      "evaluatedValue" : 240
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_Top",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 6,
-      "evaluatedValue" : "48"
+      "evaluatedValue" : 48
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_Bot",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 7,
-      "evaluatedValue" : "192"
+      "evaluatedValue" : 192
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_Left",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 8,
-      "evaluatedValue" : "80"
+      "evaluatedValue" : 80
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImDrawCornerFlags_Right",
       "qualType" : "ImDrawCornerFlags_",
       "order" : 9,
-      "evaluatedValue" : "160"
+      "evaluatedValue" : 160
     } ]
   } ]
 }

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui_internal.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui_internal.json
@@ -25,6 +25,19 @@
       } ]
     } ]
   }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawChannel",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Forward declarations"
+        } ]
+      } ]
+    } ]
+  }, {
     "@type" : "AstNamespaceDecl",
     "name" : "ImStb",
     "decls" : [ {
@@ -45,8 +58,60 @@
     } ]
   }, {
     "@type" : "AstFunctionDecl",
+    "name" : "ImHashData",
+    "resultType" : "ImGuiID",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "data",
+      "qualType" : "const void *",
+      "desugaredQualType" : "const void *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "data_size",
+      "qualType" : "size_t",
+      "desugaredQualType" : "unsigned long"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "seed",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int",
+      "defaultValue" : "0"
+    }, {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helpers: Hashing"
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImHashStr",
+    "resultType" : "ImGuiID",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "data",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "data_size",
+      "qualType" : "size_t",
+      "desugaredQualType" : "unsigned long",
+      "defaultValue" : "0"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "seed",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int",
+      "defaultValue" : "0"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
     "name" : "ImHash",
-    "resultType" : "int",
+    "resultType" : "ImGuiID",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "data",
@@ -60,8 +125,8 @@
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "seed",
-      "qualType" : "int",
-      "desugaredQualType" : "int",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int",
       "defaultValue" : "0"
     } ]
   }, {
@@ -91,22 +156,27 @@
     } ]
   }, {
     "@type" : "AstFunctionDecl",
-    "name" : "ImIsPowerOfTwo",
-    "resultType" : "bool",
+    "name" : "ImAlphaBlendColors",
+    "resultType" : "ImU32",
     "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "col_a",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "col_b",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    }, {
       "@type" : "AstFullComment",
       "decls" : [ {
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Helpers: Bit manipulation"
+          "text" : " Helpers: Color Blending"
         } ]
       } ]
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "v",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -117,6 +187,25 @@
       "name" : "v",
       "qualType" : "int",
       "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helpers: Bit manipulation"
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImIsPowerOfTwo",
+    "resultType" : "bool",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "v",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -133,15 +222,6 @@
     "name" : "ImStricmp",
     "resultType" : "int",
     "decls" : [ {
-      "@type" : "AstFullComment",
-      "decls" : [ {
-        "@type" : "AstParagraphComment",
-        "decls" : [ {
-          "@type" : "AstTextComment",
-          "text" : " Helpers: String, Formatting"
-        } ]
-      } ]
-    }, {
       "@type" : "AstParmVarDecl",
       "name" : "str1",
       "qualType" : "const char *",
@@ -151,6 +231,15 @@
       "name" : "str2",
       "qualType" : "const char *",
       "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helpers: String, Formatting"
+        } ]
+      } ]
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -175,7 +264,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImStrncpy",
-    "resultType" : "int",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "dst",
@@ -195,7 +284,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImStrdup",
-    "resultType" : "int *",
+    "resultType" : "char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "str",
@@ -205,7 +294,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImStrdupcpy",
-    "resultType" : "int *",
+    "resultType" : "char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "dst",
@@ -225,7 +314,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImStrchrRange",
-    "resultType" : "const int *",
+    "resultType" : "const char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "str_begin",
@@ -249,13 +338,13 @@
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "str",
-      "qualType" : "const int *",
-      "desugaredQualType" : "const int *"
+      "qualType" : "const ImWchar *",
+      "desugaredQualType" : "const ImWchar *"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImStreolRange",
-    "resultType" : "const int *",
+    "resultType" : "const char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "str",
@@ -269,8 +358,23 @@
     } ]
   }, {
     "@type" : "AstFunctionDecl",
+    "name" : "ImStrbolW",
+    "resultType" : "const ImWchar *",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "buf_mid_line",
+      "qualType" : "const ImWchar *",
+      "desugaredQualType" : "const ImWchar *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "buf_begin",
+      "qualType" : "const ImWchar *",
+      "desugaredQualType" : "const ImWchar *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
     "name" : "ImStristr",
-    "resultType" : "const int *",
+    "resultType" : "const char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "haystack",
@@ -295,7 +399,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImStrTrimBlanks",
-    "resultType" : "int",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "str",
@@ -305,7 +409,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImStrSkipBlank",
-    "resultType" : "const int *",
+    "resultType" : "const char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "str",
@@ -314,8 +418,63 @@
     } ]
   }, {
     "@type" : "AstFunctionDecl",
+    "name" : "ImFormatString",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "buf",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "buf_size",
+      "qualType" : "size_t",
+      "desugaredQualType" : "unsigned long"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "fmt",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "#FORMAT_ATTR_MARKER#",
+      "qualType" : "#FORMAT_ATTR_MARKER#",
+      "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImFormatStringV",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "buf",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "buf_size",
+      "qualType" : "size_t",
+      "desugaredQualType" : "unsigned long"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "fmt",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "args",
+      "qualType" : "__va_list_tag *",
+      "desugaredQualType" : "__va_list_tag *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "#FORMAT_ATTR_MARKER#",
+      "qualType" : "#FORMAT_ATTR_MARKER#",
+      "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
     "name" : "ImParseFormatFindStart",
-    "resultType" : "const int *",
+    "resultType" : "const char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "format",
@@ -325,7 +484,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImParseFormatFindEnd",
-    "resultType" : "const int *",
+    "resultType" : "const char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "format",
@@ -335,7 +494,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImParseFormatTrimDecorations",
-    "resultType" : "const int *",
+    "resultType" : "const char *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "format",
@@ -368,6 +527,32 @@
       "desugaredQualType" : "int"
     } ]
   }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImVec2",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " ImVec2: 2D vector used to store positions, sizes etc. [Compile-time configurable type]"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " This is a frequently used type in the API. Consider using IM_VEC2_CLASS_EXTRA to create implicit cast from/to our preferred type."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "x",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "y",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    } ]
+  }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImCharIsBlankA",
     "resultType" : "bool",
@@ -390,8 +575,18 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImTextCharToUtf8",
-    "resultType" : "const int *",
+    "resultType" : "const char *",
     "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "out_buf",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
       "@type" : "AstFullComment",
       "decls" : [ {
         "@type" : "AstParagraphComment",
@@ -406,16 +601,6 @@
           "text" : "> wchar conversions"
         } ]
       } ]
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "out_buf",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "unsigned int",
-      "desugaredQualType" : "unsigned int"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -434,13 +619,13 @@
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "in_text",
-      "qualType" : "const int *",
-      "desugaredQualType" : "const int *"
+      "qualType" : "const ImWchar *",
+      "desugaredQualType" : "const ImWchar *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "in_text_end",
-      "qualType" : "const int *",
-      "desugaredQualType" : "const int *"
+      "qualType" : "const ImWchar *",
+      "desugaredQualType" : "const ImWchar *"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -461,6 +646,70 @@
       "name" : "in_text_end",
       "qualType" : "const char *",
       "desugaredQualType" : "const char *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImTextStrFromUtf8",
+    "resultType" : "int",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "out_buf",
+      "qualType" : "ImWchar *",
+      "desugaredQualType" : "ImWchar *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "out_buf_size",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "in_text",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "in_text_end",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "in_remaining",
+      "qualType" : "const char **",
+      "desugaredQualType" : "const char **",
+      "defaultValue" : "NULL"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImVec4",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " ImVec4: 4D vector used to store clipping rectangles, colors etc. [Compile-time configurable type]"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "x",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "y",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "z",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "w",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -499,18 +748,7100 @@
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "in_text",
-      "qualType" : "const int *",
-      "desugaredQualType" : "const int *"
+      "qualType" : "const ImWchar *",
+      "desugaredQualType" : "const ImWchar *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "in_text_end",
-      "qualType" : "const int *",
-      "desugaredQualType" : "const int *"
+      "qualType" : "const ImWchar *",
+      "desugaredQualType" : "const ImWchar *"
+    } ]
+  }, {
+    "@type" : "AstNamespaceDecl",
+    "name" : "ImGui",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " [SECTION] Dear ImGui end-user API functions"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (Note that ImGui:: being a namespace, you can add extra ImGui:: functions in your own separate file. Please don't modify imgui source files!)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CreateContext",
+      "resultType" : "ImGuiContext *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "shared_font_atlas",
+        "qualType" : "ImFontAtlas *",
+        "desugaredQualType" : "ImFontAtlas *",
+        "defaultValue" : "s, c"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Context creation and access"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Each context create its own ImFontAtlas by default. You may instance one yourself and pass it to CreateContext() to share a font atlas between contexts."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   for each static/DLL boundary you are calling from. Read \"Context and Memory Allocators\" section of imgui.cpp for details."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DestroyContext",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "ImGuiContext *",
+        "desugaredQualType" : "ImGuiContext *",
+        "defaultValue" : "+ rh"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCurrentContext",
+      "resultType" : "ImGuiContext *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetCurrentContext",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "ImGuiContext *",
+        "desugaredQualType" : "ImGuiContext *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetIO",
+      "resultType" : "ImGuiIO &",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Main"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetStyle",
+      "resultType" : "ImGuiStyle &"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "NewFrame",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndFrame",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Render",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetDrawData",
+      "resultType" : "ImDrawData *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShowDemoWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "ec4 "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Demo, Debug, Information"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShowMetricsWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "BLE_"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShowStackToolWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "\nsta"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShowAboutWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "    "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShowStyleEditor",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ref",
+        "qualType" : "ImGuiStyle *",
+        "desugaredQualType" : "ImGuiStyle *",
+        "defaultValue" : "ite("
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShowStyleSelector",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShowFontSelector",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShowUserGuide",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetVersion",
+      "resultType" : "const char *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "StyleColorsDark",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImGuiStyle *",
+        "desugaredQualType" : "ImGuiStyle *",
+        "defaultValue" : " to "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Styles"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "StyleColorsLight",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImGuiStyle *",
+        "desugaredQualType" : "ImGuiStyle *",
+        "defaultValue" : "    "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "StyleColorsClassic",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImGuiStyle *",
+        "desugaredQualType" : "ImGuiStyle *",
+        "defaultValue" : " sin"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Begin",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "etur"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "s"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Windows"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Begin() = push window to the stack and start appending to it. End() = pop window from the stack."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Passing 'bool* p_open != NULL' shows a window-closing widget in the upper-right corner of the window,"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   which clicking will set the boolean to false when clicked."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You may append multiple times to the same window during the same frame by calling Begin()/End() pairs multiple times."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   Some information such as 'flags' or 'p_open' will only be considered by the first call to Begin()."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Begin() return false to indicate the window is collapsed or fully clipped, so you may early out and omit submitting"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   anything to the window. Always call a matching End() for each Begin() call, regardless of its return value!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   [Important: due to legacy reason, this is inconsistent with most other functions such as BeginMenu/EndMenu,"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the corresponding BeginXXX function"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.]"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Note that the bottom of window stack always contains a window called \"Debug\"."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "End",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginChild",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : " > 0 && (a >"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "border",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : " mx; "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "p"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Child Windows"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use child windows to begin into a self-contained independent scrolling/clipping regions within a host window. Child windows can embed their own child."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - For each independent axis of 'size': ==0.0f: use remaining host window size / >0.0f: fixed size / "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "<"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "0.0f: use remaining window size minus abs(size) / Each axis can use a different mode, e.g. ImVec2(0,400)."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - BeginChild() returns false to indicate the window is collapsed or fully clipped, so you may early out and omit submitting anything to the window."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   Always call a matching EndChild() for each BeginChild() call, regardless of its return value."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   [Important: due to legacy reason, this is inconsistent with most other functions such as BeginMenu/EndMenu,"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the corresponding BeginXXX function"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.]"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginChild",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : " > 0 && (a <"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "border",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : " mn; "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "r"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndChild",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowAppearing",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Windows Utilities"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - 'current window' = the window we are appending into while inside a Begin()/End() block. 'next window' = next window we will Begin() into."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowCollapsed",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowFocused",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiFocusedFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "n"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowHovered",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiHoveredFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : ">"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowDrawList",
+      "resultType" : "ImDrawList *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowDpiScale",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowPos",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowSize",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowWidth",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowHeight",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowViewport",
+      "resultType" : "ImGuiViewport *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowPos",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "pivot",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "oat)(int)(v."
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Window manipulation"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin)."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowSize",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : ")"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowSizeConstraints",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "custom_callback",
+        "qualType" : "ImGuiSizeCallback",
+        "desugaredQualType" : "void (*)(ImGuiSizeCallbackData *)",
+        "defaultValue" : "loat"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "custom_callback_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *",
+        "defaultValue" : "curr"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowContentSize",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowCollapsed",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "collapsed",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "I"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowFocus",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowBgAlpha",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "alpha",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowViewport",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "viewport_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowPos",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "T"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowSize",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "t"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowCollapsed",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "collapsed",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "i"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowFocus",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowFontScale",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowPos",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowSize",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "m"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowCollapsed",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "collapsed",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : ","
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowFocus",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetContentRegionAvail",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Content region"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Retrieve available space from a given point. GetContentRegionAvail() is frequently useful."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Those functions are bound to be redesigned (they are confusing, incomplete and the Min/Max return values are in local window coordinates which increases confusion)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetContentRegionMax",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowContentRegionMin",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowContentRegionMax",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetScrollX",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Windows Scrolling"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetScrollY",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollX",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "scroll_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollY",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "scroll_y",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetScrollMaxX",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetScrollMaxY",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollHereX",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "center_x_ratio",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "y +="
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollHereY",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "center_y_ratio",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : " ImC"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollFromPosX",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "local_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "center_x_ratio",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "{ re"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollFromPosY",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "local_y",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "center_y_ratio",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "tArr"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushFont",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "font",
+        "qualType" : "ImFont *",
+        "desugaredQualType" : "ImFont *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Parameters stacks (shared)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopFont",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushStyleColor",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImGuiCol",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushStyleColor",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImGuiCol",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopStyleColor",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "4"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushStyleVar",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImGuiStyleVar",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "val",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushStyleVar",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImGuiStyleVar",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "val",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopStyleVar",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "t"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushAllowKeyboardFocus",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "allow_keyboard_focus",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopAllowKeyboardFocus",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushButtonRepeat",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "repeat",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopButtonRepeat",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushItemWidth",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "item_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Parameters stacks (current window)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopItemWidth",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextItemWidth",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "item_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcItemWidth",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushTextWrapPos",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "wrap_local_pos_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "    "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopTextWrapPos",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFont",
+      "resultType" : "ImFont *",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Style read access"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use the style editor (ShowStyleEditor() function) to interactively see what the colors are)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFontSize",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFontTexUvWhitePixel",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetColorU32",
+      "resultType" : "ImU32",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImGuiCol",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "alpha_mul",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : " }\n "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetColorU32",
+      "resultType" : "ImU32",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetColorU32",
+      "resultType" : "ImU32",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetStyleColorVec4",
+      "resultType" : "const ImVec4 &",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImGuiCol",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Separator",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Cursor / Layout"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - By \"cursor\" we mean the current output position."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - The typical widget behavior is to output themselves at the current cursor position, then move the cursor one line down."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You can call SameLine() between widgets to undo the last carriage return and output at the right of the preceding widget."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Attention! We currently have inconsistencies between window-local and absolute positions we will aim to fix with future API:"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    Window-local coordinates:   SameLine(), GetCursorPos(), SetCursorPos(), GetCursorStartPos(), GetContentRegionMax(), GetWindowContentRegion*(), PushTextWrapPos()"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    Absolute coordinate:        GetCursorScreenPos(), SetCursorScreenPos(), all ImDrawList:: functions."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SameLine",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "offset_from_start_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "move"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "spacing",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "point"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "NewLine",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Spacing",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Dummy",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Indent",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "indent_w",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "   G"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Unindent",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "indent_w",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "_idx"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginGroup",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndGroup",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCursorPos",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCursorPosX",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCursorPosY",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetCursorPos",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "local_pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetCursorPosX",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "local_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetCursorPosY",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "local_y",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCursorStartPos",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCursorScreenPos",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetCursorScreenPos",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AlignTextToFramePadding",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTextLineHeight",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTextLineHeightWithSpacing",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFrameHeight",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFrameHeightWithSpacing",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushID",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " ID stack/scopes"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Read the FAQ (docs/FAQ.md or http://dearimgui.org/faq) for more details about how ID are handled in dear imgui."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Those questions are answered and impacted by understanding of the ID stack system:"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   - \"Q: Why is my widget not reacting when I click on it?\""
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   - \"Q: How can I have widgets with an empty label?\""
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   - \"Q: How can I have multiple widgets with the same label?\""
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Short version: ID are hashes of the entire ID stack. If you are creating widgets in a loop you most likely"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   want to push a unique identifier (e.g. object pointer, loop index) to uniquely differentiate them."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You can also use the \"Label##foobar\" syntax within widget label to distinguish them from each others."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - In this header file we use the \"label\"/\"name\" terminology to denote a string that will be displayed + used as an ID,"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   whereas \"str_id\" denote a string that is only used as an ID and not normally displayed."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushID",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id_begin",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushID",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr_id",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushID",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "int_id",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopID",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id_begin",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr_id",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TextUnformatted",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "writ"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Text"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Text",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TextV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TextColored",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TextColoredV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TextDisabled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TextDisabledV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TextWrapped",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TextWrappedV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LabelText",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LabelTextV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BulletText",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BulletTextV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Button",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "   // Global"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Main"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Most widgets return true when the value has been changed or when pressed/selected"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You may also use one of the many IsItemXXX functions (e.g. IsItemActive, IsItemHovered, etc.) to query widget state."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SmallButton",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InvisibleButton",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiButtonFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ArrowButton",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "dir",
+        "qualType" : "ImGuiDir",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Image",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_texture_id",
+        "qualType" : "ImTextureID",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv0",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "ndow flags, "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : " of the fra"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "tint_col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &",
+        "defaultValue" : "ited from paren"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "border_col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &",
+        "defaultValue" : "s going to be e"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ImageButton",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_texture_id",
+        "qualType" : "ImTextureID",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv0",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : ",\n    ImGuiI"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "           "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "frame_padding",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "  "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "bg_col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &",
+        "defaultValue" : "ng (FIXME: shou"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "tint_col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &",
+        "defaultValue" : "mGuiItemFlags_B"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Checkbox",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CheckboxFlags",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags_value",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CheckboxFlags",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "unsigned int *",
+        "desugaredQualType" : "unsigned int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags_value",
+        "qualType" : "unsigned int",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "RadioButton",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "active",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "RadioButton",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_button",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ProgressBar",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fraction",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size_arg",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "ble() automatically"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "overlay",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "dow\n"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Bullet",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginCombo",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "preview_value",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiComboFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "="
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Combo Box"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - The BeginCombo()/EndCombo() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() items."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndCombo",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Combo",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "current_item",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items",
+        "qualType" : "const char *const *",
+        "desugaredQualType" : "const char *const *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_max_height_in_items",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "ui"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Combo",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "current_item",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_separated_by_zeros",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_max_height_in_items",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "Va"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Combo",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "current_item",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_getter",
+        "qualType" : "bool (*)(void *, int, const char **)",
+        "desugaredQualType" : "bool (*)(void *, int, const char **)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_max_height_in_items",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "le"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloat",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "n if"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "nt i"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : " hov"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "iButto"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Drag Sliders"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - CTRL+Click on any drag box to turn them into an input box. Manually input values aren't clamped by default and can go off-bounds. Use ImGuiSliderFlags_AlwaysClamp to always clamp."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - For all the Float2/Float3/Float4/Int2/Int3/Int4 versions of every functions, note that a 'float v[X]' function argument is the same as 'float* v', the array syntax is just a way to document the number of elements that are expected to be accessible. You can pass address of your first element out of a contiguous set, e.g. "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "&myvector"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : ".x"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Adjust format string to decorate the value with a prefix, a suffix, or adapt the editing and display precision e.g. \"%.3f\" -> 1.234; \"%5.2f secs\" -> 01.23 secs; \"Biscuit: %.0f\" -> Biscuit: 1; etc."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Format string may also be set to NULL or use the default format (\"%f\" or \"%d\")."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Speed are per-pixel of mouse movement (v_speed=0.2f: mouse needs to move by 5 pixels to increase value by 1). For gamepad/keyboard navigation, minimum speed is Max(v_speed, minimum_step_at_given_precision)."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use v_min "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "<"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " v_max to clamp edits to given limits. Note that CTRL+Click manual input can override those limits if ImGuiSliderFlags_AlwaysClamp is not used."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use v_max = FLT_MAX / INT_MAX etc to avoid clamping to a maximum, same with v_min = -FLT_MAX / INT_MIN to avoid clamping to a minimum."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - We use the same sets of flags for DragXXX() and SliderXXX() functions as the features are the same and it makes it easier to swap them."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Legacy: Pre-1.78 there are DragXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloat2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : " ret"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "le-c"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "quir"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "mGuiBu"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "H"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloat3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "m (u"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : " nod"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "eade"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "s_Repe"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloat4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "erac"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "chil"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "lapp"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "s_Allo"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "2"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloatRange2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_current_min",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_current_max",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "\n   "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "s_Do"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "    "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : " autom"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format_max",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "up o"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "m"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragInt",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "inDi"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "G"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "s"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "ags_"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "<"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragInt2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "utto"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "b"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "e"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "evLi"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "e"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragInt3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "\n   "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "a"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "t"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "// d"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "d"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragInt4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "    "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "o"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "s wh"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "n"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragIntRange2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_current_min",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_current_max",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "Pres"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "t"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "| Im"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format_max",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "ckRe"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "e"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragScalar",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "Flag"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : "d,\n "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : "esse"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "iBut"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "a"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragScalarN",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "components",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "ginC"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : "xten"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : "um I"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "\n{\n "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "l"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderFloat",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "<< 24,"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "v"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Regular Sliders"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - CTRL+Click on any slider to turn them into an input box. Manually input values aren't clamped by default and can go off-bounds. Use ImGuiSliderFlags_AlwaysClamp to always clamp."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Adjust format string to decorate the value with a prefix, a suffix, or adapt the editing and display precision e.g. \"%.3f\" -> 1.234; \"%5.2f secs\" -> 01.23 secs; \"Biscuit: %.0f\" -> Biscuit: 1; etc."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Format string may also be set to NULL or use the default format (\"%f\" or \"%d\")."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Legacy: Pre-1.78 there are SliderXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderFloat2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "red. T"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "b"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderFloat3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "er (us"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "l"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderFloat4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "eeNode"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "a"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderAngle",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_rad",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_degrees_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "ags_\n{\n"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_degrees_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "None   "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "mGuiSepara"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderInt",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "iSep"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderInt2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "one "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "i"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderInt3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "s_Ov"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "<"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderInt4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "evel"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "n"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderScalar",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "ntal"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "e"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderScalarN",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "components",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "e fi"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "s"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "VSliderFloat",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "Type_L"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "t"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "VSliderInt",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "iInp"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "I"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "VSliderScalar",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "-NAV"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSliderFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "p"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputText",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "buf",
+        "qualType" : "char *",
+        "desugaredQualType" : "char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "buf_size",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "callback",
+        "qualType" : "ImGuiInputTextCallback",
+        "desugaredQualType" : "int (*)(ImGuiInputTextCallbackData *)",
+        "defaultValue" : " up "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *",
+        "defaultValue" : "NT\n}"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Input with Keyboard"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - If you want to use InputText() with std::string or any custom dynamic string type, see misc/cpp/imgui_stdlib.h and comments in imgui_demo.cpp."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Most of the ImGuiInputTextFlags flags are only useful for InputText() and not for InputFloatX, InputIntX, InputDouble etc."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputTextMultiline",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "buf",
+        "qualType" : "char *",
+        "desugaredQualType" : "char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "buf_size",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "  size_t    "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "y"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "callback",
+        "qualType" : "ImGuiInputTextCallback",
+        "desugaredQualType" : "int (*)(ImGuiInputTextCallbackData *)",
+        "defaultValue" : "// S"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *",
+        "defaultValue" : "e fo"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputTextWithHint",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "hint",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "buf",
+        "qualType" : "char *",
+        "desugaredQualType" : "char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "buf_size",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "n"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "callback",
+        "qualType" : "ImGuiInputTextCallback",
+        "desugaredQualType" : "int (*)(ImGuiInputTextCallbackData *)",
+        "defaultValue" : "ImGu"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *",
+        "defaultValue" : "iDat"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputFloat",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "step",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "e_Po"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "step_fast",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "Type"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "r modi"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "s"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputFloat2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "\n\n// S"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "o"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputFloat3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "d\n{\n  "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "u"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputFloat4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : ", int "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "n"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputInt",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "step",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "c"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "step_fast",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "\n  "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "i"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputInt2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "o"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputInt3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputInt4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "V"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputDouble",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "double *",
+        "desugaredQualType" : "double *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "step",
+        "qualType" : "double",
+        "desugaredQualType" : "double",
+        "defaultValue" : "\n  "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "step_fast",
+        "qualType" : "double",
+        "desugaredQualType" : "double",
+        "defaultValue" : "kup"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "Previe"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "o"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputScalar",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_step",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : "dowI"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_step_fast",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : "sorP"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "kupC"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "a"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InputScalarN",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "components",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_step",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : "D   "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_step_fast",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : " boo"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "Prev"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiInputTextFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorEdit3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiColorEditFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Color Editor/Picker (tip: the ColorEdit* functions have a little color square that can be left-clicked to open a picker, and right-clicked to open an option menu.)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Note that in C++ a 'float v[X]' function argument is the _same_ as 'float* v', the array syntax is just a way to document the number of elements that are expected to be accessible."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You can pass the address of a first float element out of a contiguous structure, e.g. "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "&myvector"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : ".x"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorEdit4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiColorEditFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorPicker3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiColorEditFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "a"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorPicker4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiColorEditFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "e"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "ref_col",
+        "qualType" : "const float *",
+        "desugaredQualType" : "const float *",
+        "defaultValue" : "ly f"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorButton",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "desc_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiColorEditFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "G"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2",
+        "defaultValue" : "te\n{\n    ImGui"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetColorEditOptions",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiColorEditFlags",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNode",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Trees"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - TreeNode functions return true when the node is open, in which case you need to also call TreePop() when you are finished displaying the tree node contents."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNode",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNode",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr_id",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNodeV",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNodeV",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr_id",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNodeEx",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTreeNodeFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNodeEx",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTreeNodeFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNodeEx",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr_id",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTreeNodeFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNodeExV",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTreeNodeFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeNodeExV",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr_id",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTreeNodeFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreePush",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreePush",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr_id",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *",
+        "defaultValue" : "t() "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreePop",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTreeNodeToLabelSpacing",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CollapsingHeader",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTreeNodeFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "t"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CollapsingHeader",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_visible",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTreeNodeFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "{"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextItemOpen",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "is_open",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Selectable",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "selected",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : " at t"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSelectableFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "enFrameCount"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Selectables"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - A selectable highlights when hovered, and can display another color when selected."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Neighbors selectable extend their highlight bounds in order to leave no gap between them. This is so a series of selected Selectable appear contiguous."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Selectable",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_selected",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiSelectableFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : ";"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "), copy of m"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginListBox",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "            "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: List Boxes"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - This is essentially a thin wrapper to using BeginChild/EndChild with some stylistic changes."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - The BeginListBox()/EndListBox() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() or any items."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - The simplified/old ListBox() api are helpers over BeginListBox()/EndListBox() which are kept available for convenience purpose. This is analoguous to how Combos are created."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Choose frame width:   size.x > 0.0f: custom  /  size.x "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "<"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " 0.0f or -FLT_MIN: right-align   /  size.x = 0.0f (default): use current ItemWidth"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Choose frame height:  size.y > 0.0f: custom  /  size.y "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "<"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " 0.0f or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndListBox",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ListBox",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "current_item",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items",
+        "qualType" : "const char *const *",
+        "desugaredQualType" : "const char *const *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "height_in_items",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "  "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ListBox",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "current_item",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_getter",
+        "qualType" : "bool (*)(void *, int, const char **)",
+        "desugaredQualType" : "bool (*)(void *, int, const char **)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "height_in_items",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "  "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PlotLines",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values",
+        "qualType" : "const float *",
+        "desugaredQualType" : "const float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_offset",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "k"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "overlay_text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "    "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "ImVec2 "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : " MenuBa"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "graph_size",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2",
+        "defaultValue" : " (Always on) T"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "stride",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "sed publicly,"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Data Plotting"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Consider using ImPlot (https://github.com/epezent/implot) which is much better!"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PlotLines",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_getter",
+        "qualType" : "float (*)(void *, int)",
+        "desugaredQualType" : "float (*)(void *, int)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_offset",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "s"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "overlay_text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "ags("
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "NextWin"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "\n};\n\nen"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "graph_size",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2",
+        "defaultValue" : "Flags_\n{\n    I"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PlotHistogram",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values",
+        "qualType" : "const float *",
+        "desugaredQualType" : "const float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_offset",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "<"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "overlay_text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "ta\n{"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "taFlags"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "at     "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "graph_size",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2",
+        "defaultValue" : "dth;          "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "stride",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "xtItemWidth()"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PlotHistogram",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_getter",
+        "qualType" : "float (*)(void *, int)",
+        "desugaredQualType" : "float (*)(void *, int)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "values_offset",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "e"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "overlay_text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "gs f"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : " are cl"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "s is mo"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "graph_size",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2",
+        "defaultValue" : "ing)\n    ImGui"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Value",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "prefix",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "b",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Value() Helpers."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Those are merely shortcut to calling Text() with a format string. Output single value in \"name: value\" format (tip: freely declare more in your code to handle your types. you can add functions to the ImGui namespace)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Value",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "prefix",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Value",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "prefix",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "unsigned int",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Value",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "prefix",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "float_format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "  Im"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginMenuBar",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets: Menus"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use BeginMenuBar() on a window ImGuiWindowFlags_MenuBar to append to its menu bar."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use BeginMainMenuBar() to create a menu bar at the top of the screen and append to it."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use BeginMenu() to create a menu. You can call BeginMenu() multiple time with the same identifier to append more items to it."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Not that MenuItem() keyboardshortcuts are displayed as a convenience but _not processed_ by Dear ImGui at the moment."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndMenuBar",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginMainMenuBar",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndMainMenuBar",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginMenu",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "enabled",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : " // "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndMenu",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "MenuItem",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "shortcut",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "----"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "selected",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "-----"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "enabled",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "----"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "MenuItem",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "shortcut",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_selected",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "enabled",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "perR"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginTooltip",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Tooltips"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Tooltip are windows following the mouse. They do not take focus away."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndTooltip",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetTooltip",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetTooltipV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginPopup",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "m"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Popups: begin/end functions"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - BeginPopup(): query popup state, if open start appending into the window. Call EndPopup() afterwards. ImGuiWindowFlags are forwarded to the window."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - BeginPopupModal(): block every interactions behind the window, cannot be closed by user, add a dimming background, has a title bar."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginPopupModal",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "poss"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "m"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndPopup",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "OpenPopup",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "r"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Popups: open/close functions"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - OpenPopup(): set popup state to open. ImGuiPopupFlags are available for opening options."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - If not modal: they can be closed by clicking anywhere outside them, or by pressing ESCAPE."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - CloseCurrentPopup(): use inside the BeginPopup()/EndPopup() scope to close manually."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - CloseCurrentPopup() is called by default by Selectable()/MenuItem() when activated (FIXME: need some options)."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - Use ImGuiPopupFlags_NoOpenOverExistingPopup to avoid opening a popup if there's already one at the same level. This is equivalent to e.g. testing for !IsAnyPopupOpen() prior to OpenPopup()."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - Use IsWindowAppearing() after BeginPopup() to tell if a window just opened."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "OpenPopup",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "_"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "OpenPopupOnItemClick",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "Flag"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CloseCurrentPopup",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginPopupContextItem",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "vMov"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Popups: open+begin combined functions helpers"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - Helpers to do OpenPopup+BeginPopup where the Open action is triggered by e.g. hovering an item and right-clicking."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - They are convenient to easily create context menus, hence the name."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - IMPORTANT: Notice that BeginPopupContextXXX takes ImGuiPopupFlags just like OpenPopup() and unlike BeginPopup(). For full consistency, we may add ImGuiWindowFlags to the BeginPopupContextXXX functions in the future."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - IMPORTANT: we exceptionally default their flags to 1 (== ImGuiPopupFlags_MouseButtonRight) for backward compatibility with older API taking 'int mouse_button = 1' parameter, so if you add other flags remember to re-add the ImGuiPopupFlags_MouseButtonRight."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginPopupContextWindow",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "ible"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "n"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginPopupContextVoid",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "    "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsPopupOpen",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiPopupFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Popups: query functions"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - IsPopupOpen(): return true if the popup is open at the current BeginPopup() level of the popup stack."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId: return true if any popup is open at the current BeginPopup() level of the popup stack."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId + ImGuiPopupFlags_AnyPopupLevel: return true if any popup is open."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginTable",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTableFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "l"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "outer_size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "nsFlags_NoBorder  "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "inner_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "iOld"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Tables"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " [BETA API] API may evolve slightly! If you use this, please update to the next version when it comes out!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Full-featured replacement for old Columns API."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - See Demo->Tables for demo code."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - See top of imgui_tables.cpp for general commentary."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - See ImGuiTableFlags_ and ImGuiTableColumnFlags_ enums for a description of available flags."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " The typical call flow is:"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - 1. Call BeginTable()."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - 2. Optionally call TableSetupColumn() to submit column name/flags/defaults."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - 3. Optionally call TableSetupScrollFreeze() to request scroll freezing of columns/rows."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - 4. Optionally call TableHeadersRow() to submit a header row. Names are pulled from TableSetupColumn() data."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - 5. Populate contents:"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    - In most situations you can use TableNextRow() + TableSetColumnIndex(N) to start appending into a column."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    - If you are using tables as a sort of grid, where every columns is holding the same type of contents,"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "      you may prefer using TableNextColumn() instead of TableNextRow() + TableSetColumnIndex()."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "      TableNextColumn() will automatically wrap-around into the next row if needed."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    - IMPORTANT: Comparatively to the old Columns() API, we need to call TableNextColumn() for the first column!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "    - Summary of possible call flow:"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "        --------------------------------------------------------------------------------------------------------"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "        TableNextRow() -> TableSetColumnIndex(0) -> Text(\"Hello 0\") -> TableSetColumnIndex(1) -> Text(\"Hello 1\")  // OK"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "        TableNextRow() -> TableNextColumn()      -> Text(\"Hello 0\") -> TableNextColumn()      -> Text(\"Hello 1\")  // OK"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "                          TableNextColumn()      -> Text(\"Hello 0\") -> TableNextColumn()      -> Text(\"Hello 1\")  // OK: TableNextColumn() automatically gets to next row!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "        TableNextRow()                           -> Text(\"Hello 0\")                                               // Not OK! Missing TableSetColumnIndex() or TableNextColumn()! Text will not appear!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "        --------------------------------------------------------------------------------------------------------"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - 5. Call EndTable()"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndTable",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableNextRow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "row_flags",
+        "qualType" : "ImGuiTableRowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "l"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "min_row_height",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "ndow"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableNextColumn",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSetColumnIndex",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSetupColumn",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTableColumnFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "s"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "init_width_or_weight",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "nd()"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Tables: Headers "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "&"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Columns declaration"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use TableSetupColumn() to specify label, resizing policy, default width/weight, id, various other flags etc."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use TableHeadersRow() to create a header row and automatically submit a TableHeader() for each column."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   Headers are required to perform: reordering, sorting, and opening the context menu."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   The context menu can also be made available in columns body using ImGuiTableFlags_ContextMenuInBody."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You may manually submit headers using TableNextRow() + TableHeader() calls, but this is only useful in"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   some advanced use cases (e.g. adding custom widgets in header row)."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use TableSetupScrollFreeze() to lock columns/rows so they stay visible when scrolled."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSetupScrollFreeze",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "cols",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rows",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableHeadersRow",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableHeader",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetSortSpecs",
+      "resultType" : "ImGuiTableSortSpecs *",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Tables: Sorting"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Call TableGetSortSpecs() to retrieve latest sort specs for the table. NULL when not sorting."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - When 'SpecsDirty == true' you should sort your data. It will be true when sorting specs have changed"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   since last call, or the first time. Make sure to set 'SpecsDirty = false' after sorting, else you may"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   wastefully sort your data every frame!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable()."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetColumnCount",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Tables: Miscellaneous functions"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Functions args 'int column_n' treat the default value of -1 as the same as passing the current column index."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetColumnIndex",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetRowIndex",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetColumnName",
+      "resultType" : "const char *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "in"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetColumnFlags",
+      "resultType" : "ImGuiTableColumnFlags",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : " 1"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSetColumnEnabled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSetBgColor",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "target",
+        "qualType" : "ImGuiTableBgTarget",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "color",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "it"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Columns",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "d"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "wind"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "border",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "node"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Legacy Columns API (prefer using Tables!)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You can also use SameLine(pos_x) to mimic simplified columns."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "NextColumn",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetColumnIndex",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetColumnWidth",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_index",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "sk"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetColumnWidth",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_index",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetColumnOffset",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_index",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "eF"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetColumnOffset",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_index",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "offset_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetColumnsCount",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginTabBar",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTabBarFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "l"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Tab Bars, Tabs"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Note: Tabs are automatically created by the docking system. Use this to create tab bars/tabs yourself without docking being involved."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndTabBar",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginTabItem",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "ockN"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTabItemFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "a"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndTabItem",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TabItemButton",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTabItemFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "l"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetTabItemClosed",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab_or_docked_window_label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DockSpace",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
+        "defaultValue" : "hen there is"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiDockNodeFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "window_class",
+        "qualType" : "const ImGuiWindowClass *",
+        "desugaredQualType" : "const ImGuiWindowClass *",
+        "defaultValue" : "  Co"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Docking"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " [BETA API] Enable with io.ConfigFlags |= ImGuiConfigFlags_DockingEnable."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Note: You can use most Docking facilities without calling any API. You DO NOT need to call DockSpace() to use Docking!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Drag from window title bar or their tab to dock/undock. Hold SHIFT to disable docking/undocking."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Drag from window menu button (upper-left button) to undock an entire node (all windows)."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - When io.ConfigDockingWithShift == true, you instead need to hold SHIFT to _enable_ docking/undocking."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " About dockspaces:"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use DockSpace() to create an explicit dock node _within_ an existing window. See Docking demo for details."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use DockSpaceOverViewport() to create an explicit dock node covering the screen or a specific viewport."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   This is often used with ImGuiDockNodeFlags_PassthruCentralNode."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Important: Dockspaces need to be submitted _before_ any window they can host. Submit it early in your frame!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Important: Dockspaces need to be kept alive if hidden, otherwise windows docked into it will be undocked."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   e.g. if you have multiple tabs with a dockspace inside each tab: submit the non-visible dockspaces with ImGuiDockNodeFlags_KeepAliveOnly."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DockSpaceOverViewport",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "viewport",
+        "qualType" : "const ImGuiViewport *",
+        "desugaredQualType" : "const ImGuiViewport *",
+        "defaultValue" : "ive;"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiDockNodeFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "m"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "window_class",
+        "qualType" : "const ImGuiWindowClass *",
+        "desugaredQualType" : "const ImGuiWindowClass *",
+        "defaultValue" : "plic"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowDockID",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dock_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "L"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextWindowClass",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window_class",
+        "qualType" : "const ImGuiWindowClass *",
+        "desugaredQualType" : "const ImGuiWindowClass *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowDockID",
+      "resultType" : "ImGuiID"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowDocked",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LogToTTY",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "auto_open_depth",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "  "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Logging/Capture"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - All text output from the interface can be captured into tty/file/clipboard. By default, tree nodes are automatically opened during logging."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LogToFile",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "auto_open_depth",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "no"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "filename",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "    "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LogToClipboard",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "auto_open_depth",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : ":1"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LogFinish",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LogButtons",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LogText",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LogTextV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginDragDropSource",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiDragDropFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "o"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Drag and Drop"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - On source items, call BeginDragDropSource(), if it returns true also call SetDragDropPayload() + EndDragDropSource()."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - On target candidates, call BeginDragDropTarget(), if it returns true also call AcceptDragDropPayload() + EndDragDropTarget()."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - If you stop calling BeginDragDropSource() the payload is preserved however it won't have a preview tooltip (we currently display a fallback \"...\" tooltip, see #1725)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - An item can be both drag source and drop target."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetDragDropPayload",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "type",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "sz",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "s"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndDragDropSource",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginDragDropTarget",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AcceptDragDropPayload",
+      "resultType" : "const ImGuiPayload *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "type",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiDragDropFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "s"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndDragDropTarget",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetDragDropPayload",
+      "resultType" : "const ImGuiPayload *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginDisabled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "disabled",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "----"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Disabling [BETA API]"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Disable all user interactions and dim items visuals (applying style.DisabledAlpha over current colors)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Those can be nested but it cannot be used to enable an already disabled section (a single BeginDisabled(true) in the stack is enough to keep everything disabled)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - BeginDisabled(false) essentially does nothing useful but is provided to facilitate use of boolean expressions. If you can avoid calling BeginDisabled(False)/EndDisabled() best to avoid it."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndDisabled",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushClipRect",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "clip_rect_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "clip_rect_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "intersect_with_current_clip_rect",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Clipping"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Mouse hovering is affected by ImGui::PushClipRect() calls, unlike direct calls to ImDrawList::PushClipRect() which are render only."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopClipRect",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetItemDefaultFocus",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Focus, Activation"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Prefer using \"SetItemDefaultFocus()\" over \"if (IsWindowAppearing()) SetScrollHereY()\" when applicable to signify \"this is the default item\""
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetKeyboardFocusHere",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "offset",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "V"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemHovered",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiHoveredFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "u"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Item/Widgets Utilities and Query Functions"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Most of the functions are referring to the previous Item that has been submitted."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - See Demo Window under \"Widgets->Querying Status\" for an interactive visualization of most of those functions."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemActive",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemFocused",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemClicked",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "mouse_button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int",
+        "defaultValue" : "r"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemVisible",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemEdited",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemActivated",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemDeactivated",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemDeactivatedAfterEdit",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsItemToggledOpen",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsAnyItemHovered",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsAnyItemActive",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsAnyItemFocused",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetItemRectMin",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetItemRectMax",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetItemRectSize",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetItemAllowOverlap",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetMainViewport",
+      "resultType" : "ImGuiViewport *",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Viewports"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - In 'docking' branch with multi-viewport enabled, we extend this concept to have multiple active viewports."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - In the future we will extend this concept further to also represent Platform Monitor and support a \"no main platform window\" operation mode."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsRectVisible",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Miscellaneous Utilities"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsRectVisible",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "rect_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rect_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTime",
+      "resultType" : "double"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFrameCount",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetBackgroundDrawList",
+      "resultType" : "ImDrawList *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetForegroundDrawList",
+      "resultType" : "ImDrawList *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetBackgroundDrawList",
+      "resultType" : "ImDrawList *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "viewport",
+        "qualType" : "ImGuiViewport *",
+        "desugaredQualType" : "ImGuiViewport *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetForegroundDrawList",
+      "resultType" : "ImDrawList *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "viewport",
+        "qualType" : "ImGuiViewport *",
+        "desugaredQualType" : "ImGuiViewport *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetDrawListSharedData",
+      "resultType" : "ImDrawListSharedData *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetStyleColorName",
+      "resultType" : "const char *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImGuiCol",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetStateStorage",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "storage",
+        "qualType" : "ImGuiStorage *",
+        "desugaredQualType" : "ImGuiStorage *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetStateStorage",
+      "resultType" : "ImGuiStorage *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginChildFrame",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "d"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "EndChildFrame",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcTextSize",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "    "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "hide_text_after_double_hash",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "gHook"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "wrap_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "     "
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Text Utilities"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorConvertU32ToFloat4",
+      "resultType" : "ImVec4",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "in",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Color Utilities"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorConvertFloat4ToU32",
+      "resultType" : "ImU32",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "in",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorConvertRGBtoHSV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "g",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "b",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_h",
+        "qualType" : "float &",
+        "desugaredQualType" : "float &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_s",
+        "qualType" : "float &",
+        "desugaredQualType" : "float &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_v",
+        "qualType" : "float &",
+        "desugaredQualType" : "float &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ColorConvertHSVtoRGB",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "h",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "s",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_r",
+        "qualType" : "float &",
+        "desugaredQualType" : "float &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_g",
+        "qualType" : "float &",
+        "desugaredQualType" : "float &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_b",
+        "qualType" : "float &",
+        "desugaredQualType" : "float &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetKeyIndex",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "imgui_key",
+        "qualType" : "ImGuiKey",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Inputs Utilities: Keyboard"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - For 'int user_key_index' you can use your own indices/enums according to how your backend/engine stored them in io.KeysDown[]."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - We don't know the meaning of those value. You can use GetKeyIndex() to map a ImGuiKey_ value into the user index."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsKeyDown",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_key_index",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsKeyPressed",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_key_index",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "repeat",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "onte"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsKeyReleased",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_key_index",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetKeyPressedAmount",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key_index",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "repeat_delay",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rate",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CaptureKeyboardFromApp",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "want_capture_keyboard_value",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "imgu"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsMouseDown",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Inputs Utilities: Mouse"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - To refer to a mouse button, you may use named enums in your code e.g. ImGuiMouseButton_Left, ImGuiMouseButton_Right."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You can also use regular integer: it is forever guaranteed that 0=Left, 1=Right, 2=Middle."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Dragging operations are only reported after mouse has moved a certain distance away from the initial clicking position (see 'lock_threshold' and 'io.MouseDraggingThreshold')"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsMouseClicked",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "repeat",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : " * Fo"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsMouseReleased",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsMouseDoubleClicked",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetMouseClickedCount",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsMouseHoveringRect",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "r_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "clip",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "eHoo"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsMousePosValid",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "mouse_pos",
+        "qualType" : "const ImVec2 *",
+        "desugaredQualType" : "const ImVec2 *",
+        "defaultValue" : " sta"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsAnyMouseDown",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetMousePos",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetMousePosOnOpeningCurrentPopup",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsMouseDragging",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "lock_threshold",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "round"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetMouseDragDelta",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int",
+        "defaultValue" : "n"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "lock_threshold",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : " // W"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ResetMouseDragDelta",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "button",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int",
+        "defaultValue" : " "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetMouseCursor",
+      "resultType" : "ImGuiMouseCursor"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetMouseCursor",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "cursor_type",
+        "qualType" : "ImGuiMouseCursor",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CaptureMouseFromApp",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "want_capture_mouse_value",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "    "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetClipboardText",
+      "resultType" : "const char *",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Clipboard Utilities"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Also see the LogToClipboard() function to capture GUI into clipboard, or easily output text data to the clipboard."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetClipboardText",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LoadIniSettingsFromDisk",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ini_filename",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Settings/.Ini Utilities"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - The disk functions are automatically called if io.IniFilename != NULL (default is \"imgui.ini\")."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Set io.IniFilename to NULL to load/save manually. Read io.WantSaveIniSettings description about handling .ini saving manually."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Important: default value \"imgui.ini\" is relative to current working dir! Most apps will want to lock this to an absolute path (e.g. same path as executables)."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LoadIniSettingsFromMemory",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ini_data",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "ini_size",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long",
+        "defaultValue" : "m"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SaveIniSettingsToDisk",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ini_filename",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SaveIniSettingsToMemory",
+      "resultType" : "const char *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_ini_size",
+        "qualType" : "size_t *",
+        "desugaredQualType" : "size_t *",
+        "defaultValue" : "ng w"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DebugCheckVersionAndDataLayout",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "version_str",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "sz_io",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "sz_style",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "sz_vec2",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "sz_vec4",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "sz_drawvert",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "sz_drawidx",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Debug Utilities"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - This is used by the IMGUI_CHECKVERSION() macro."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetAllocatorFunctions",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "alloc_func",
+        "qualType" : "ImGuiMemAllocFunc",
+        "desugaredQualType" : "void *(*)(size_t, void *)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "free_func",
+        "qualType" : "ImGuiMemFreeFunc",
+        "desugaredQualType" : "void (*)(void *, void *)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *",
+        "defaultValue" : "av i"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Memory Allocators"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Those functions are not reliant on the current context."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   for each static/DLL boundary you are calling from. Read \"Context and Memory Allocators\" section of imgui.cpp for more details."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetAllocatorFunctions",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_alloc_func",
+        "qualType" : "ImGuiMemAllocFunc *",
+        "desugaredQualType" : "ImGuiMemAllocFunc *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_free_func",
+        "qualType" : "ImGuiMemFreeFunc *",
+        "desugaredQualType" : "ImGuiMemFreeFunc *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_user_data",
+        "qualType" : "void **",
+        "desugaredQualType" : "void **"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "MemAlloc",
+      "resultType" : "void *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "MemFree",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetPlatformIO",
+      "resultType" : "ImGuiPlatformIO &",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " (Optional) Platform/OS interface for multi-viewport support"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Read comments around the ImGuiPlatformIO structure for more details."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Note: You may use GetWindowViewport() to get the current viewport of the current window."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "UpdatePlatformWindows",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "RenderPlatformWindowsDefault",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "platform_render_arg",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *",
+        "defaultValue" : " ani"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "renderer_render_arg",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *",
+        "defaultValue" : "    "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DestroyPlatformWindows",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindViewportByID",
+      "resultType" : "ImGuiViewport *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindViewportByPlatformHandle",
+      "resultType" : "ImGuiViewport *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "platform_handle",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImFileOpen",
+    "resultType" : "ImFileHandle",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "filename",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "mode",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFileClose",
-    "resultType" : "int",
+    "resultType" : "bool",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "file",
@@ -519,8 +7850,68 @@
     } ]
   }, {
     "@type" : "AstFunctionDecl",
+    "name" : "ImFileGetSize",
+    "resultType" : "ImU64",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "file",
+      "qualType" : "ImFileHandle",
+      "desugaredQualType" : "FILE *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImFileRead",
+    "resultType" : "ImU64",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "data",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "size",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "count",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "file",
+      "qualType" : "ImFileHandle",
+      "desugaredQualType" : "FILE *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImFileWrite",
+    "resultType" : "ImU64",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "data",
+      "qualType" : "const void *",
+      "desugaredQualType" : "const void *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "size",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "count",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "file",
+      "qualType" : "ImFileHandle",
+      "desugaredQualType" : "FILE *"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
     "name" : "ImFileLoadToMemory",
-    "resultType" : "int *",
+    "resultType" : "void *",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "filename",
@@ -547,7 +7938,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImPow",
-    "resultType" : "int",
+    "resultType" : "float",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "x",
@@ -667,8 +8058,18 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImMin",
-    "resultType" : "int",
+    "resultType" : "ImVec2",
     "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "lhs",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "rhs",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
       "@type" : "AstFullComment",
       "decls" : [ {
         "@type" : "AstParagraphComment",
@@ -677,66 +8078,56 @@
           "text" : " - Misc maths helpers"
         } ]
       } ]
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "lhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "rhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImMax",
-    "resultType" : "int",
+    "resultType" : "ImVec2",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "lhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "rhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImClamp",
-    "resultType" : "int",
+    "resultType" : "ImVec2",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "v",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "mn",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "mx",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImLerp",
-    "resultType" : "int",
+    "resultType" : "ImVec2",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "a",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "b",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "t",
@@ -746,37 +8137,37 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImLerp",
-    "resultType" : "int",
+    "resultType" : "ImVec2",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "a",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "b",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "t",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImLerp",
-    "resultType" : "int",
+    "resultType" : "ImVec4",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "a",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec4 &",
+      "desugaredQualType" : "const ImVec4 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "b",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec4 &",
+      "desugaredQualType" : "const ImVec4 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "t",
@@ -800,8 +8191,8 @@
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "lhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -810,8 +8201,8 @@
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "lhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec4 &",
+      "desugaredQualType" : "const ImVec4 &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -820,8 +8211,8 @@
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "lhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "fail_value",
@@ -851,12 +8242,12 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFloor",
-    "resultType" : "int",
+    "resultType" : "ImVec2",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "v",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -880,23 +8271,23 @@
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "a",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "b",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImRotate",
-    "resultType" : "int",
+    "resultType" : "ImVec2",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "v",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "cos_a",
@@ -931,17 +8322,17 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImMul",
-    "resultType" : "int",
+    "resultType" : "ImVec2",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "lhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "rhs",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
@@ -955,53 +8346,232 @@
     } ]
   }, {
     "@type" : "AstFunctionDecl",
-    "name" : "ImTriangleContainsPoint",
-    "resultType" : "int",
+    "name" : "ImBezierCubicCalc",
+    "resultType" : "ImVec2",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
-      "name" : "a",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "name" : "p1",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
-      "name" : "b",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "name" : "p2",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "name" : "p3",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p4",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "t",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helpers: Geometry"
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImBezierCubicClosestPoint",
+    "resultType" : "ImVec2",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "p1",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p2",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p3",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p4",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "p",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "num_segments",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImBezierCubicClosestPointCasteljau",
+    "resultType" : "ImVec2",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "p1",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p2",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p3",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p4",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "tess_tol",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImBezierQuadraticCalc",
+    "resultType" : "ImVec2",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "p1",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p2",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p3",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "t",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImLineClosestPoint",
+    "resultType" : "ImVec2",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "a",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "b",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImTriangleContainsPoint",
+    "resultType" : "bool",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "a",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "b",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImTriangleClosestPoint",
+    "resultType" : "ImVec2",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "a",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "b",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "c",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "p",
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImTriangleBarycentricCoords",
-    "resultType" : "int",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "a",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "b",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "c",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "p",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "out_u",
@@ -1025,18 +8595,33 @@
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "a",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "b",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "c",
-      "qualType" : "const int &",
-      "desugaredQualType" : "const int &"
+      "qualType" : "const ImVec2 &",
+      "desugaredQualType" : "const ImVec2 &"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImGetDirQuadrantFromDelta",
+    "resultType" : "ImGuiDir",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "dx",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "dy",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -1083,10 +8668,214 @@
       "desugaredQualType" : "short"
     } ]
   }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImRect",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper: ImRect (2D axis aligned bounding-box)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " NB: we can't rely on ImVec2 math operators being available here!"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Min",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Max",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCenter",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetSize",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWidth",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetHeight",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetArea",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTL",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTR",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetBL",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetBR",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Contains",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Contains",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Overlaps",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Add",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Add",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Expand",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "amount",
+        "qualType" : "const float",
+        "desugaredQualType" : "const float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Expand",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "amount",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Translate",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "d",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TranslateX",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dx",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TranslateY",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dy",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClipWith",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClipWithFull",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Floor",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsInverted",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ToVec4",
+      "resultType" : "ImVec4"
+    } ]
+  }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImBitArrayTestBit",
-    "resultType" : "int",
+    "resultType" : "bool",
     "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "arr",
+      "qualType" : "const ImU32 *",
+      "desugaredQualType" : "const ImU32 *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "n",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
       "@type" : "AstFullComment",
       "decls" : [ {
         "@type" : "AstParagraphComment",
@@ -1095,11 +8884,16 @@
           "text" : " Helper: ImBitArray"
         } ]
       } ]
-    }, {
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImBitArrayClearBit",
+    "resultType" : "void",
+    "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "arr",
-      "qualType" : "const int *",
-      "desugaredQualType" : "const int *"
+      "qualType" : "ImU32 *",
+      "desugaredQualType" : "ImU32 *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "n",
@@ -1107,13 +8901,194 @@
       "desugaredQualType" : "int"
     } ]
   }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImBitArraySetBit",
+    "resultType" : "void",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "arr",
+      "qualType" : "ImU32 *",
+      "desugaredQualType" : "ImU32 *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "n",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImBitArraySetBitRange",
+    "resultType" : "void",
+    "decls" : [ {
+      "@type" : "AstParmVarDecl",
+      "name" : "arr",
+      "qualType" : "ImU32 *",
+      "desugaredQualType" : "ImU32 *"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "n",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstParmVarDecl",
+      "name" : "n2",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImBitVector",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper: ImBitVector"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Store 1-bit per value."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Storage",
+      "qualType" : "ImVector<ImU32>",
+      "desugaredQualType" : "ImVector<unsigned int>"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Create",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "sz",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Clear",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TestBit",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetBit",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearBit",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawListSharedData",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Data shared between all ImDrawList instances"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " You may want to create your own instance of this if you want to use ImDrawList completely without ImGui. In that case, watch out for future changes to this structure."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexUvWhitePixel",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Font",
+      "qualType" : "ImFont *",
+      "desugaredQualType" : "ImFont *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurveTessellationTol",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CircleSegmentMaxError",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ClipRectFullscreen",
+      "qualType" : "ImVec4",
+      "desugaredQualType" : "ImVec4"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InitialFlags",
+      "qualType" : "ImDrawListFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ArcFastVtx",
+      "qualType" : "ImVec2[48]",
+      "desugaredQualType" : "ImVec2[48]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ArcFastRadiusCutoff",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CircleSegmentCounts",
+      "qualType" : "ImU8[64]",
+      "desugaredQualType" : "ImU8[64]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexUvLines",
+      "qualType" : "const ImVec4 *",
+      "desugaredQualType" : "const ImVec4 *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetCircleTessellationMaxError",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "max_error",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    } ]
+  }, {
     "@type" : "AstRecordDecl",
     "name" : "ImDrawDataBuilder",
     "decls" : [ {
       "@type" : "AstFieldDecl",
       "name" : "Layers",
-      "qualType" : "int[2]",
-      "desugaredQualType" : "int[2]"
+      "qualType" : "ImVector<ImDrawList *>[2]",
+      "desugaredQualType" : "ImVector<ImDrawList *>[2]"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "Clear",
@@ -1129,7 +9104,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "FlattenIntoSingleLayer",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1762,22 +9737,26 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLogType_TTY",
       "qualType" : "ImGuiLogType",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLogType_File",
       "qualType" : "ImGuiLogType",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLogType_Buffer",
       "qualType" : "ImGuiLogType",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiLogType_Clipboard",
       "qualType" : "ImGuiLogType",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1795,21 +9774,21 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiAxis_None",
       "qualType" : "ImGuiAxis",
-      "order" : -1,
+      "order" : 0,
       "value" : "-1",
       "evaluatedValue" : "-1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiAxis_X",
       "qualType" : "ImGuiAxis",
-      "order" : 0,
+      "order" : 1,
       "value" : "0",
       "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiAxis_Y",
       "qualType" : "ImGuiAxis",
-      "order" : 1,
+      "order" : 2,
       "value" : "1",
       "evaluatedValue" : "1"
     } ]
@@ -1820,12 +9799,14 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPlotType_Lines",
       "qualType" : "ImGuiPlotType",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPlotType_Histogram",
       "qualType" : "ImGuiPlotType",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1841,34 +9822,40 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Mouse",
       "qualType" : "ImGuiInputSource",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Keyboard",
       "qualType" : "ImGuiInputSource",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Gamepad",
       "qualType" : "ImGuiInputSource",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Nav",
       "docComment" : "Stored in g.ActiveIdSource only",
       "qualType" : "ImGuiInputSource",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_Clipboard",
       "docComment" : "Currently only used by InputText()",
       "qualType" : "ImGuiInputSource",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputSource_COUNT",
       "qualType" : "ImGuiInputSource",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1886,32 +9873,38 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_Down",
       "qualType" : "ImGuiInputReadMode",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_Pressed",
       "qualType" : "ImGuiInputReadMode",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_Released",
       "qualType" : "ImGuiInputReadMode",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_Repeat",
       "qualType" : "ImGuiInputReadMode",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_RepeatSlow",
       "qualType" : "ImGuiInputReadMode",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiInputReadMode_RepeatFast",
       "qualType" : "ImGuiInputReadMode",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1920,17 +9913,20 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupPositionPolicy_Default",
       "qualType" : "ImGuiPopupPositionPolicy",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupPositionPolicy_ComboBox",
       "qualType" : "ImGuiPopupPositionPolicy",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiPopupPositionPolicy_Tooltip",
       "qualType" : "ImGuiPopupPositionPolicy",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -1938,8 +9934,8 @@
     "decls" : [ {
       "@type" : "AstFieldDecl",
       "name" : "Data",
-      "qualType" : "int[8]",
-      "desugaredQualType" : "int[8]"
+      "qualType" : "ImU8[8]",
+      "desugaredQualType" : "ImU8[8]"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -1990,17 +9986,21 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_String",
       "qualType" : "ImGuiDataTypePrivate_",
-      "order" : 0
+      "order" : 0,
+      "value" : "ImGuiDataType_COUNT + 1",
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_Pointer",
       "qualType" : "ImGuiDataTypePrivate_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataType_ID",
       "qualType" : "ImGuiDataTypePrivate_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "13"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -2017,13 +10017,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Col",
-      "qualType" : "int",
+      "qualType" : "ImGuiCol",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "BackupValue",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec4",
+      "desugaredQualType" : "ImVec4"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -2040,8 +10040,387 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "VarIdx",
+      "qualType" : "ImGuiStyleVar",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiComboPreviewData",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Storage data for BeginComboPreview()/EndComboPreview()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PreviewRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupCursorPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupCursorMaxPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupCursorPosPrevLine",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupPrevLineTextBaseOffset",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupLayout",
+      "qualType" : "ImGuiLayoutType",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiGroupData",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Stacked storage data for BeginGroup()/EndGroup()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowID",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupCursorPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupCursorMaxPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupIndent",
+      "qualType" : "ImVec1",
+      "desugaredQualType" : "ImVec1"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupGroupOffset",
+      "qualType" : "ImVec1",
+      "desugaredQualType" : "ImVec1"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupCurrLineSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupCurrLineTextBaseOffset",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupActiveIdIsAlive",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupActiveIdPreviousFrameIsAlive",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupHoveredIdIsAlive",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "EmitItem",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiMenuColumns",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Simple column measurement, currently used for MenuItem() only.. This is very short-sighted/throw-away code and NOT a generic helper."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TotalWidth",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NextTotalWidth",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Spacing",
+      "qualType" : "ImU16",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OffsetIcon",
+      "qualType" : "ImU16",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OffsetLabel",
+      "qualType" : "ImU16",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OffsetShortcut",
+      "qualType" : "ImU16",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OffsetMark",
+      "qualType" : "ImU16",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Widths",
+      "qualType" : "ImU16[4]",
+      "desugaredQualType" : "ImU16[4]"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Update",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "spacing",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "window_reappearing",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DeclColumns",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "w_icon",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "w_label",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "w_shortcut",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "w_mark",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcNextTotalWidth",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "update_offsets",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiInputTextState",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Internal state of the currently focused/edited text input box"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " For a given item ID, access with ImGui::GetInputTextState()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ID",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurLenW",
       "qualType" : "int",
       "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurLenA",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TextW",
+      "qualType" : "ImVector<ImWchar>",
+      "desugaredQualType" : "ImVector<unsigned short>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TextA",
+      "qualType" : "ImVector<char>",
+      "desugaredQualType" : "ImVector<char>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InitialTextA",
+      "qualType" : "ImVector<char>",
+      "desugaredQualType" : "ImVector<char>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TextAIsValid",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BufCapacityA",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Stb",
+      "qualType" : "ImStb::STB_TexteditState",
+      "desugaredQualType" : "ImStb::STB_TexteditState"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CursorAnim",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CursorFollow",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SelectedAllMouseLock",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Edited",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImGuiInputTextFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearText",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearFreeMemory",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetUndoAvailCount",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetRedoAvailCount",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "OnKeyPressed",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CursorAnimReset",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Cursor "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "&"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Selection"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CursorClamp",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "HasSelection",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearSelection",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCursorPos",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetSelectionStart",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetSelectionEnd",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SelectAll",
+      "resultType" : "void"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -2058,8 +10437,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PopupId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Window",
@@ -2078,18 +10457,18 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "OpenParentId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "OpenPopupPos",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "OpenMousePos",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -2199,48 +10578,48 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PosCond",
-      "qualType" : "int",
+      "qualType" : "ImGuiCond",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SizeCond",
-      "qualType" : "int",
+      "qualType" : "ImGuiCond",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "CollapsedCond",
-      "qualType" : "int",
+      "qualType" : "ImGuiCond",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DockCond",
-      "qualType" : "int",
+      "qualType" : "ImGuiCond",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PosVal",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PosPivotVal",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SizeVal",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ContentSizeVal",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ScrollVal",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PosUndock",
@@ -2259,8 +10638,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SizeCallback",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiSizeCallback",
+      "desugaredQualType" : "void (*)(ImGuiSizeCallbackData *)"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SizeCallbackUserData",
@@ -2274,23 +10653,23 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ViewportId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DockId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WindowClass",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiWindowClass",
+      "desugaredQualType" : "ImGuiWindowClass"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "MenuBarOffsetMinVal",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ClearFlags",
@@ -2337,12 +10716,12 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "FocusScopeId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "OpenCond",
-      "qualType" : "int",
+      "qualType" : "ImGuiCond",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -2369,8 +10748,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "InFlags",
@@ -2396,6 +10775,63 @@
       "name" : "DisplayRect",
       "qualType" : "ImRect",
       "desugaredQualType" : "ImRect"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiStackSizes",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfIDStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfColorStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfStyleVarStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfFontStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfFocusScopeStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfGroupStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfItemFlagsStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfBeginPopupStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeOfDisabledStack",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetToCurrentState",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CompareWithCurrentState",
+      "resultType" : "void"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -2489,13 +10925,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PosToIndexOffsetMin",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PosToIndexOffsetMax",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "FromIndices",
@@ -2552,8 +10988,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ListClipper",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImGuiListClipper *",
+      "desugaredQualType" : "ImGuiListClipper *"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LossynessOffset",
@@ -2572,8 +11008,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Ranges",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiListClipperRange>",
+      "desugaredQualType" : "ImVector<ImGuiListClipperRange>"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "Reset",
@@ -2581,8 +11017,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "clipper",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImGuiListClipper *",
+        "desugaredQualType" : "ImGuiListClipper *"
       } ]
     } ]
   }, {
@@ -2939,7 +11375,8 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiNavLayer_COUNT",
       "qualType" : "ImGuiNavLayer",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -2952,13 +11389,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "FocusScopeId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "RectRel",
@@ -3121,8 +11558,8 @@
     "decls" : [ {
       "@type" : "AstFieldDecl",
       "name" : "ID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Flags",
@@ -3196,13 +11633,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Columns",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiOldColumnData>",
+      "desugaredQualType" : "ImVector<ImGuiOldColumnData>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Splitter",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImDrawListSplitter",
+      "desugaredQualType" : "ImDrawListSplitter"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -3339,12 +11776,16 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_NoResizeFlagsMask_",
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
-      "order" : 15
+      "order" : 15,
+      "value" : "ImGuiDockNodeFlags_NoResize | ImGuiDockNodeFlags_NoResizeX | ImGuiDockNodeFlags_NoResizeY",
+      "evaluatedValue" : "12582944"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_LocalFlagsMask_",
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
-      "order" : 16
+      "order" : 16,
+      "value" : "ImGuiDockNodeFlags_NoSplit | ImGuiDockNodeFlags_NoResizeFlagsMask_ | ImGuiDockNodeFlags_AutoHideTabBar | ImGuiDockNodeFlags_DockSpace | ImGuiDockNodeFlags_CentralNode | ImGuiDockNodeFlags_NoTabBar | ImGuiDockNodeFlags_HiddenTabBar | ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_NoCloseButton | ImGuiDockNodeFlags_NoDocking",
+      "evaluatedValue" : "12713072"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_LocalFlagsTransferMask_",
@@ -3352,14 +11793,14 @@
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 17,
       "value" : "ImGuiDockNodeFlags_LocalFlagsMask_ & ~ImGuiDockNodeFlags_DockSpace",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : "12712048"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeFlags_SavedFlagsMask_",
       "qualType" : "ImGuiDockNodeFlagsPrivate_",
       "order" : 18,
       "value" : "ImGuiDockNodeFlags_NoResizeFlagsMask_ | ImGuiDockNodeFlags_DockSpace | ImGuiDockNodeFlags_CentralNode | ImGuiDockNodeFlags_NoTabBar | ImGuiDockNodeFlags_HiddenTabBar | ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_NoCloseButton | ImGuiDockNodeFlags_NoDocking",
-      "evaluatedValue" : "130048"
+      "evaluatedValue" : "12712992"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -3377,17 +11818,20 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataAuthority_Auto",
       "qualType" : "ImGuiDataAuthority_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataAuthority_DockNode",
       "qualType" : "ImGuiDataAuthority_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDataAuthority_Window",
       "qualType" : "ImGuiDataAuthority_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -3396,22 +11840,298 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeState_Unknown",
       "qualType" : "ImGuiDockNodeState",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeState_HostWindowHiddenBecauseSingleWindow",
       "qualType" : "ImGuiDockNodeState",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeState_HostWindowHiddenBecauseWindowsAreResizing",
       "qualType" : "ImGuiDockNodeState",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiDockNodeState_HostWindowVisible",
       "qualType" : "ImGuiDockNodeState",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiDockNode",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " sizeof() 156~192"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ID",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SharedFlags",
+      "qualType" : "ImGuiDockNodeFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LocalFlags",
+      "qualType" : "ImGuiDockNodeFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LocalFlagsInWindows",
+      "qualType" : "ImGuiDockNodeFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MergedFlags",
+      "qualType" : "ImGuiDockNodeFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "State",
+      "qualType" : "ImGuiDockNodeState",
+      "desugaredQualType" : "ImGuiDockNodeState"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ParentNode",
+      "qualType" : "ImGuiDockNode *",
+      "desugaredQualType" : "ImGuiDockNode *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ChildNodes",
+      "qualType" : "ImGuiDockNode *[2]",
+      "desugaredQualType" : "ImGuiDockNode *[2]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Windows",
+      "qualType" : "ImVector<ImGuiWindow *>",
+      "desugaredQualType" : "ImVector<ImGuiWindow *>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TabBar",
+      "qualType" : "ImGuiTabBar *",
+      "desugaredQualType" : "ImGuiTabBar *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Pos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Size",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeRef",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SplitAxis",
+      "qualType" : "ImGuiAxis",
+      "desugaredQualType" : "ImGuiAxis"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowClass",
+      "qualType" : "ImGuiWindowClass",
+      "desugaredQualType" : "ImGuiWindowClass"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastBgColor",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostWindow",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "VisibleWindow",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CentralNode",
+      "qualType" : "ImGuiDockNode *",
+      "desugaredQualType" : "ImGuiDockNode *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OnlyNodeWithWindows",
+      "qualType" : "ImGuiDockNode *",
+      "desugaredQualType" : "ImGuiDockNode *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CountNodeWithWindows",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastFrameAlive",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastFrameActive",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastFrameFocused",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastFocusedNodeId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SelectedTabId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantCloseTabId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AuthorityForPos",
+      "qualType" : "ImGuiDataAuthority",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AuthorityForSize",
+      "qualType" : "ImGuiDataAuthority",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AuthorityForViewport",
+      "qualType" : "ImGuiDataAuthority",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsVisible",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsFocused",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsBgDrawnThisFrame",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HasCloseButton",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HasWindowMenuButton",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HasCentralNodeChild",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantCloseAll",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantLockSizeOnce",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantMouseMove",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantHiddenTabBarUpdate",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantHiddenTabBarToggle",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsRootNode",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsDockSpace",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsFloatingNode",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsCentralNode",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsHiddenTabBar",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsNoTabBar",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsSplitNode",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsLeafNode",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsEmpty",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Rect",
+      "resultType" : "ImRect"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetLocalFlags",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiDockNodeFlags",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "UpdateMergedFlags",
+      "resultType" : "void"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -3438,37 +12158,44 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_Text",
       "qualType" : "ImGuiWindowDockStyleCol",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_Tab",
       "qualType" : "ImGuiWindowDockStyleCol",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_TabHovered",
       "qualType" : "ImGuiWindowDockStyleCol",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_TabActive",
       "qualType" : "ImGuiWindowDockStyleCol",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_TabUnfocused",
       "qualType" : "ImGuiWindowDockStyleCol",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_TabUnfocusedActive",
       "qualType" : "ImGuiWindowDockStyleCol",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiWindowDockStyleCol_COUNT",
       "qualType" : "ImGuiWindowDockStyleCol",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -3476,8 +12203,8 @@
     "decls" : [ {
       "@type" : "AstFieldDecl",
       "name" : "Colors",
-      "qualType" : "int[6]",
-      "desugaredQualType" : "int[6]"
+      "qualType" : "ImU32[6]",
+      "desugaredQualType" : "ImU32[6]"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -3485,18 +12212,18 @@
     "decls" : [ {
       "@type" : "AstFieldDecl",
       "name" : "Nodes",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiStorage",
+      "desugaredQualType" : "ImGuiStorage"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Requests",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiDockRequest>",
+      "desugaredQualType" : "ImVector<ImGuiDockRequest>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NodesSettings",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiDockNodeSettings>",
+      "desugaredQualType" : "ImVector<ImGuiDockNodeSettings>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WantFullRebuild",
@@ -3536,13 +12263,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LastNameHash",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LastPos",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Alpha",
@@ -3576,13 +12303,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DrawLists",
-      "qualType" : "int *[2]",
-      "desugaredQualType" : "int *[2]"
+      "qualType" : "ImDrawList *[2]",
+      "desugaredQualType" : "ImDrawList *[2]"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DrawDataP",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImDrawData",
+      "desugaredQualType" : "ImDrawData"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DrawDataBuilder",
@@ -3591,38 +12318,38 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LastPlatformPos",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LastPlatformSize",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LastRendererSize",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WorkOffsetMin",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WorkOffsetMax",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "BuildWorkOffsetMin",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "BuildWorkOffsetMax",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ClearRequestFlags",
@@ -3630,8 +12357,13 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "CalcWorkRectPos",
-      "resultType" : "int",
+      "resultType" : "ImVec2",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "off_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3640,26 +12372,21 @@
             "text" : " Calculate work rect pos/size given a set of offset (we have 1 pair of offset for rect locked from last frame data, and 1 pair for currently building rect)"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "off_min",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "CalcWorkRectSize",
-      "resultType" : "int",
+      "resultType" : "ImVec2",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "off_min",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "off_max",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3709,8 +12436,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Pos",
@@ -3729,18 +12456,18 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ViewportId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DockId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ClassId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DockOrder",
@@ -3772,8 +12499,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "TypeHash",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ClearAllFn",
@@ -3802,8 +12529,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WriteAllFn",
-      "qualType" : "void (*)(ImGuiContext *, ImGuiSettingsHandler *, int *)",
-      "desugaredQualType" : "void (*)(ImGuiContext *, ImGuiSettingsHandler *, int *)"
+      "qualType" : "void (*)(ImGuiContext *, ImGuiSettingsHandler *, ImGuiTextBuffer *)",
+      "desugaredQualType" : "void (*)(ImGuiContext *, ImGuiSettingsHandler *, ImGuiTextBuffer *)"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "UserData",
@@ -3880,13 +12607,13 @@
     "decls" : [ {
       "@type" : "AstFieldDecl",
       "name" : "ID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "QueryFrameCount",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "QuerySuccess",
@@ -3923,13 +12650,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "QueryId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Results",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiStackLevelInfo>",
+      "desugaredQualType" : "ImVector<ImGuiStackLevelInfo>"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -3938,42 +12665,50 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_NewFramePre",
       "qualType" : "ImGuiContextHookType",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_NewFramePost",
       "qualType" : "ImGuiContextHookType",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_EndFramePre",
       "qualType" : "ImGuiContextHookType",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_EndFramePost",
       "qualType" : "ImGuiContextHookType",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_RenderPre",
       "qualType" : "ImGuiContextHookType",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_RenderPost",
       "qualType" : "ImGuiContextHookType",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_Shutdown",
       "qualType" : "ImGuiContextHookType",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiContextHookType_PendingRemoval_",
       "qualType" : "ImGuiContextHookType",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -3981,8 +12716,8 @@
     "decls" : [ {
       "@type" : "AstFieldDecl",
       "name" : "HookId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Type",
@@ -3991,8 +12726,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Owner",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Callback",
@@ -4035,33 +12770,33 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "IO",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiIO",
+      "desugaredQualType" : "ImGuiIO"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PlatformIO",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiPlatformIO",
+      "desugaredQualType" : "ImGuiPlatformIO"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Style",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiStyle",
+      "desugaredQualType" : "ImGuiStyle"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ConfigFlagsCurrFrame",
-      "qualType" : "int",
+      "qualType" : "ImGuiConfigFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ConfigFlagsLastFrame",
-      "qualType" : "int",
+      "qualType" : "ImGuiConfigFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Font",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFont *",
+      "desugaredQualType" : "ImFont *"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "FontSize",
@@ -4135,28 +12870,28 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Windows",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiWindow *>",
+      "desugaredQualType" : "ImVector<ImGuiWindow *>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WindowsFocusOrder",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiWindow *>",
+      "desugaredQualType" : "ImVector<ImGuiWindow *>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WindowsTempSortBuffer",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiWindow *>",
+      "desugaredQualType" : "ImVector<ImGuiWindow *>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "CurrentWindowStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiWindowStackData>",
+      "desugaredQualType" : "ImVector<ImGuiWindowStackData>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WindowsById",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiStorage",
+      "desugaredQualType" : "ImGuiStorage"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WindowsActiveCount",
@@ -4165,8 +12900,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WindowsHoverPadding",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "CurrentWindow",
@@ -4200,8 +12935,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WheelingWindowRefMousePos",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WheelingWindowTimer",
@@ -4210,18 +12945,18 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DebugHookIdInfo",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "HoveredId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "HoveredIdPreviousFrame",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "HoveredIdAllowOverlap",
@@ -4255,13 +12990,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdIsAlive",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdTimer",
@@ -4305,23 +13040,23 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdUsingNavDirMask",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdUsingNavInputMask",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdUsingKeyInputMask",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdClickOffset",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdWindow",
@@ -4340,8 +13075,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdPreviousFrame",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ActiveIdPreviousFrameIsAlive",
@@ -4360,8 +13095,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LastActiveId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LastActiveIdTimer",
@@ -4390,43 +13125,43 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ColorStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiColorMod>",
+      "desugaredQualType" : "ImVector<ImGuiColorMod>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "StyleVarStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiStyleMod>",
+      "desugaredQualType" : "ImVector<ImGuiStyleMod>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "FontStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImFont *>",
+      "desugaredQualType" : "ImVector<ImFont *>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "FocusScopeStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiID>",
+      "desugaredQualType" : "ImVector<unsigned int>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ItemFlagsStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiItemFlags>",
+      "desugaredQualType" : "ImVector<int>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "GroupStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiGroupData>",
+      "desugaredQualType" : "ImVector<ImGuiGroupData>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "OpenPopupStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiPopupData>",
+      "desugaredQualType" : "ImVector<ImGuiPopupData>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "BeginPopupStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiPopupData>",
+      "desugaredQualType" : "ImVector<ImGuiPopupData>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "BeginMenuCount",
@@ -4435,8 +13170,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Viewports",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiViewportP *>",
+      "desugaredQualType" : "ImVector<ImGuiViewportP *>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "CurrentDpiScale",
@@ -4460,13 +13195,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PlatformLastFocusedViewportId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "FallbackMonitor",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiPlatformMonitor",
+      "desugaredQualType" : "ImGuiPlatformMonitor"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ViewportFrontMostStampCount",
@@ -4480,33 +13215,33 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavFocusScopeId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavActivateId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavActivateDownId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavActivatePressedId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavActivateInputId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavActivateFlags",
@@ -4515,23 +13250,23 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavJustMovedToId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavJustMovedToFocusScopeId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavJustMovedToKeyMods",
-      "qualType" : "int",
+      "qualType" : "ImGuiKeyModFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavNextActivateId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavNextActivateFlags",
@@ -4585,8 +13320,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavInitResultId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavInitResultRectRel",
@@ -4620,22 +13355,22 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavMoveKeyMods",
-      "qualType" : "int",
+      "qualType" : "ImGuiKeyModFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavMoveDir",
-      "qualType" : "int",
+      "qualType" : "ImGuiDir",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavMoveDirForDebug",
-      "qualType" : "int",
+      "qualType" : "ImGuiDir",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavMoveClipDir",
-      "qualType" : "int",
+      "qualType" : "ImGuiDir",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -4720,7 +13455,7 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "MouseCursor",
-      "qualType" : "int",
+      "qualType" : "ImGuiMouseCursor",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -4740,7 +13475,7 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropSourceFlags",
-      "qualType" : "int",
+      "qualType" : "ImGuiDragDropFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -4755,8 +13490,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropPayload",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiPayload",
+      "desugaredQualType" : "ImGuiPayload"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropTargetRect",
@@ -4765,12 +13500,12 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropTargetId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropAcceptFlags",
-      "qualType" : "int",
+      "qualType" : "ImGuiDragDropFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -4780,13 +13515,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropAcceptIdCurr",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropAcceptIdPrev",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropAcceptFrameCount",
@@ -4795,13 +13530,13 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropHoldJustPressedId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropPayloadBufHeap",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<unsigned char>",
+      "desugaredQualType" : "ImVector<unsigned char>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DragDropPayloadBufLocal",
@@ -4815,8 +13550,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ClipperTempData",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiListClipperData>",
+      "desugaredQualType" : "ImVector<ImGuiListClipperData>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "CurrentTable",
@@ -4830,23 +13565,23 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "TablesTempData",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiTableTempData>",
+      "desugaredQualType" : "ImVector<ImGuiTableTempData>"
     }, {
       "@type" : "AstFieldDecl",
-      "name" : "ImPool",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "name" : "Tables",
+      "qualType" : "ImPool<ImGuiTable>",
+      "desugaredQualType" : "ImPool<ImGuiTable>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "TablesLastTimeActive",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<float>",
+      "desugaredQualType" : "ImVector<float>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DrawChannelsTempMergeBuffer",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImDrawChannel>",
+      "desugaredQualType" : "ImVector<ImDrawChannel>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "CurrentTabBar",
@@ -4855,23 +13590,23 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "TabBars",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImPool<ImGuiTabBar>",
+      "desugaredQualType" : "ImPool<ImGuiTabBar>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "CurrentTabBarStack",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiPtrOrIndex>",
+      "desugaredQualType" : "ImVector<ImGuiPtrOrIndex>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ShrinkWidthBuffer",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiShrinkWidthItem>",
+      "desugaredQualType" : "ImVector<ImGuiShrinkWidthItem>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "MouseLastValidPos",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "InputTextState",
@@ -4880,17 +13615,17 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "InputTextPasswordFont",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImFont",
+      "desugaredQualType" : "ImFont"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "TempInputId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ColorEditOptions",
-      "qualType" : "int",
+      "qualType" : "ImGuiColorEditFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -4905,18 +13640,18 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ColorEditLastColor",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ColorPickerRef",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec4",
+      "desugaredQualType" : "ImVec4"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ComboPreviewData",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiComboPreviewData",
+      "desugaredQualType" : "ImGuiComboPreviewData"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SliderCurrentAccum",
@@ -4970,23 +13705,23 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ClipboardHandlerData",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<char>",
+      "desugaredQualType" : "ImVector<char>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "MenusIdSubmittedThisFrame",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiID>",
+      "desugaredQualType" : "ImVector<unsigned int>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PlatformImePos",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PlatformImeLastPos",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PlatformImePosViewport",
@@ -5015,33 +13750,33 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SettingsIniData",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiTextBuffer",
+      "desugaredQualType" : "ImGuiTextBuffer"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SettingsHandlers",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiSettingsHandler>",
+      "desugaredQualType" : "ImVector<ImGuiSettingsHandler>"
     }, {
       "@type" : "AstFieldDecl",
-      "name" : "ImChunkStream",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "name" : "SettingsWindows",
+      "qualType" : "ImChunkStream<ImGuiWindowSettings>",
+      "desugaredQualType" : "ImChunkStream<ImGuiWindowSettings>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SettingsTables",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImChunkStream<ImGuiTableSettings>",
+      "desugaredQualType" : "ImChunkStream<ImGuiTableSettings>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Hooks",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImVector<ImGuiContextHook>",
+      "desugaredQualType" : "ImVector<ImGuiContextHook>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "HookIdNext",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LogEnabled",
@@ -5060,8 +13795,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LogBuffer",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiTextBuffer",
+      "desugaredQualType" : "ImGuiTextBuffer"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "LogNextPrefix",
@@ -5105,8 +13840,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DebugItemPickerBreakId",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DebugMetricsConfig",
@@ -5160,6 +13895,3330 @@
     } ]
   }, {
     "@type" : "AstEnumDecl",
+    "name" : "ImGuiWindowFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::Begin()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_None",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 0,
+      "value" : "a",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoTitleBar",
+      "docComment" : "Disable title-bar",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 1,
+      "value" : "emFlag",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoResize",
+      "docComment" : "Disable user resizing with the lower-right grip",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 2,
+      "value" : "upStac",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoMove",
+      "docComment" : "Disable user moving the window",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 3,
+      "value" : "or<ImG",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoScrollbar",
+      "docComment" : "Disable scrollbars (window can still scroll with mouse or programmatically)",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 4,
+      "value" : ")\n    ",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoScrollWithMouse",
+      "docComment" : "Disable user vertically scrolling with mouse wheel. On child window, mouse wheel will be forwarded to the parent unless NoScrollbar is also set.",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 5,
+      "value" : "      ",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoCollapse",
+      "docComment" : "Disable user collapsing window by double-clicking on it. Also referred to as Window Menu Button (e.g. within a docking node).",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 6,
+      "value" : "ach vi",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_AlwaysAutoResize",
+      "docComment" : "Resize every window to its content every frame",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 7,
+      "value" : "      ",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoBackground",
+      "docComment" : "Disable drawing background color (WindowBg, etc.) and outside border. Similar as using SetNextWindowBgAlpha(0.0f).",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 8,
+      "value" : "Viewpo",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoSavedSettings",
+      "docComment" : "Never load/save settings in .ini file",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 9,
+      "value" : "f we a",
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoMouseInputs",
+      "docComment" : "Disable catching mouse, hovering test with pass through.",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 10,
+      "value" : "      ",
+      "evaluatedValue" : "512"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_MenuBar",
+      "docComment" : "Has a menu-bar",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 11,
+      "value" : "itor us",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_HorizontalScrollbar",
+      "docComment" : "Allow horizontal scrollbar to appear (off by default). You may use SetNextWindowContentSize(ImVec2(width,0.0f)); prior to calling Begin() to specify width. Read code in imgui_demo in the \"Horizontal Scrolling\" section.",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 12,
+      "value" : "int    ",
+      "evaluatedValue" : "2048"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoFocusOnAppearing",
+      "docComment" : "Disable taking focus when transitioning from hidden to visible state",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 13,
+      "value" : "navigat",
+      "evaluatedValue" : "4096"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoBringToFrontOnFocus",
+      "docComment" : "Disable bringing window to front when taking focus (e.g. clicking on it or programmatically giving it focus)",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 14,
+      "value" : "vigatio",
+      "evaluatedValue" : "8192"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_AlwaysVerticalScrollbar",
+      "docComment" : "Always show vertical scrollbar (even if ContentSize.y < Size.y)",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 15,
+      "value" : "n an it",
+      "evaluatedValue" : "16384"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_AlwaysHorizontalScrollbar",
+      "docComment" : "Always show horizontal scrollbar (even if ContentSize.x < Size.x)",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 16,
+      "value" : "sNavIn",
+      "evaluatedValue" : "32768"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_AlwaysUseWindowPadding",
+      "docComment" : "Ensure child windows without border uses style.WindowPadding (ignored by default for non-bordered child windows, because more convenient)",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 17,
+      "value" : "tivateD",
+      "evaluatedValue" : "65536"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoNavInputs",
+      "docComment" : "No gamepad/keyboard navigation within the window",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 18,
+      "value" : "e) ? Na",
+      "evaluatedValue" : "262144"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoNavFocus",
+      "docComment" : "No focusing toward this window with gamepad/keyboard navigation (e.g. skipped by CTRL+TAB)",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 19,
+      "value" : "NavInpu",
+      "evaluatedValue" : "524288"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_UnsavedDocument",
+      "docComment" : "Display a dot next to the title. When used in a tab/docking context, tab is selected when clicking the X + closure is not assumed (will wait for user to stop submitting the tab). Otherwise closure is assumed when pressing the X, so if you keep submitting the tab may reappear at end of tab bar.",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 20,
+      "value" : " ImGuiI",
+      "evaluatedValue" : "1048576"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoDocking",
+      "docComment" : "Disable docking of this window",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 21,
+      "value" : "NavNext",
+      "evaluatedValue" : "2097152"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoNav",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 22,
+      "value" : "ImGuiActivateFlags      NavNextActivateFlags;\n    ImGuiInp",
+      "evaluatedValue" : "786432"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoDecoration",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 23,
+      "value" : "    // Keyboard or Gamepad mode? THIS WILL ONLY BE None or NavGamepad or NavKeyboard.\n    ImGuiNavLayer           Na",
+      "evaluatedValue" : "43"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NoInputs",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 24,
+      "value" : "e navigating on. For now the system is hard-coded for 0=main contents and 1=menu/title bar,",
+      "evaluatedValue" : "786944"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_NavFlattened",
+      "docComment" : "[BETA] On child window: allow gamepad/keyboard navigation to cross over parent border to this child or between sibling child windows.",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 25,
+      "value" : "       ",
+      "evaluatedValue" : "8388608"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_ChildWindow",
+      "docComment" : "Don't use! For internal use by BeginChild()",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 26,
+      "value" : " (io.Co",
+      "evaluatedValue" : "16777216"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_Tooltip",
+      "docComment" : "Don't use! For internal use by BeginTooltip()",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 27,
+      "value" : "bool   ",
+      "evaluatedValue" : "33554432"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_Popup",
+      "docComment" : "Don't use! For internal use by BeginPopup()",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 28,
+      "value" : "pad/key",
+      "evaluatedValue" : "67108864"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_Modal",
+      "docComment" : "Don't use! For internal use by BeginPopupModal()",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 29,
+      "value" : " != Nav",
+      "evaluatedValue" : "134217728"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_ChildMenu",
+      "docComment" : "Don't use! For internal use by BeginMenu()",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 30,
+      "value" : "s using",
+      "evaluatedValue" : "268435456"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiWindowFlags_DockNodeHost",
+      "docComment" : "Don't use! For internal use by Begin()/NewFrame()",
+      "qualType" : "ImGuiWindowFlags_",
+      "order" : 31,
+      "value" : "ation: ",
+      "evaluatedValue" : "536870912"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiInputTextFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::InputText()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_None",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 0,
+      "value" : " ",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CharsDecimal",
+      "docComment" : "Allow 0123456789.+-*/",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 1,
+      "value" : " windo",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CharsHexadecimal",
+      "docComment" : "Allow 0123456789ABCDEFabcdef",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 2,
+      "value" : "      ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CharsUppercase",
+      "docComment" : "Turn a..z into A..Z",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 3,
+      "value" : " paren",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CharsNoBlank",
+      "docComment" : "Filter out spaces, tabs",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 4,
+      "value" : " // Mo",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_AutoSelectAll",
+      "docComment" : "Select entire text when first taking mouse focus",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 5,
+      "value" : "      ",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_EnterReturnsTrue",
+      "docComment" : "Return 'true' when Enter is pressed (as opposed to every time the value was modified). Consider looking at the IsItemDeactivatedAfterEdit() function.",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 6,
+      "value" : "bool  ",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CallbackCompletion",
+      "docComment" : "Callback on pressing TAB (for completion handling)",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 7,
+      "value" : "    Na",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CallbackHistory",
+      "docComment" : "Callback on pressing Up/Down arrows (for history handling)",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 8,
+      "value" : "      ",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CallbackAlways",
+      "docComment" : "Callback on each iteration. User code may query cursor position, modify text buffer.",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 9,
+      "value" : " the p",
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CallbackCharFilter",
+      "docComment" : "Callback on character inputs to replace or discard them. Modify 'EventChar' to replace or discard, or return 1 in callback to discard.",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 10,
+      "value" : ", in s",
+      "evaluatedValue" : "512"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_AllowTabInput",
+      "docComment" : "Pressing TAB input a ' ' character into the text field",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 11,
+      "value" : "eUp/Pag",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CtrlEnterForNewLine",
+      "docComment" : "In multi-line mode, unfocus with Enter, add new line with Ctrl+Enter (default is opposite: unfocus with Ctrl+Enter, add line with Enter).",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 12,
+      "value" : "coringD",
+      "evaluatedValue" : "2048"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_NoHorizontalScroll",
+      "docComment" : "Disable following the cursor horizontally",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 13,
+      "value" : "       ",
+      "evaluatedValue" : "4096"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_AlwaysOverwrite",
+      "docComment" : "Overwrite mode",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 14,
+      "value" : "       ",
+      "evaluatedValue" : "8192"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_ReadOnly",
+      "docComment" : "Read-only mode",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 15,
+      "value" : " within",
+      "evaluatedValue" : "16384"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_Password",
+      "docComment" : "Password mode, display all characters as '*'",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 16,
+      "value" : "       ",
+      "evaluatedValue" : "32768"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_NoUndoRedo",
+      "docComment" : "Disable undo/redo. Note that input text owns the text data while active, if you want to provide your own undo/redo stack you need e.g. to call ClearActiveID().",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 17,
+      "value" : "Flags_A",
+      "evaluatedValue" : "65536"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CharsScientific",
+      "docComment" : "Allow 0123456789.+-*/eE (Scientific notation input)",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 18,
+      "value" : "mGuiNav",
+      "evaluatedValue" : "131072"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CallbackResize",
+      "docComment" : "Callback on buffer capacity changes request (beyond 'buf_size' parameter value), allowing the string to grow. Notify when the string wants to be resized (for string types which hold a cache of their Size). You will be provided a new BufSize in the callback and NEED to honor it. (see misc/cpp/imgui_stdlib.h for an example of using this)",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 19,
+      "value" : "and fla",
+      "evaluatedValue" : "262144"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_CallbackEdit",
+      "docComment" : "Callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active)",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 20,
+      "value" : "id NavW",
+      "evaluatedValue" : "524288"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiInputTextFlags_AlwaysInsertMode",
+      "docComment" : "[renamed in 1.82] name was not matching behavior",
+      "qualType" : "ImGuiInputTextFlags_",
+      "order" : 21,
+      "value" : "  NavWindowingHighlightAlpha;\n    b",
+      "evaluatedValue" : "8192"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiTreeNodeFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::TreeNodeEx(), ImGui::CollapsingHeader*()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_None",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 0,
+      "value" : "o",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_Selected",
+      "docComment" : "Draw as selected",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 1,
+      "value" : " Mouse",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_Framed",
+      "docComment" : "Draw frame with background (e.g. for CollapsingHeader)",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 2,
+      "value" : "ve;\n  ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_AllowItemOverlap",
+      "docComment" : "Hit testing to allow subsequent widgets to overlap this one",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 3,
+      "value" : "ropXXX",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_NoTreePushOnOpen",
+      "docComment" : "Don't do a TreePush() when open (e.g. for CollapsingHeader) = no extra indent nor pushing on ID stack",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 4,
+      "value" : "ginDra",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_NoAutoOpenOnLog",
+      "docComment" : "Don't automatically and temporarily open node when Logging is active (by default logging will automatically open tree nodes)",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 5,
+      "value" : " int  ",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_DefaultOpen",
+      "docComment" : "Default node to be open",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 6,
+      "value" : " targe",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_OpenOnDoubleClick",
+      "docComment" : "Need double-click to open node",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 7,
+      "value" : "     D",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_OpenOnArrow",
+      "docComment" : "Only open when clicking on the arrow part. If ImGuiTreeNodeFlags_OpenOnDoubleClick is also set, single-click arrow or double-click all box to open.",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 8,
+      "value" : "      ",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_Leaf",
+      "docComment" : "No collapsing, no arrow (use as a convenience for leaf nodes).",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 9,
+      "value" : "rget i",
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_Bullet",
+      "docComment" : "Display a bullet instead of arrow",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 10,
+      "value" : " Targe",
+      "evaluatedValue" : "512"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_FramePadding",
+      "docComment" : "Use FramePadding (even for an unframed text node) to vertically align text baseline to regular widget height. Equivalent to calling AlignTextToFramePadding().",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 11,
+      "value" : "drop ta",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_SpanAvailWidth",
+      "docComment" : "Extend hit box to the right-most edge, even if not framed. This is not the default in order to allow adding other items on the same line. In the future we may refactor the hit system to be front-to-back, allowing natural overlaps and then this can become the default.",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 12,
+      "value" : "lding a",
+      "evaluatedValue" : "2048"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_SpanFullWidth",
+      "docComment" : "Extend hit box to the left-most and right-most edges (bypass the indented area).",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 13,
+      "value" : "       ",
+      "evaluatedValue" : "4096"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_NavLeftJumpsBackHere",
+      "docComment" : "(WIP) Nav: left direction may move to this TreeNode() from any of its child (items submitted between TreeNode and TreePop)",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 14,
+      "value" : "       ",
+      "evaluatedValue" : "8192"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTreeNodeFlags_CollapsingHeader",
+      "docComment" : "ImGuiTreeNodeFlags_NoScrollOnOpen     = 1 < < 14,  // FIXME: TODO: Disable automatic scroll on TreePop() if node got just open and contents is not visible",
+      "qualType" : "ImGuiTreeNodeFlags_",
+      "order" : 15,
+      "value" : "es, support nesting)\n    ImPool<ImGuiTable>              Tables;                     // Persistent t",
+      "evaluatedValue" : "26"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiPopupFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for OpenPopup*(), BeginPopupContext*(), IsPopupOpen() functions."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - To be backward compatible with older API which took an 'int mouse_button = 1' argument, we need to treat"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   small flags values as a mouse button index, so we encode the mouse button in the first few bits of the flags."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   It is therefore guaranteed to be legal to pass a mouse button index in ImGuiPopupFlags."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - For the same reason, we exceptionally default the ImGuiPopupFlags argument of BeginPopupContextXXX functions to 1 instead of 0."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   IMPORTANT: because the default parameter is 1 (==ImGuiPopupFlags_MouseButtonRight), if you rely on the default parameter"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   and want to another another flag, you need to pass in the ImGuiPopupFlags_MouseButtonRight flag."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Multiple buttons currently cannot be combined/or-ed in those functions (we could allow it later)."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_None",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 0,
+      "value" : ",",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_MouseButtonLeft",
+      "docComment" : "For BeginPopupContext*(): open on Left Mouse release. Guaranteed to always be == 0 (same as ImGuiMouseButton_Left)",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 1,
+      "value" : "r",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_MouseButtonRight",
+      "docComment" : "For BeginPopupContext*(): open on Right Mouse release. Guaranteed to always be == 1 (same as ImGuiMouseButton_Right)",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 2,
+      "value" : "d",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_MouseButtonMiddle",
+      "docComment" : "For BeginPopupContext*(): open on Middle Mouse release. Guaranteed to always be == 2 (same as ImGuiMouseButton_Middle)",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 3,
+      "value" : "t",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_MouseButtonMask_",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 4,
+      "value" : "umul",
+      "evaluatedValue" : "31"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_MouseButtonDefault_",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 5,
+      "value" : ".",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_NoOpenOverExistingPopup",
+      "docComment" : "For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 6,
+      "value" : "irty; ",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_NoOpenOverItems",
+      "docComment" : "For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 7,
+      "value" : "    Dr",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_AnyPopupId",
+      "docComment" : "For IsPopupOpen(): ignore the ImGuiID parameter and test for any popup.",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 8,
+      "value" : "      ",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_AnyPopupLevel",
+      "docComment" : "For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level)",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 9,
+      "value" : "      ",
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiPopupFlags_AnyPopup",
+      "qualType" : "ImGuiPopupFlags_",
+      "order" : 10,
+      "value" : "      DisabledAlphaBackup;                // Backup for st",
+      "evaluatedValue" : "384"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiSelectableFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::Selectable()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSelectableFlags_None",
+      "qualType" : "ImGuiSelectableFlags_",
+      "order" : 0,
+      "value" : "v",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSelectableFlags_DontClosePopups",
+      "docComment" : "Clicking this don't close parent popup window",
+      "qualType" : "ImGuiSelectableFlags_",
+      "order" : 1,
+      "value" : "SlowDe",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSelectableFlags_SpanAllColumns",
+      "docComment" : "Selectable frame can span all columns (text will still fit in current column)",
+      "qualType" : "ImGuiSelectableFlags_",
+      "order" : 2,
+      "value" : "e in t",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSelectableFlags_AllowDoubleClick",
+      "docComment" : "Generate press events on double clicks too",
+      "qualType" : "ImGuiSelectableFlags_",
+      "order" : 3,
+      "value" : "fined\n",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSelectableFlags_Disabled",
+      "docComment" : "Cannot be selected, display grayed out text",
+      "qualType" : "ImGuiSelectableFlags_",
+      "order" : 4,
+      "value" : "render",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSelectableFlags_AllowItemOverlap",
+      "docComment" : "(WIP) Hit testing to allow subsequent widgets to overlap this one",
+      "qualType" : "ImGuiSelectableFlags_",
+      "order" : 5,
+      "value" : "      ",
+      "evaluatedValue" : "16"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiComboFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::BeginCombo()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_None",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 0,
+      "value" : "a",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_PopupAlignLeft",
+      "docComment" : "Align the popup toward the left by default",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 1,
+      "value" : "      ",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_HeightSmall",
+      "docComment" : "Max ~4 items visible. Tip: If you want your combo popup to be a specific size you can use SetNextWindowSizeConstraints() prior to calling BeginCombo()",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 2,
+      "value" : "PI to ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_HeightRegular",
+      "docComment" : "Max ~8 items visible (default)",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 3,
+      "value" : "      ",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_HeightLarge",
+      "docComment" : "Max ~20 items visible",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 4,
+      "value" : "      ",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_HeightLargest",
+      "docComment" : "As many fitting items as possible",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 5,
+      "value" : "r<ImGu",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_NoArrowButton",
+      "docComment" : "Display on the preview box without the square arrow button",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 6,
+      "value" : "ChunkS",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_NoPreview",
+      "docComment" : "Display only a square arrow button",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 7,
+      "value" : "TableS",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiComboFlags_HeightMask_",
+      "qualType" : "ImGuiComboFlags_",
+      "order" : 8,
+      "value" : "iContextHook>          Hooks;                  // Hooks for extensions (e.g. test engine)\n    ImGuiID                    ",
+      "evaluatedValue" : "30"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiTabBarFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::BeginTabBar()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_None",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 0,
+      "value" : "e",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_Reorderable",
+      "docComment" : "Allow manually dragging tabs to re-order them + New tabs are appended at the end of list",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 1,
+      "value" : "GuiLog",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_AutoSelectNewTabs",
+      "docComment" : "Automatically select new tabs when they appear",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 2,
+      "value" : "g to s",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_TabListPopupButton",
+      "docComment" : "Disable buttons to open the tab list popup",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 3,
+      "value" : "to cli",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_NoCloseWithMiddleMouseButton",
+      "docComment" : "Disable behavior of closing tabs (that are submitted with p_open != NULL) with middle mouse button. You can still repro this behavior on user's side with if (IsItemHovered() & & IsMouseClicked(2)) *p_open = false.",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 4,
+      "value" : "      ",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_NoTabListScrollingButtons",
+      "docComment" : "Disable scrolling buttons (apply when fitting policy is ImGuiTabBarFlags_FittingPolicyScroll)",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 5,
+      "value" : "oExpan",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_NoTooltip",
+      "docComment" : "Disable tooltips when hovering a tab",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 6,
+      "value" : "      ",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_FittingPolicyResizeDown",
+      "docComment" : "Resize tabs when they don't fit",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 7,
+      "value" : "\n    I",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_FittingPolicyScroll",
+      "docComment" : "Add scroll buttons when tabs don't fit",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 8,
+      "value" : " encou",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_FittingPolicyMask_",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 9,
+      "value" : "ckTool;\n\n    // Misc\n    float                   FramerateSecPerFrame[120];    ",
+      "evaluatedValue" : "192"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabBarFlags_FittingPolicyDefault_",
+      "qualType" : "ImGuiTabBarFlags_",
+      "order" : 10,
+      "value" : "he last 2 seconds.\n    int              ",
+      "evaluatedValue" : "64"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiTabItemFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::BeginTabItem()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_None",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 0,
+      "value" : "r",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_UnsavedDocument",
+      "docComment" : "Display a dot next to the title + tab is selected when clicking the X + closure is not assumed (will wait for user to stop submitting the tab). Otherwise closure is assumed when pressing the X, so if you keep submitting the tab may reappear at end of tab bar.",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 1,
+      "value" : "tureMo",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_SetSelected",
+      "docComment" : "Trigger flag to programmatically make the tab selected when calling BeginTabItem()",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 2,
+      "value" : "ontext",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_NoCloseWithMiddleMouseButton",
+      "docComment" : "Disable behavior of closing tabs (that are submitted with p_open != NULL) with middle mouse button. You can still repro this behavior on user's side with if (IsItemHovered() & & IsMouseClicked(2)) *p_open = false.",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 3,
+      "value" : "\n     ",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_NoPushId",
+      "docComment" : "Don't call PushID(tab->ID)/PopID() on BeginTabItem()/EndTabItem()",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 4,
+      "value" : " = Fra",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_NoTooltip",
+      "docComment" : "Disable tooltip for the given tab",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 5,
+      "value" : "= fals",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_NoReorder",
+      "docComment" : "Disable reordering this tab or having another tab cross over this tab",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 6,
+      "value" : ";\n\n   ",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_Leading",
+      "docComment" : "Enforce the tab position to the left of the tab bar (after the tab list popup button)",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 7,
+      "value" : "ULL;\n ",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTabItemFlags_Trailing",
+      "docComment" : "Enforce the tab position to the right of the tab bar (before the scrolling buttons)",
+      "qualType" : "ImGuiTabItemFlags_",
+      "order" : 8,
+      "value" : "Info =",
+      "evaluatedValue" : "128"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiTableFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::BeginTable()"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " [BETA API] API may evolve slightly! If you use this, please update to the next version when it comes out!"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Important! Sizing policies have complex and subtle side effects, more so than you would expect."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   Read comments/demos carefully + experiment with live demos to get acquainted with them."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - The DEFAULT sizing policies are:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Default to ImGuiTableFlags_SizingFixedFit    if ScrollX is on, or if host window has ImGuiWindowFlags_AlwaysAutoResize."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Default to ImGuiTableFlags_SizingStretchSame if ScrollX is off."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - When ScrollX is off:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Table defaults to ImGuiTableFlags_SizingStretchSame -> all Columns defaults to ImGuiTableColumnFlags_WidthStretch with same weight."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Columns sizing policy allowed: Stretch (default), Fixed/Auto."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Fixed Columns will generally obtain their requested width (unless the table cannot fit them all)."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Stretch Columns will share the remaining width."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Mixed Fixed/Stretch columns is possible but has various side-effects on resizing behaviors."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "      The typical use of mixing sizing policies is: any number of LEADING Fixed columns, followed by one or two TRAILING Stretch columns."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "      (this is because the visible order of columns have subtle but necessary effects on how they react to manual resizing)."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - When ScrollX is on:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Table defaults to ImGuiTableFlags_SizingFixedFit -> all Columns defaults to ImGuiTableColumnFlags_WidthFixed"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Columns sizing policy allowed: Fixed/Auto mostly."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Fixed Columns can be enlarged as needed. Table will show an horizontal scrollbar if needed."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - When using auto-resizing (non-resizable) fixed columns, querying the content width to use item right-alignment e.g. SetNextItemWidth(-FLT_MIN) doesn't make sense, would create a feedback loop."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    - Using Stretch columns OFTEN DOES NOT MAKE SENSE if ScrollX is on, UNLESS you have specified a value for 'inner_width' in BeginTable()."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "      If you specify a value for 'inner_width' then effectively the scrolling space is known and Stretch or mixed Fixed/Stretch columns become meaningful again."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Read on documentation at the top of imgui_tables.cpp for details."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_None",
+      "docComment" : "Features",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 0,
+      "value" : "d",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_Resizable",
+      "docComment" : "Enable resizing columns.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 1,
+      "value" : "MoveDi",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_Reorderable",
+      "docComment" : "Enable reordering columns in header row (need calling TableSetupColumn() + TableHeadersRow() to display headers)",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 2,
+      "value" : "     N",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_Hideable",
+      "docComment" : "Enable hiding/disabling columns in context menu.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 3,
+      "value" : "dowing",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_Sortable",
+      "docComment" : "Enable sorting. Call TableGetSortSpecs() to obtain sort specs. Also see ImGuiTableFlags_SortMulti and ImGuiTableFlags_SortTristate.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 4,
+      "value" : "Cursor",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoSavedSettings",
+      "docComment" : "Disable persisting columns order, width and sort settings in the .ini file.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 5,
+      "value" : "Count ",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_ContextMenuInBody",
+      "docComment" : "Right-click on columns body/contents will display table context menu. By default it is available in TableHeadersRow().",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 6,
+      "value" : " DragD",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_RowBg",
+      "docComment" : "Set each RowBg color with ImGuiCol_TableRowBg or ImGuiCol_TableRowBgAlt (equivalent of calling TableSetBgColor with ImGuiTableBgFlags_RowBg0 on each row manually)",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 7,
+      "value" : "ayload",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_BordersInnerH",
+      "docComment" : "Draw horizontal borders between rows.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 8,
+      "value" : "ditOpt",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_BordersOuterH",
+      "docComment" : "Draw horizontal borders at the top and bottom.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 9,
+      "value" : ";\n    ",
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_BordersInnerV",
+      "docComment" : "Draw vertical borders between columns.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 10,
+      "value" : "\n     ",
+      "evaluatedValue" : "512"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_BordersOuterV",
+      "docComment" : "Draw vertical borders on the left and right sides.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 11,
+      "value" : "o = 1.0",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_BordersH",
+      "docComment" : "Draw horizontal borders.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 12,
+      "value" : "ToGrabCenter = 0.0f;\n        TooltipOverrideCount = 0;\n      ",
+      "evaluatedValue" : "384"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_BordersV",
+      "docComment" : "Draw vertical borders.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 13,
+      "value" : "c2(FLT_MAX, FLT_MAX);\n        PlatformImePosViewport = 0;\n   ",
+      "evaluatedValue" : "1536"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_BordersInner",
+      "docComment" : "Draw inner borders.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 14,
+      "value" : "   SettingsDirtyTimer = 0.0f;\n        HookIdNext = 0;\n\n      ",
+      "evaluatedValue" : "640"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_BordersOuter",
+      "docComment" : "Draw outer borders.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 15,
+      "value" : "Prefix = LogNextSuffix = NULL;\n        LogFile = NULL;\n      ",
+      "evaluatedValue" : "1280"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_Borders",
+      "docComment" : "Draw all borders.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 16,
+      "value" : "hRef = 0;\n        LogDepthToExpand = LogDepthToExpandDefaul",
+      "evaluatedValue" : "1920"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoBordersInBody",
+      "docComment" : "[ALPHA] Disable vertical borders in columns Body (borders will always appears in Headers). -> May move to style",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 17,
+      "value" : "kId = 0",
+      "evaluatedValue" : "2048"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoBordersInBodyUntilResize",
+      "docComment" : "[ALPHA] Disable vertical borders in columns Body until hovered for resize (borders will always appears in Headers). -> May move to style",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 18,
+      "value" : "Accum =",
+      "evaluatedValue" : "4096"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_SizingFixedFit",
+      "docComment" : "Columns default to _WidthFixed or _WidthAuto (if resizable or not resizable), matching contents width.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 19,
+      "value" : "----\n//",
+      "evaluatedValue" : "8192"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_SizingFixedSame",
+      "docComment" : "Columns default to _WidthFixed or _WidthAuto (if resizable or not resizable), matching the maximum contents width of all columns. Implicitly enable ImGuiTableFlags_NoKeepColumnsVisible.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 20,
+      "value" : "et at t",
+      "evaluatedValue" : "16384"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_SizingStretchProp",
+      "docComment" : "Columns default to _WidthStretch with default weights proportional to each columns contents widths.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 21,
+      "value" : "ered..)",
+      "evaluatedValue" : "24576"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_SizingStretchSame",
+      "docComment" : "Columns default to _WidthStretch with default weights all equal, unless overridden by TableSetupColumn().",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 22,
+      "value" : "iWindow",
+      "evaluatedValue" : "32768"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoHostExtendX",
+      "docComment" : "Make outer width auto-fit to columns, overriding outer_size.x value. Only available when ScrollX/ScrollY are disabled and Stretch columns are not used.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 23,
+      "value" : "       ",
+      "evaluatedValue" : "65536"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoHostExtendY",
+      "docComment" : "Make outer height stop exactly at outer_size.y (prevent auto-extending table past the limit). Only available when ScrollX/ScrollY are disabled. Data below the limit will be clipped and not visible.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 24,
+      "value" : "ize at ",
+      "evaluatedValue" : "131072"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoKeepColumnsVisible",
+      "docComment" : "Disable keeping column always minimally visible when ScrollX is off and table gets too small. Not recommended if columns are resizable.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 25,
+      "value" : " Always",
+      "evaluatedValue" : "262144"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_PreciseWidths",
+      "docComment" : "Disable distributing remainder width to stretched columns (width allocation on a 100-wide table with 3 columns: Without this flag: 33,33,34. With this flag: 33,33,33). With larger number of columns, resizing will appear to be less smooth.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 26,
+      "value" : "default",
+      "evaluatedValue" : "524288"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoClip",
+      "docComment" : "Disable clipping rectangle for every individual columns (reduce draw command count, items will be able to overflow into other columns). Generally incompatible with TableSetupScrollFreeze().",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 27,
+      "value" : "lumnsOf",
+      "evaluatedValue" : "1048576"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_PadOuterX",
+      "docComment" : "Default if BordersOuterV is on. Enable outer-most padding. Generally desirable if you have headers.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 28,
+      "value" : "StartPo",
+      "evaluatedValue" : "2097152"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoPadOuterX",
+      "docComment" : "Default if BordersOuterV is off. Disable outer-most padding.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 29,
+      "value" : "t commo",
+      "evaluatedValue" : "4194304"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_NoPadInnerX",
+      "docComment" : "Disable inner padding between columns (double inner padding if BordersOuterV is on, single inner padding if BordersOuterV is off).",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 30,
+      "value" : "     //",
+      "evaluatedValue" : "8388608"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_ScrollX",
+      "docComment" : "Enable horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Changes default sizing policy. Because this create a child window, ScrollY is currently generally recommended when using ScrollX.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 31,
+      "value" : "ersActi",
+      "evaluatedValue" : "16777216"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_ScrollY",
+      "docComment" : "Enable vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size.",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 32,
+      "value" : "scrolli",
+      "evaluatedValue" : "33554432"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_SortMulti",
+      "docComment" : "Hold shift when clicking headers to sort on multiple column. TableGetSortSpecs() may return specs where (SpecsCount > 1).",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 33,
+      "value" : "       ",
+      "evaluatedValue" : "67108864"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_SortTristate",
+      "docComment" : "Allow no sorting, disable default sorting. TableGetSortSpecs() may return specs where (SpecsCount == 0).",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 34,
+      "value" : "aPaddin",
+      "evaluatedValue" : "134217728"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableFlags_SizingMask_",
+      "docComment" : "[Internal] Combinations and masks",
+      "qualType" : "ImGuiTableFlags_",
+      "order" : 35,
+      "value" : " // Current tree depth.\n    ImU32                   TreeJumpToParentOnPopMask; // Store a copy of !g.NavIdIsAlive for TreeDepth 0..31.. ",
+      "evaluatedValue" : "57344"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiWindowTempData",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Transient per-window data, reset at the beginning of the frame. This used to be called ImGuiDrawContext, hence the DC variable name in ImGuiWindow."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (That's theory, in practice the delimitation between ImGuiWindow and ImGuiWindowTempData is quite tenuous and could be reconsidered..)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (This doesn't need a constructor because we zero-clear it as part of ImGuiWindow and all frame-temporary data are setup on Begin)"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CursorPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CursorPosPrevLine",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CursorStartPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CursorMaxPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IdealMaxPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrLineSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PrevLineSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrLineTextBaseOffset",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PrevLineTextBaseOffset",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Indent",
+      "qualType" : "ImVec1",
+      "desugaredQualType" : "ImVec1"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsOffset",
+      "qualType" : "ImVec1",
+      "desugaredQualType" : "ImVec1"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GroupOffset",
+      "qualType" : "ImVec1",
+      "desugaredQualType" : "ImVec1"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CursorStartPosLossyness",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavLayerCurrent",
+      "qualType" : "ImGuiNavLayer",
+      "desugaredQualType" : "ImGuiNavLayer"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavLayersActiveMask",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavLayersActiveMaskNext",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavFocusScopeIdCurrent",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavHideHighlightOneFrame",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavHasScroll",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MenuBarAppending",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MenuBarOffset",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MenuColumns",
+      "qualType" : "ImGuiMenuColumns",
+      "desugaredQualType" : "ImGuiMenuColumns"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TreeDepth",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TreeJumpToParentOnPopMask",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ChildWindows",
+      "qualType" : "ImVector<ImGuiWindow *>",
+      "desugaredQualType" : "ImVector<ImGuiWindow *>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "StateStorage",
+      "qualType" : "ImGuiStorage *",
+      "desugaredQualType" : "ImGuiStorage *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrentColumns",
+      "qualType" : "ImGuiOldColumns *",
+      "desugaredQualType" : "ImGuiOldColumns *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrentTableIdx",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LayoutType",
+      "qualType" : "ImGuiLayoutType",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ParentLayoutType",
+      "qualType" : "ImGuiLayoutType",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ItemWidth",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TextWrapPos",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ItemWidthStack",
+      "qualType" : "ImVector<float>",
+      "desugaredQualType" : "ImVector<float>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TextWrapPosStack",
+      "qualType" : "ImVector<float>",
+      "desugaredQualType" : "ImVector<float>"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiTableColumnFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::TableSetupColumn()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_None",
+      "docComment" : "Input configuration flags",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 0,
+      "value" : "i",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_Disabled",
+      "docComment" : "Overriding/master disable flag: hide column, won't show in context menu (unlike calling TableSetColumnEnabled() which manipulates the user accessible state)",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 1,
+      "value" : "ty (re",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_DefaultHide",
+      "docComment" : "Default as a hidden/disabled column.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 2,
+      "value" : " item ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_DefaultSort",
+      "docComment" : "Default as a sorting column.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 3,
+      "value" : "      ",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_WidthStretch",
+      "docComment" : "Column will stretch. Preferable with horizontal scrolling disabled (default if table sizing policy is _SizingStretchSame or _SizingStretchProp).",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 4,
+      "value" : "mWidth",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_WidthFixed",
+      "docComment" : "Column will not stretch. Preferable with horizontal scrolling enabled (default if table sizing policy is _SizingFixedFit and table is resizable).",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 5,
+      "value" : "= Text",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoResize",
+      "docComment" : "Disable manual resizing.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 6,
+      "value" : "      ",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoReorder",
+      "docComment" : "Disable manual reordering this column, this will also prevent other columns from crossing over this column.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 7,
+      "value" : " Flags",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoHide",
+      "docComment" : "Disable ability to hide/disable this column.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 8,
+      "value" : "lass()",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoClip",
+      "docComment" : "Disable clipping for this column (all NoClip columns will render in a same draw command).",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 9,
+      "value" : "ve win",
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoSort",
+      "docComment" : "Disable ability to sort on this field (even if ImGuiTableFlags_Sortable is set on the table).",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 10,
+      "value" : "y disa",
+      "evaluatedValue" : "512"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoSortAscending",
+      "docComment" : "Disable ability to sort in the ascending direction.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 11,
+      "value" : " (since",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoSortDescending",
+      "docComment" : "Disable ability to sort in the descending direction.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 12,
+      "value" : "ortAllo",
+      "evaluatedValue" : "2048"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoHeaderLabel",
+      "docComment" : "TableHeadersRow() will not submit label for this column. Convenient for some small columns. Name will still appear in context menu.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 13,
+      "value" : "e), onl",
+      "evaluatedValue" : "4096"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoHeaderWidth",
+      "docComment" : "Disable header text width contribution to automatic column width.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 14,
+      "value" : "arest p",
+      "evaluatedValue" : "8192"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_PreferSortAscending",
+      "docComment" : "Make the initial sort direction Ascending when first sorting on this column (default).",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 15,
+      "value" : "ize)\n  ",
+      "evaluatedValue" : "16384"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_PreferSortDescending",
+      "docComment" : "Make the initial sort direction Descending when first sorting on this column.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 16,
+      "value" : "       ",
+      "evaluatedValue" : "32768"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_IndentEnable",
+      "docComment" : "Use current Indent value when entering cell (default for column 0).",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 17,
+      "value" : "window ",
+      "evaluatedValue" : "65536"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_IndentDisable",
+      "docComment" : "Ignore current Indent value when entering cell (default for columns > 0). Indentation changes _within_ the cell will still be honored.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 18,
+      "value" : "       ",
+      "evaluatedValue" : "131072"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_IsEnabled",
+      "docComment" : "Status: is enabled == not hidden by user/api (referred to as \"Hide\" in _DefaultHide and _NoHide) flags.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 19,
+      "value" : "ounding",
+      "evaluatedValue" : "16777216"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_IsVisible",
+      "docComment" : "Status: is visible == is enabled AND not clipped by scrolling.",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 20,
+      "value" : "       ",
+      "evaluatedValue" : "33554432"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_IsSorted",
+      "docComment" : "Status: is currently part of the sort specs",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 21,
+      "value" : "eBufLen",
+      "evaluatedValue" : "67108864"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_IsHovered",
+      "docComment" : "Status: is hovered by mouse",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 22,
+      "value" : "ID     ",
+      "evaluatedValue" : "134217728"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_WidthMask_",
+      "docComment" : "[Internal] Combinations and masks",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 23,
+      "value" : "               // ID of corresponding item in parent window (for navi",
+      "evaluatedValue" : "24"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_IndentMask_",
+      "docComment" : "[Internal] Combinations and masks",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 24,
+      "value" : "\n    ImVec2                  Scroll;\n    ImVec2                  ScrollM",
+      "evaluatedValue" : "196608"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_StatusMask_",
+      "docComment" : "[Internal] Combinations and masks",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 25,
+      "value" : "                // target scroll position. stored as cursor position with scrolling canceled out, so the highest point is always 0.0",
+      "evaluatedValue" : "251658240"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableColumnFlags_NoDirectResize_",
+      "docComment" : "[Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge)",
+      "qualType" : "ImGuiTableColumnFlags_",
+      "order" : 26,
+      "value" : "   Scro",
+      "evaluatedValue" : "1073741824"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiWindow",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Storage for one window"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Name",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ID",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImGuiWindowFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FlagsPreviousFrame",
+      "qualType" : "ImGuiWindowFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowClass",
+      "qualType" : "ImGuiWindowClass",
+      "desugaredQualType" : "ImGuiWindowClass"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Viewport",
+      "qualType" : "ImGuiViewportP *",
+      "desugaredQualType" : "ImGuiViewportP *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ViewportId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ViewportPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ViewportAllowPlatformMonitorExtend",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Pos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Size",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizeFull",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ContentSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ContentSizeIdeal",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ContentSizeExplicit",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowPadding",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowRounding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowBorderSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NameBufLen",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MoveId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ChildId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Scroll",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollMax",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollTarget",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollTargetCenterRatio",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollTargetEdgeSnapDist",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollbarSizes",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollbarX",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollbarY",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ViewportOwned",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Active",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WasActive",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WriteAccessed",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Collapsed",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantCollapseToggle",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SkipItems",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Appearing",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Hidden",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsFallbackWindow",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsExplicitChild",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HasCloseButton",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ResizeBorderHeld",
+      "qualType" : "signed char",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BeginCount",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BeginOrderWithinParent",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BeginOrderWithinContext",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FocusOrder",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PopupId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AutoFitFramesX",
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AutoFitFramesY",
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AutoFitChildAxises",
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AutoFitOnlyGrows",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AutoPosLastDirection",
+      "qualType" : "ImGuiDir",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HiddenFramesCanSkipItems",
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HiddenFramesCannotSkipItems",
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HiddenFramesForRenderOnly",
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisableInputsFrames",
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SetWindowPosAllowFlags",
+      "qualType" : "ImGuiCond",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SetWindowSizeAllowFlags",
+      "qualType" : "ImGuiCond",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SetWindowCollapsedAllowFlags",
+      "qualType" : "ImGuiCond",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SetWindowDockAllowFlags",
+      "qualType" : "ImGuiCond",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SetWindowPosVal",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SetWindowPosPivot",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IDStack",
+      "qualType" : "ImVector<ImGuiID>",
+      "desugaredQualType" : "ImVector<unsigned int>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DC",
+      "qualType" : "ImGuiWindowTempData",
+      "desugaredQualType" : "ImGuiWindowTempData"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OuterRectClipped",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InnerRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InnerClipRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WorkRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ParentWorkRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ClipRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ContentRegionRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HitTestHoleSize",
+      "qualType" : "ImVec2ih",
+      "desugaredQualType" : "ImVec2ih"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HitTestHoleOffset",
+      "qualType" : "ImVec2ih",
+      "desugaredQualType" : "ImVec2ih"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastFrameActive",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastFrameJustFocused",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastTimeActive",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ItemWidthDefault",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "StateStorage",
+      "qualType" : "ImGuiStorage",
+      "desugaredQualType" : "ImGuiStorage"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsStorage",
+      "qualType" : "ImVector<ImGuiOldColumns>",
+      "desugaredQualType" : "ImVector<ImGuiOldColumns>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontWindowScale",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontDpiScale",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SettingsOffset",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DrawList",
+      "qualType" : "ImDrawList *",
+      "desugaredQualType" : "ImDrawList *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DrawListInst",
+      "qualType" : "ImDrawList",
+      "desugaredQualType" : "ImDrawList"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ParentWindow",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ParentWindowInBeginStack",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RootWindow",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RootWindowPopupTree",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RootWindowDockTree",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RootWindowForTitleBarHighlight",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RootWindowForNav",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavLastChildNavWindow",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavLastIds",
+      "qualType" : "ImGuiID[2]",
+      "desugaredQualType" : "ImGuiID[2]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavRectRel",
+      "qualType" : "ImRect[2]",
+      "desugaredQualType" : "ImRect[2]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MemoryDrawListIdxCapacity",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MemoryDrawListVtxCapacity",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MemoryCompacted",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockIsActive",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockNodeIsVisible",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockTabIsVisible",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockTabWantClose",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockOrder",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockStyle",
+      "qualType" : "ImGuiWindowDockStyle",
+      "desugaredQualType" : "ImGuiWindowDockStyle"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockNode",
+      "qualType" : "ImGuiDockNode *",
+      "desugaredQualType" : "ImGuiDockNode *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockNodeAsHost",
+      "qualType" : "ImGuiDockNode *",
+      "desugaredQualType" : "ImGuiDockNode *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockTabItemStatusFlags",
+      "qualType" : "ImGuiItemStatusFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockTabItemRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "NULL"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetIDNoKeepAlive",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "NULL"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetIDNoKeepAlive",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ptr",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetIDNoKeepAlive",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetIDFromRectangle",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r_abs",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Rect",
+      "resultType" : "ImRect",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " We don't use g.FontSize because the window may be != g.CurrentWidow."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcFontSize",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TitleBarHeight",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TitleBarRect",
+      "resultType" : "ImRect"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "MenuBarHeight",
+      "resultType" : "float"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "MenuBarRect",
+      "resultType" : "ImRect"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiTableRowFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::TableNextRow()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableRowFlags_None",
+      "qualType" : "ImGuiTableRowFlags_",
+      "order" : 0,
+      "value" : "b",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableRowFlags_Headers",
+      "docComment" : "Identify header row (set default background color + width of its contents accounted different for auto column width)",
+      "qualType" : "ImGuiTableRowFlags_",
+      "order" : 1,
+      "value" : "    bo",
+      "evaluatedValue" : "1"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiTableBgTarget_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Enum for ImGui::TableSetBgColor()"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Background colors are rendering in 3 layers:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Layer 0: draw with RowBg0 color if set, otherwise draw with ColumnBg0 if set."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Layer 1: draw with RowBg1 color if set, otherwise draw with ColumnBg1 if set."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Layer 2: draw with CellBg color if set."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " The purpose of the two row/columns layers is to let you decide if a background color changes should override or blend with the existing color."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " When using ImGuiTableFlags_RowBg on the table, each row has the RowBg0 color automatically set for odd/even rows."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " If you set the color of RowBg0 target, your color will override the existing RowBg0 color."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " If you set the color of RowBg1 or ColumnBg1 target, your color will blend over the RowBg0 color."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableBgTarget_None",
+      "qualType" : "ImGuiTableBgTarget_",
+      "order" : 0,
+      "value" : " ",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableBgTarget_RowBg0",
+      "docComment" : "Set row background color 0 (generally used for background, automatically set when ImGuiTableFlags_RowBg is used)",
+      "qualType" : "ImGuiTableBgTarget_",
+      "order" : 1,
+      "value" : " ",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableBgTarget_RowBg1",
+      "docComment" : "Set row background color 1 (generally used for selection marking)",
+      "qualType" : "ImGuiTableBgTarget_",
+      "order" : 2,
+      "value" : "o",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiTableBgTarget_CellBg",
+      "docComment" : "Set cell background color (top-most color)",
+      "qualType" : "ImGuiTableBgTarget_",
+      "order" : 3,
+      "value" : "r",
+      "evaluatedValue" : "3"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiFocusedFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::IsWindowFocused()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiFocusedFlags_None",
+      "qualType" : "ImGuiFocusedFlags_",
+      "order" : 0,
+      "value" : " ",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiFocusedFlags_ChildWindows",
+      "docComment" : "Return true if any children of the window is focused",
+      "qualType" : "ImGuiFocusedFlags_",
+      "order" : 1,
+      "value" : "t;    ",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiFocusedFlags_RootWindow",
+      "docComment" : "Test from root window (top most parent of the current hierarchy)",
+      "qualType" : "ImGuiFocusedFlags_",
+      "order" : 2,
+      "value" : "      ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiFocusedFlags_AnyWindow",
+      "docComment" : "Return true if any window is focused. Important: If you are trying to tell how to dispatch your low-level inputs, do NOT use this. Use 'io.WantCaptureMouse' instead! Please read the FAQ!",
+      "qualType" : "ImGuiFocusedFlags_",
+      "order" : 3,
+      "value" : "ssion ",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiFocusedFlags_NoPopupHierarchy",
+      "docComment" : "Do not consider popup hierarchy (do not treat popup emitter as parent of popup) (when used with _ChildWindows or _RootWindow)",
+      "qualType" : "ImGuiFocusedFlags_",
+      "order" : 4,
+      "value" : "en thi",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiFocusedFlags_DockHierarchy",
+      "docComment" : "Consider docking hierarchy (treat dockspace host as parent of docked window) (when used with _ChildWindows or _RootWindow)",
+      "qualType" : "ImGuiFocusedFlags_",
+      "order" : 5,
+      "value" : "\n    b",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiFocusedFlags_RootAndChildWindows",
+      "qualType" : "ImGuiFocusedFlags_",
+      "order" : 6,
+      "value" : "es\n    ImS8                    HiddenFramesCannotSkipItems;  ",
+      "evaluatedValue" : "3"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiHoveredFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::IsItemHovered(), ImGui::IsWindowHovered()"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Note: if you are trying to check whether your mouse should be dispatched to Dear ImGui or to your app, you should use 'io.WantCaptureMouse' instead! Please read the FAQ!"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Note: windows with the ImGuiWindowFlags_NoInputs flag are ignored by IsWindowHovered() calls."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_None",
+      "docComment" : "Return true if directly over the item/window, not obstructed by another window, not obstructed by an active popup or modal blocking inputs under them.",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 0,
+      "value" : "n",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_ChildWindows",
+      "docComment" : "IsWindowHovered() only: Return true if any children of the window is hovered",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 1,
+      "value" : "llowFl",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_RootWindow",
+      "docComment" : "IsWindowHovered() only: Test from root window (top most parent of the current hierarchy)",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 2,
+      "value" : "      ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_AnyWindow",
+      "docComment" : "IsWindowHovered() only: Return true if any window is hovered",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 3,
+      "value" : "tion w",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_NoPopupHierarchy",
+      "docComment" : "IsWindowHovered() only: Do not consider popup hierarchy (do not treat popup emitter as parent of popup) (when used with _ChildWindows or _RootWindow)",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 4,
+      "value" : "etWind",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_DockHierarchy",
+      "docComment" : "IsWindowHovered() only: Consider docking hierarchy (treat dockspace host as parent of docked window) (when used with _ChildWindows or _RootWindow)",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 5,
+      "value" : "   IDS",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_AllowWhenBlockedByPopup",
+      "docComment" : "Return true even if a popup window is normally blocking access to this item/window",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 6,
+      "value" : "      ",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_AllowWhenBlockedByActiveItem",
+      "docComment" : "Return true even if an active item is blocking access to this item/window. Useful for Drag and Drop patterns.",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 7,
+      "value" : "w->Rec",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_AllowWhenOverlapped",
+      "docComment" : "IsItemHovered() only: Return true even if the position is obstructed or overlapped by another window",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 8,
+      "value" : "      ",
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_AllowWhenDisabled",
+      "docComment" : "IsItemHovered() only: Return true even if the item is disabled",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 9,
+      "value" : " // ==",
+      "evaluatedValue" : "512"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_RectOnly",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 10,
+      "value" : "   WorkRect;                           // Initially covers the whole scrolling region. Reduced by containers e.g columns/tables wh",
+      "evaluatedValue" : "416"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiHoveredFlags_RootAndChildWindows",
+      "qualType" : "ImGuiHoveredFlags_",
+      "order" : 11,
+      "value" : "is is meant to replace ContentRegionRect over time (from 1.71",
+      "evaluatedValue" : "3"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiDockNodeFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::DockSpace(), shared/inherited by child nodes."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (Some flags can be applied to individual nodes directly)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " FIXME-DOCK: Also see ImGuiDockNodeFlagsPrivate_ which may involve using the WIP and internal DockBuilder api."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDockNodeFlags_None",
+      "qualType" : "ImGuiDockNodeFlags_",
+      "order" : 0,
+      "value" : " ",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDockNodeFlags_KeepAliveOnly",
+      "docComment" : "Shared       // Don't display the dockspace node but keep it alive. Windows docked into this dockspace node won't be undocked.",
+      "qualType" : "ImGuiDockNodeFlags_",
+      "order" : 1,
+      "value" : "/sciss",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDockNodeFlags_NoDockingInCentralNode",
+      "docComment" : "Shared       // Disable docking inside the Central Node, which will be always kept empty.",
+      "qualType" : "ImGuiDockNodeFlags_",
+      "order" : 2,
+      "value" : " opera",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDockNodeFlags_PassthruCentralNode",
+      "docComment" : "Shared       // Enable passthru dockspace: 1) DockSpace() will render a ImGuiCol_WindowBg background covering everything excepted the Central Node when empty. Meaning the host window should probably use SetNextWindowBgAlpha(0.0f) prior to Begin() when using this. 2) When Central Node is empty: let inputs pass-through + won't display a DockingEmptyBg background. See demo for details.",
+      "qualType" : "ImGuiDockNodeFlags_",
+      "order" : 3,
+      "value" : " pass-",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDockNodeFlags_NoSplit",
+      "docComment" : "Shared/Local // Disable splitting the node into smaller nodes. Useful e.g. when embedding dockspaces into a main root one (the root one may have splitting disabled to reduce confusion). Note: when turned off, existing splits will be preserved.",
+      "qualType" : "ImGuiDockNodeFlags_",
+      "order" : 4,
+      "value" : "   flo",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDockNodeFlags_NoResize",
+      "docComment" : "Shared/Local // Disable resizing node using the splitter/separators. Useful with programmatically setup dockspaces.",
+      "qualType" : "ImGuiDockNodeFlags_",
+      "order" : 5,
+      "value" : "      ",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDockNodeFlags_AutoHideTabBar",
+      "docComment" : "Shared/Local // Tab bar will automatically hide when there is a single window in the dock node.",
+      "qualType" : "ImGuiDockNodeFlags_",
+      "order" : 6,
+      "value" : "DrawLi",
+      "evaluatedValue" : "64"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiDragDropFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImGui::BeginDragDropSource(), ImGui::AcceptDragDropPayload()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_None",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 0,
+      "value" : " ",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_SourceNoPreviewTooltip",
+      "docComment" : "By default, a successful call to BeginDragDropSource opens a tooltip so you can display a preview or description of the source contents. This flag disable this behavior.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 1,
+      "value" : "GuiWin",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_SourceNoDisableHover",
+      "docComment" : "By default, when dragging we clear data so that IsItemHovered() will return false, to avoid subsequent user code submitting tooltips. This flag disable this behavior so you can still call IsItemHovered() on the source item.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 2,
+      "value" : "      ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_SourceNoHoldToOpenOthers",
+      "docComment" : "Disable the behavior that allows to open tree nodes and collapsing header by holding over them while dragging a source item.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 3,
+      "value" : " dock ",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_SourceAllowNullID",
+      "docComment" : "Allow items such as Text(), Image() that have no unique identifier to be used as drag source, by manufacturing a temporary identifier based on their window-relative position. This is extremely unusual within the dear imgui ecosystem and so we made it explicit.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 4,
+      "value" : "indow*",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_SourceExtern",
+      "docComment" : "External source (from outside of dear imgui), won't attempt to read current item/window info. Will always return true. Only one Extern source can be active simultaneously.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 5,
+      "value" : "ows so",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_SourceAutoExpirePayload",
+      "docComment" : "Automatically expire the payload if the source cease to be submitted (otherwise payloads are persisting while being dragged)",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 6,
+      "value" : "erence",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_AcceptBeforeDelivery",
+      "docComment" : "AcceptDragDropPayload() will returns true even before the mouse button is released. You can then call IsDelivery() to test if the payload needs to be delivered.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 7,
+      "value" : "       ",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_AcceptNoDrawDefaultRect",
+      "docComment" : "Do not draw the default highlight rectangle when hovering over target.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 8,
+      "value" : "e      ",
+      "evaluatedValue" : "2048"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_AcceptNoPreviewTooltip",
+      "docComment" : "Request hiding the BeginDragDropSource tooltip from the BeginDragDropTarget site.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 9,
+      "value" : "ode != ",
+      "evaluatedValue" : "4096"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDragDropFlags_AcceptPeekOnly",
+      "docComment" : "For peeking ahead and inspecting the payload before delivery.",
+      "qualType" : "ImGuiDragDropFlags_",
+      "order" : 10,
+      "value" : "             // Is our window visible this frame? ~~ is the corresponding tab select",
+      "evaluatedValue" : "3072"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiDataType_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " A primary data type"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_S8",
+      "docComment" : "signed char / char (with sensible compilers)",
+      "qualType" : "ImGuiDataType_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_U8",
+      "docComment" : "unsigned char",
+      "qualType" : "ImGuiDataType_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_S16",
+      "docComment" : "short",
+      "qualType" : "ImGuiDataType_",
+      "order" : 2,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_U16",
+      "docComment" : "unsigned short",
+      "qualType" : "ImGuiDataType_",
+      "order" : 3,
+      "evaluatedValue" : "3"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_S32",
+      "docComment" : "int",
+      "qualType" : "ImGuiDataType_",
+      "order" : 4,
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_U32",
+      "docComment" : "unsigned int",
+      "qualType" : "ImGuiDataType_",
+      "order" : 5,
+      "evaluatedValue" : "5"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_S64",
+      "docComment" : "long long / __int64",
+      "qualType" : "ImGuiDataType_",
+      "order" : 6,
+      "evaluatedValue" : "6"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_U64",
+      "docComment" : "unsigned long long / unsigned __int64",
+      "qualType" : "ImGuiDataType_",
+      "order" : 7,
+      "evaluatedValue" : "7"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_Float",
+      "docComment" : "float",
+      "qualType" : "ImGuiDataType_",
+      "order" : 8,
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_Double",
+      "docComment" : "double",
+      "qualType" : "ImGuiDataType_",
+      "order" : 9,
+      "evaluatedValue" : "9"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDataType_COUNT",
+      "qualType" : "ImGuiDataType_",
+      "order" : 10,
+      "evaluatedValue" : "10"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiDir_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " A cardinal direction"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDir_None",
+      "qualType" : "ImGuiDir_",
+      "order" : 0,
+      "value" : "Ge",
+      "evaluatedValue" : "-1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDir_Left",
+      "qualType" : "ImGuiDir_",
+      "order" : 1,
+      "value" : "t",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDir_Right",
+      "qualType" : "ImGuiDir_",
+      "order" : 2,
+      "value" : " ",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDir_Up",
+      "qualType" : "ImGuiDir_",
+      "order" : 3,
+      "value" : " ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDir_Down",
+      "qualType" : "ImGuiDir_",
+      "order" : 4,
+      "value" : " ",
+      "evaluatedValue" : "3"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiDir_COUNT",
+      "qualType" : "ImGuiDir_",
+      "order" : 5,
+      "evaluatedValue" : "4"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiSortDirection_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " A sorting direction"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSortDirection_None",
+      "qualType" : "ImGuiSortDirection_",
+      "order" : 0,
+      "value" : "t",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSortDirection_Ascending",
+      "docComment" : "Ascending = 0->9, A->Z etc.",
+      "qualType" : "ImGuiSortDirection_",
+      "order" : 1,
+      "value" : "i",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSortDirection_Descending",
+      "docComment" : "Descending = 9->0, Z->A etc.",
+      "qualType" : "ImGuiSortDirection_",
+      "order" : 2,
+      "value" : "m",
+      "evaluatedValue" : "2"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiKey_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " User fill ImGuiIO.KeyMap[] array with indices into the ImGuiIO.KeysDown[512] array"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Tab",
+      "qualType" : "ImGuiKey_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_LeftArrow",
+      "qualType" : "ImGuiKey_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_RightArrow",
+      "qualType" : "ImGuiKey_",
+      "order" : 2,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_UpArrow",
+      "qualType" : "ImGuiKey_",
+      "order" : 3,
+      "evaluatedValue" : "3"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_DownArrow",
+      "qualType" : "ImGuiKey_",
+      "order" : 4,
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_PageUp",
+      "qualType" : "ImGuiKey_",
+      "order" : 5,
+      "evaluatedValue" : "5"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_PageDown",
+      "qualType" : "ImGuiKey_",
+      "order" : 6,
+      "evaluatedValue" : "6"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Home",
+      "qualType" : "ImGuiKey_",
+      "order" : 7,
+      "evaluatedValue" : "7"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_End",
+      "qualType" : "ImGuiKey_",
+      "order" : 8,
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Insert",
+      "qualType" : "ImGuiKey_",
+      "order" : 9,
+      "evaluatedValue" : "9"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Delete",
+      "qualType" : "ImGuiKey_",
+      "order" : 10,
+      "evaluatedValue" : "10"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Backspace",
+      "qualType" : "ImGuiKey_",
+      "order" : 11,
+      "evaluatedValue" : "11"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Space",
+      "qualType" : "ImGuiKey_",
+      "order" : 12,
+      "evaluatedValue" : "12"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Enter",
+      "qualType" : "ImGuiKey_",
+      "order" : 13,
+      "evaluatedValue" : "13"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Escape",
+      "qualType" : "ImGuiKey_",
+      "order" : 14,
+      "evaluatedValue" : "14"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_KeyPadEnter",
+      "qualType" : "ImGuiKey_",
+      "order" : 15,
+      "evaluatedValue" : "15"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_A",
+      "docComment" : "for text edit CTRL+A: select all",
+      "qualType" : "ImGuiKey_",
+      "order" : 16,
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_C",
+      "docComment" : "for text edit CTRL+C: copy",
+      "qualType" : "ImGuiKey_",
+      "order" : 17,
+      "evaluatedValue" : "17"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_V",
+      "docComment" : "for text edit CTRL+V: paste",
+      "qualType" : "ImGuiKey_",
+      "order" : 18,
+      "evaluatedValue" : "18"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_X",
+      "docComment" : "for text edit CTRL+X: cut",
+      "qualType" : "ImGuiKey_",
+      "order" : 19,
+      "evaluatedValue" : "19"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Y",
+      "docComment" : "for text edit CTRL+Y: redo",
+      "qualType" : "ImGuiKey_",
+      "order" : 20,
+      "evaluatedValue" : "20"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_Z",
+      "docComment" : "for text edit CTRL+Z: undo",
+      "qualType" : "ImGuiKey_",
+      "order" : 21,
+      "evaluatedValue" : "21"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKey_COUNT",
+      "qualType" : "ImGuiKey_",
+      "order" : 22,
+      "evaluatedValue" : "22"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiKeyModFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " To test io.KeyMods (which is a combination of individual fields io.KeyCtrl, io.KeyShift, io.KeyAlt set by user/backend)"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKeyModFlags_None",
+      "qualType" : "ImGuiKeyModFlags_",
+      "order" : 0,
+      "value" : "-",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKeyModFlags_Ctrl",
+      "qualType" : "ImGuiKeyModFlags_",
+      "order" : 1,
+      "value" : "-----\n",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKeyModFlags_Shift",
+      "qualType" : "ImGuiKeyModFlags_",
+      "order" : 2,
+      "value" : "rt\n//-",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKeyModFlags_Alt",
+      "qualType" : "ImGuiKeyModFlags_",
+      "order" : 3,
+      "value" : "------",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiKeyModFlags_Super",
+      "qualType" : "ImGuiKeyModFlags_",
+      "order" : 4,
+      "value" : "// Ext",
+      "evaluatedValue" : "8"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
     "name" : "ImGuiTabBarFlagsPrivate_",
     "decls" : [ {
       "@type" : "AstFullComment",
@@ -5210,7 +17269,9 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_SectionMask_",
       "qualType" : "ImGuiTabItemFlagsPrivate_",
-      "order" : 0
+      "order" : 0,
+      "value" : "ImGuiTabItemFlags_Leading | ImGuiTabItemFlags_Trailing",
+      "evaluatedValue" : "192"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImGuiTabItemFlags_NoCloseButton",
@@ -5245,6 +17306,175 @@
       "evaluatedValue" : "8388608"
     } ]
   }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiNavInput_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Gamepad/Keyboard navigation"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Keyboard: Set io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard to enable. NewFrame() will automatically fill io.NavInputs[] based on your io.KeysDown[] + io.KeyMap[] arrays."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Gamepad:  Set io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad to enable. Backend: set ImGuiBackendFlags_HasGamepad and fill the io.NavInputs[] fields before calling NewFrame(). Note that io.NavInputs[] is cleared by EndFrame()."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Read instructions in imgui.cpp for more details. Download PNG/PSD at http://dearimgui.org/controls_sheets."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_Activate",
+      "docComment" : "activate / open / toggle / tweak value       // e.g. Cross  (PS4), A (Xbox), A (Switch), Space (Keyboard)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_Cancel",
+      "docComment" : "cancel / close / exit                        // e.g. Circle (PS4), B (Xbox), B (Switch), Escape (Keyboard)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_Input",
+      "docComment" : "text input / on-screen keyboard              // e.g. Triang.(PS4), Y (Xbox), X (Switch), Return (Keyboard)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 2,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_Menu",
+      "docComment" : "tap: toggle menu / hold: focus, move, resize // e.g. Square (PS4), X (Xbox), Y (Switch), Alt (Keyboard)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 3,
+      "evaluatedValue" : "3"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_DpadLeft",
+      "docComment" : "move / tweak / resize window (w/ PadMenu)    // e.g. D-pad Left/Right/Up/Down (Gamepads), Arrow keys (Keyboard)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 4,
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_DpadRight",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 5,
+      "evaluatedValue" : "5"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_DpadUp",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 6,
+      "evaluatedValue" : "6"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_DpadDown",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 7,
+      "evaluatedValue" : "7"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_LStickLeft",
+      "docComment" : "scroll / move window (w/ PadMenu)            // e.g. Left Analog Stick Left/Right/Up/Down",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 8,
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_LStickRight",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 9,
+      "evaluatedValue" : "9"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_LStickUp",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 10,
+      "evaluatedValue" : "10"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_LStickDown",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 11,
+      "evaluatedValue" : "11"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_FocusPrev",
+      "docComment" : "next window (w/ PadMenu)                     // e.g. L1 or L2 (PS4), LB or LT (Xbox), L or ZL (Switch)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 12,
+      "evaluatedValue" : "12"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_FocusNext",
+      "docComment" : "prev window (w/ PadMenu)                     // e.g. R1 or R2 (PS4), RB or RT (Xbox), R or ZL (Switch)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 13,
+      "evaluatedValue" : "13"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_TweakSlow",
+      "docComment" : "slower tweaks                                // e.g. L1 or L2 (PS4), LB or LT (Xbox), L or ZL (Switch)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 14,
+      "evaluatedValue" : "14"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_TweakFast",
+      "docComment" : "faster tweaks                                // e.g. R1 or R2 (PS4), RB or RT (Xbox), R or ZL (Switch)",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 15,
+      "evaluatedValue" : "15"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_KeyLeft_",
+      "docComment" : "move left                                    // = Arrow keys",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 16,
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_KeyRight_",
+      "docComment" : "move right",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 17,
+      "evaluatedValue" : "17"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_KeyUp_",
+      "docComment" : "move up",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 18,
+      "evaluatedValue" : "18"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_KeyDown_",
+      "docComment" : "move down",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 19,
+      "evaluatedValue" : "19"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_COUNT",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 20,
+      "evaluatedValue" : "20"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiNavInput_InternalStart_",
+      "qualType" : "ImGuiNavInput_",
+      "order" : 21,
+      "value" : "-bars used by docking\n",
+      "evaluatedValue" : "16"
+    } ]
+  }, {
     "@type" : "AstRecordDecl",
     "name" : "ImGuiTabItem",
     "decls" : [ {
@@ -5259,12 +17489,12 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Flags",
-      "qualType" : "int",
+      "qualType" : "ImGuiTabItemFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -5299,23 +17529,403 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NameOffset",
-      "qualType" : "int",
+      "qualType" : "ImS32",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "BeginOrder",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "IndexDuringLayout",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WantClose",
       "qualType" : "bool",
       "desugaredQualType" : "bool"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiTabBar",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Storage for a tab bar (sizeof() 152 bytes)"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Tabs",
+      "qualType" : "ImVector<ImGuiTabItem>",
+      "desugaredQualType" : "ImVector<ImGuiTabItem>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImGuiTabBarFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ID",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SelectedTabId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NextSelectedTabId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "VisibleTabId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrFrameVisible",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PrevFrameVisible",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BarRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrTabsContentsHeight",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PrevTabsContentsHeight",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WidthAllTabs",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WidthAllTabsIdeal",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollingAnim",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollingTarget",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollingTargetDistToVisibility",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollingSpeed",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollingRectMinX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollingRectMaxX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ReorderRequestTabId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ReorderRequestOffset",
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BeginCount",
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantLayout",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "VisibleTabWasSubmitted",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TabsAddedNew",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TabsActiveCount",
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastTabItemIdx",
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ItemSpacingY",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FramePadding",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackupCursorPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TabsNames",
+      "qualType" : "ImGuiTextBuffer",
+      "desugaredQualType" : "ImGuiTextBuffer"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTabOrder",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab",
+        "qualType" : "const ImGuiTabItem *",
+        "desugaredQualType" : "const ImGuiTabItem *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTabName",
+      "resultType" : "const char *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab",
+        "qualType" : "const ImGuiTabItem *",
+        "desugaredQualType" : "const ImGuiTabItem *"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiConfigFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Configuration flags stored in io.ConfigFlags. Set by user/application."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_None",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 0,
+      "value" : "l",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_NavEnableKeyboard",
+      "docComment" : "Master keyboard navigation enable flag. NewFrame() will automatically fill io.NavInputs[] based on io.KeysDown[].",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 1,
+      "value" : "      ",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_NavEnableGamepad",
+      "docComment" : "Master gamepad navigation enable flag. This is mostly to instruct your imgui backend to fill io.NavInputs[]. Backend also needs to set ImGuiBackendFlags_HasGamepad.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 2,
+      "value" : "   int",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_NavEnableSetMousePos",
+      "docComment" : "Instruct navigation to move the mouse cursor. May be useful on TV/console systems where moving a virtual mouse is awkward. Will update io.MousePos and set io.WantSetMousePos=true. If enabled you MUST honor io.WantSetMousePos requests in your backend, otherwise ImGui will react as if the mouse is jumping around back and forth.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 3,
+      "value" : "ab bar",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_NavNoCaptureKeyboard",
+      "docComment" : "Instruct navigation to not set the io.WantCaptureKeyboard flag when io.NavActive is set.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 4,
+      "value" : "    fl",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_NoMouse",
+      "docComment" : "Instruct imgui to clear mouse position/buttons in NewFrame(). This allows ignoring the mouse information set by the backend.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 5,
+      "value" : "      ",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_NoMouseCursorChange",
+      "docComment" : "Instruct backend to not alter mouse cursor shape and visibility. Use if the backend cursor changes are interfering with yours and you don't want to use SetMouseCursor() to change mouse cursor. You may want to honor requests from imgui by reading GetMouseCursor() yourself instead.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 6,
+      "value" : "w;    ",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_DockingEnable",
+      "docComment" : "Docking enable flags.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 7,
+      "value" : " Frame",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_ViewportsEnable",
+      "docComment" : "Viewport enable flags (require both ImGuiBackendFlags_PlatformHasViewports + ImGuiBackendFlags_RendererHasViewports set by the respective backends)",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 8,
+      "value" : "       ",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_DpiEnableScaleViewports",
+      "docComment" : "[BETA: Don't use] FIXME-DPI: Reposition and resize imgui windows when the DpiScale of a viewport changed (mostly useful for the main viewport hosting other window). Note that resizing the main window itself is up to your application.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 9,
+      "value" : "return ",
+      "evaluatedValue" : "16384"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_DpiEnableScaleFonts",
+      "docComment" : "[BETA: Don't use] FIXME-DPI: Request bitmap-scaled fonts to match DpiScale. This is a very low-quality workaround. The correct way to handle DPI is _currently_ to replace the atlas and/or fonts in the Platform_OnChangedViewport callback, but this is all early work in progress.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 10,
+      "value" : "-------",
+      "evaluatedValue" : "32768"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_IsSRGB",
+      "docComment" : "Application is SRGB-aware.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 11,
+      "value" : "ture.\nt",
+      "evaluatedValue" : "1048576"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiConfigFlags_IsTouchScreen",
+      "docComment" : "Application is using a touch screen instead of a mouse.",
+      "qualType" : "ImGuiConfigFlags_",
+      "order" : 12,
+      "value" : "ternal]",
+      "evaluatedValue" : "2097152"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiBackendFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Backend capabilities flags stored in io.BackendFlags. Set by imgui_impl_xxx or custom backend."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiBackendFlags_None",
+      "qualType" : "ImGuiBackendFlags_",
+      "order" : 0,
+      "value" : " ",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiBackendFlags_HasGamepad",
+      "docComment" : "Backend Platform supports gamepad and currently has one connected.",
+      "qualType" : "ImGuiBackendFlags_",
+      "order" : 1,
+      "value" : ") / Is",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiBackendFlags_HasMouseCursors",
+      "docComment" : "Backend Platform supports honoring GetMouseCursor() value to change the OS cursor shape.",
+      "qualType" : "ImGuiBackendFlags_",
+      "order" : 2,
+      "value" : "      ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiBackendFlags_HasSetMousePos",
+      "docComment" : "Backend Platform supports io.WantSetMousePos requests to reposition the OS mouse position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set).",
+      "qualType" : "ImGuiBackendFlags_",
+      "order" : 3,
+      "value" : "WidthG",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiBackendFlags_RendererHasVtxOffset",
+      "docComment" : "Backend Renderer supports ImDrawCmd::VtxOffset. This enables output of large meshes (64K+ vertices) while still using 16-bit indices.",
+      "qualType" : "ImGuiBackendFlags_",
+      "order" : 4,
+      "value" : " in ti",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiBackendFlags_PlatformHasViewports",
+      "docComment" : "Backend Platform supports multiple viewports.",
+      "qualType" : "ImGuiBackendFlags_",
+      "order" : 5,
+      "value" : "value w",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiBackendFlags_HasMouseHoveredViewport",
+      "docComment" : "Backend Platform supports setting io.MouseHoveredViewport to the viewport directly under the mouse _IGNORING_ viewports with the ImGuiViewportFlags_NoInputs flag and _REGARDLESS_ of whether another viewport is focused and may be capturing the mouse. This information is _NOT EASY_ to provide correctly with most high-level engines! Don't set this without studying _carefully_ how the backends handle ImGuiViewportFlags_NoInputs!",
+      "qualType" : "ImGuiBackendFlags_",
+      "order" : 6,
+      "value" : "UpdateL",
+      "evaluatedValue" : "2048"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiBackendFlags_RendererHasViewports",
+      "docComment" : "Backend Renderer supports multiple viewports.",
+      "qualType" : "ImGuiBackendFlags_",
+      "order" : 7,
+      "value" : "  ImGui",
+      "evaluatedValue" : "4096"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -5341,7 +17951,7 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Flags",
-      "qualType" : "int",
+      "qualType" : "ImGuiTableColumnFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -5386,8 +17996,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "UserID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WorkMinX",
@@ -5426,48 +18036,48 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NameOffset",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DisplayOrder",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "IndexWithinEnabledSet",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PrevEnabledColumn",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NextEnabledColumn",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SortOrder",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DrawChannelCurrent",
       "qualType" : "ImGuiTableDrawChannelIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DrawChannelFrozen",
       "qualType" : "ImGuiTableDrawChannelIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DrawChannelUnfrozen",
       "qualType" : "ImGuiTableDrawChannelIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "IsEnabled",
@@ -5511,38 +18121,615 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "NavLayerCurrent",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImS8",
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "AutoFitQueue",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "CannotSkipItemsQueue",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SortDirection",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SortDirectionsAvailCount",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SortDirectionsAvailMask",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SortDirectionsAvailList",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiCol_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Enumeration for PushStyleColor() / PopStyleColor()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_Text",
+      "qualType" : "ImGuiCol_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TextDisabled",
+      "qualType" : "ImGuiCol_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_WindowBg",
+      "docComment" : "Background of normal windows",
+      "qualType" : "ImGuiCol_",
+      "order" : 2,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ChildBg",
+      "docComment" : "Background of child windows",
+      "qualType" : "ImGuiCol_",
+      "order" : 3,
+      "evaluatedValue" : "3"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_PopupBg",
+      "docComment" : "Background of popups, menus, tooltips windows",
+      "qualType" : "ImGuiCol_",
+      "order" : 4,
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_Border",
+      "qualType" : "ImGuiCol_",
+      "order" : 5,
+      "evaluatedValue" : "5"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_BorderShadow",
+      "qualType" : "ImGuiCol_",
+      "order" : 6,
+      "evaluatedValue" : "6"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_FrameBg",
+      "docComment" : "Background of checkbox, radio button, plot, slider, text input",
+      "qualType" : "ImGuiCol_",
+      "order" : 7,
+      "evaluatedValue" : "7"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_FrameBgHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 8,
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_FrameBgActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 9,
+      "evaluatedValue" : "9"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TitleBg",
+      "qualType" : "ImGuiCol_",
+      "order" : 10,
+      "evaluatedValue" : "10"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TitleBgActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 11,
+      "evaluatedValue" : "11"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TitleBgCollapsed",
+      "qualType" : "ImGuiCol_",
+      "order" : 12,
+      "evaluatedValue" : "12"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_MenuBarBg",
+      "qualType" : "ImGuiCol_",
+      "order" : 13,
+      "evaluatedValue" : "13"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ScrollbarBg",
+      "qualType" : "ImGuiCol_",
+      "order" : 14,
+      "evaluatedValue" : "14"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ScrollbarGrab",
+      "qualType" : "ImGuiCol_",
+      "order" : 15,
+      "evaluatedValue" : "15"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ScrollbarGrabHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 16,
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ScrollbarGrabActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 17,
+      "evaluatedValue" : "17"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_CheckMark",
+      "qualType" : "ImGuiCol_",
+      "order" : 18,
+      "evaluatedValue" : "18"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_SliderGrab",
+      "qualType" : "ImGuiCol_",
+      "order" : 19,
+      "evaluatedValue" : "19"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_SliderGrabActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 20,
+      "evaluatedValue" : "20"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_Button",
+      "qualType" : "ImGuiCol_",
+      "order" : 21,
+      "evaluatedValue" : "21"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ButtonHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 22,
+      "evaluatedValue" : "22"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ButtonActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 23,
+      "evaluatedValue" : "23"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_Header",
+      "docComment" : "Header* colors are used for CollapsingHeader, TreeNode, Selectable, MenuItem",
+      "qualType" : "ImGuiCol_",
+      "order" : 24,
+      "evaluatedValue" : "24"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_HeaderHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 25,
+      "evaluatedValue" : "25"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_HeaderActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 26,
+      "evaluatedValue" : "26"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_Separator",
+      "qualType" : "ImGuiCol_",
+      "order" : 27,
+      "evaluatedValue" : "27"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_SeparatorHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 28,
+      "evaluatedValue" : "28"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_SeparatorActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 29,
+      "evaluatedValue" : "29"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ResizeGrip",
+      "qualType" : "ImGuiCol_",
+      "order" : 30,
+      "evaluatedValue" : "30"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ResizeGripHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 31,
+      "evaluatedValue" : "31"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ResizeGripActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 32,
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_Tab",
+      "qualType" : "ImGuiCol_",
+      "order" : 33,
+      "evaluatedValue" : "33"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TabHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 34,
+      "evaluatedValue" : "34"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TabActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 35,
+      "evaluatedValue" : "35"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TabUnfocused",
+      "qualType" : "ImGuiCol_",
+      "order" : 36,
+      "evaluatedValue" : "36"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TabUnfocusedActive",
+      "qualType" : "ImGuiCol_",
+      "order" : 37,
+      "evaluatedValue" : "37"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_DockingPreview",
+      "docComment" : "Preview overlay color when about to docking something",
+      "qualType" : "ImGuiCol_",
+      "order" : 38,
+      "evaluatedValue" : "38"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_DockingEmptyBg",
+      "docComment" : "Background color for empty node (e.g. CentralNode with no window docked into it)",
+      "qualType" : "ImGuiCol_",
+      "order" : 39,
+      "evaluatedValue" : "39"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_PlotLines",
+      "qualType" : "ImGuiCol_",
+      "order" : 40,
+      "evaluatedValue" : "40"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_PlotLinesHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 41,
+      "evaluatedValue" : "41"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_PlotHistogram",
+      "qualType" : "ImGuiCol_",
+      "order" : 42,
+      "evaluatedValue" : "42"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_PlotHistogramHovered",
+      "qualType" : "ImGuiCol_",
+      "order" : 43,
+      "evaluatedValue" : "43"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TableHeaderBg",
+      "docComment" : "Table header background",
+      "qualType" : "ImGuiCol_",
+      "order" : 44,
+      "evaluatedValue" : "44"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TableBorderStrong",
+      "docComment" : "Table outer and header borders (prefer using Alpha=1.0 here)",
+      "qualType" : "ImGuiCol_",
+      "order" : 45,
+      "evaluatedValue" : "45"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TableBorderLight",
+      "docComment" : "Table inner borders (prefer using Alpha=1.0 here)",
+      "qualType" : "ImGuiCol_",
+      "order" : 46,
+      "evaluatedValue" : "46"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TableRowBg",
+      "docComment" : "Table row background (even rows)",
+      "qualType" : "ImGuiCol_",
+      "order" : 47,
+      "evaluatedValue" : "47"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TableRowBgAlt",
+      "docComment" : "Table row background (odd rows)",
+      "qualType" : "ImGuiCol_",
+      "order" : 48,
+      "evaluatedValue" : "48"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_TextSelectedBg",
+      "qualType" : "ImGuiCol_",
+      "order" : 49,
+      "evaluatedValue" : "49"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_DragDropTarget",
+      "qualType" : "ImGuiCol_",
+      "order" : 50,
+      "evaluatedValue" : "50"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_NavHighlight",
+      "docComment" : "Gamepad/keyboard: current highlighted item",
+      "qualType" : "ImGuiCol_",
+      "order" : 51,
+      "evaluatedValue" : "51"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_NavWindowingHighlight",
+      "docComment" : "Highlight window when using CTRL+TAB",
+      "qualType" : "ImGuiCol_",
+      "order" : 52,
+      "evaluatedValue" : "52"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_NavWindowingDimBg",
+      "docComment" : "Darken/colorize entire screen behind the CTRL+TAB window list, when active",
+      "qualType" : "ImGuiCol_",
+      "order" : 53,
+      "evaluatedValue" : "53"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_ModalWindowDimBg",
+      "docComment" : "Darken/colorize entire screen behind a modal window, when one is active",
+      "qualType" : "ImGuiCol_",
+      "order" : 54,
+      "evaluatedValue" : "54"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCol_COUNT",
+      "qualType" : "ImGuiCol_",
+      "order" : 55,
+      "evaluatedValue" : "55"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiStyleVar_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Enumeration for PushStyleVar() / PopStyleVar() to temporarily modify the ImGuiStyle structure."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - The enum only refers to fields of ImGuiStyle which makes sense to be pushed/popped inside UI code."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   During initialization or between frames, feel free to just poke into ImGuiStyle directly."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Tip: Use your programming IDE navigation facilities on the names in the _second column_ below to find the actual members and their description."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   In Visual Studio IDE: CTRL+comma (\"Edit.NavigateTo\") can follow symbols in comments, whereas CTRL+F12 (\"Edit.GoToImplementation\") cannot."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   With Visual Assist installed: ALT+G (\"VAssistX.GoToImplementation\") can also follow symbols in comments."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - When changing this enum, you need to update the associated internal table GStyleVarInfo[] accordingly. This is where we link enum values to members offset/type."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_Alpha",
+      "docComment" : "float     Alpha",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_DisabledAlpha",
+      "docComment" : "float     DisabledAlpha",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_WindowPadding",
+      "docComment" : "ImVec2    WindowPadding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 2,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_WindowRounding",
+      "docComment" : "float     WindowRounding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 3,
+      "evaluatedValue" : "3"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_WindowBorderSize",
+      "docComment" : "float     WindowBorderSize",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 4,
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_WindowMinSize",
+      "docComment" : "ImVec2    WindowMinSize",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 5,
+      "evaluatedValue" : "5"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_WindowTitleAlign",
+      "docComment" : "ImVec2    WindowTitleAlign",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 6,
+      "evaluatedValue" : "6"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_ChildRounding",
+      "docComment" : "float     ChildRounding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 7,
+      "evaluatedValue" : "7"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_ChildBorderSize",
+      "docComment" : "float     ChildBorderSize",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 8,
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_PopupRounding",
+      "docComment" : "float     PopupRounding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 9,
+      "evaluatedValue" : "9"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_PopupBorderSize",
+      "docComment" : "float     PopupBorderSize",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 10,
+      "evaluatedValue" : "10"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_FramePadding",
+      "docComment" : "ImVec2    FramePadding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 11,
+      "evaluatedValue" : "11"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_FrameRounding",
+      "docComment" : "float     FrameRounding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 12,
+      "evaluatedValue" : "12"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_FrameBorderSize",
+      "docComment" : "float     FrameBorderSize",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 13,
+      "evaluatedValue" : "13"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_ItemSpacing",
+      "docComment" : "ImVec2    ItemSpacing",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 14,
+      "evaluatedValue" : "14"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_ItemInnerSpacing",
+      "docComment" : "ImVec2    ItemInnerSpacing",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 15,
+      "evaluatedValue" : "15"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_IndentSpacing",
+      "docComment" : "float     IndentSpacing",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 16,
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_CellPadding",
+      "docComment" : "ImVec2    CellPadding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 17,
+      "evaluatedValue" : "17"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_ScrollbarSize",
+      "docComment" : "float     ScrollbarSize",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 18,
+      "evaluatedValue" : "18"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_ScrollbarRounding",
+      "docComment" : "float     ScrollbarRounding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 19,
+      "evaluatedValue" : "19"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_GrabMinSize",
+      "docComment" : "float     GrabMinSize",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 20,
+      "evaluatedValue" : "20"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_GrabRounding",
+      "docComment" : "float     GrabRounding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 21,
+      "evaluatedValue" : "21"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_TabRounding",
+      "docComment" : "float     TabRounding",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 22,
+      "evaluatedValue" : "22"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_ButtonTextAlign",
+      "docComment" : "ImVec2    ButtonTextAlign",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 23,
+      "evaluatedValue" : "23"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_SelectableTextAlign",
+      "docComment" : "ImVec2    SelectableTextAlign",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 24,
+      "evaluatedValue" : "24"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiStyleVar_COUNT",
+      "qualType" : "ImGuiStyleVar_",
+      "order" : 25,
+      "evaluatedValue" : "25"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -5562,12 +18749,1244 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "BgColor",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Column",
       "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiTable",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " FIXME-TABLE: more transient data could be stored in a per-stacked table structure: DrawSplitter, SortSpecs, incoming RowData"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ID",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImGuiTableFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RawData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TempData",
+      "qualType" : "ImGuiTableTempData *",
+      "desugaredQualType" : "ImGuiTableTempData *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Columns",
+      "qualType" : "ImSpan<ImGuiTableColumn>",
+      "desugaredQualType" : "ImSpan<ImGuiTableColumn>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplayOrderToIndex",
+      "qualType" : "ImSpan<ImGuiTableColumnIdx>",
+      "desugaredQualType" : "ImSpan<signed char>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowCellData",
+      "qualType" : "ImSpan<ImGuiTableCellData>",
+      "desugaredQualType" : "ImSpan<ImGuiTableCellData>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "EnabledMaskByDisplayOrder",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "EnabledMaskByIndex",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "VisibleMaskByIndex",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RequestOutputMaskByIndex",
+      "qualType" : "ImU64",
+      "desugaredQualType" : "unsigned long long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SettingsLoadedFlags",
+      "qualType" : "ImGuiTableFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SettingsOffset",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastFrameActive",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsCount",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrentRow",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrentColumn",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InstanceCurrent",
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InstanceInteracted",
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowPosY1",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowPosY2",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowMinHeight",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowTextBaseline",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowIndentOffsetX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowFlags",
+      "qualType" : "ImGuiTableRowFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastRowFlags",
+      "qualType" : "ImGuiTableRowFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowBgColorCounter",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowBgColor",
+      "qualType" : "ImU32[2]",
+      "desugaredQualType" : "ImU32[2]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BorderColorStrong",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BorderColorLight",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BorderX1",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BorderX2",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostIndentX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MinColumnWidth",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OuterPaddingX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CellPaddingX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CellPaddingY",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CellSpacingX1",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CellSpacingX2",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastOuterHeight",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastFirstRowHeight",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InnerWidth",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsGivenWidth",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsAutoFitWidth",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ResizedColumnNextWidth",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ResizeLockMinContentsX2",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RefScale",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OuterRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InnerRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WorkRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InnerClipRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BgClipRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Bg0ClipRectForDrawCmd",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Bg2ClipRectForDrawCmd",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostClipRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupInnerClipRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OuterWindow",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InnerWindow",
+      "qualType" : "ImGuiWindow *",
+      "desugaredQualType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsNames",
+      "qualType" : "ImGuiTextBuffer",
+      "desugaredQualType" : "ImGuiTextBuffer"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DrawSplitter",
+      "qualType" : "ImDrawListSplitter *",
+      "desugaredQualType" : "ImDrawListSplitter *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SortSpecsSingle",
+      "qualType" : "ImGuiTableColumnSortSpecs",
+      "desugaredQualType" : "ImGuiTableColumnSortSpecs"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SortSpecsMulti",
+      "qualType" : "ImVector<ImGuiTableColumnSortSpecs>",
+      "desugaredQualType" : "ImVector<ImGuiTableColumnSortSpecs>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SortSpecs",
+      "qualType" : "ImGuiTableSortSpecs",
+      "desugaredQualType" : "ImGuiTableSortSpecs"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SortSpecsCount",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsEnabledCount",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsEnabledFixedCount",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DeclColumnsCount",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HoveredColumnBody",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HoveredColumnBorder",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AutoFitSingleColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ResizedColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastResizedColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HeldHeaderColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ReorderColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ReorderColumnDir",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LeftMostEnabledColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RightMostEnabledColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LeftMostStretchedColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RightMostStretchedColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ContextPopupColumn",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FreezeRowsRequest",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FreezeRowsCount",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FreezeColumnsRequest",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FreezeColumnsCount",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RowCellDataCurrent",
+      "qualType" : "ImGuiTableColumnIdx",
+      "desugaredQualType" : "signed char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DummyDrawChannel",
+      "qualType" : "ImGuiTableDrawChannelIdx",
+      "desugaredQualType" : "unsigned char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Bg2DrawChannelCurrent",
+      "qualType" : "ImGuiTableDrawChannelIdx",
+      "desugaredQualType" : "unsigned char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Bg2DrawChannelUnfrozen",
+      "qualType" : "ImGuiTableDrawChannelIdx",
+      "desugaredQualType" : "unsigned char"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsLayoutLocked",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsInsideRow",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsInitializing",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsSortSpecsDirty",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsUsingHeaders",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsContextPopupOpen",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsSettingsRequestLoad",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsSettingsDirty",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsDefaultDisplayOrder",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsResetAllRequest",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsResetDisplayOrderRequest",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsUnfrozenRows",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IsDefaultSizingPolicy",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MemoryCompacted",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostSkipItems",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiButtonFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for InvisibleButton() [extended in imgui_internal.h]"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiButtonFlags_None",
+      "qualType" : "ImGuiButtonFlags_",
+      "order" : 0,
+      "value" : "C",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiButtonFlags_MouseButtonLeft",
+      "docComment" : "React on left mouse button (default)",
+      "qualType" : "ImGuiButtonFlags_",
+      "order" : 1,
+      "value" : "      ",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiButtonFlags_MouseButtonRight",
+      "docComment" : "React on right mouse button",
+      "qualType" : "ImGuiButtonFlags_",
+      "order" : 2,
+      "value" : "by use",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiButtonFlags_MouseButtonMiddle",
+      "docComment" : "React on center mouse button",
+      "qualType" : "ImGuiButtonFlags_",
+      "order" : 3,
+      "value" : "mU64  ",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiButtonFlags_MouseButtonMask_",
+      "docComment" : "[Internal]",
+      "qualType" : "ImGuiButtonFlags_",
+      "order" : 4,
+      "value" : " hidden by user/api && not hidden by scrolling/cliprect)\n    ImU64                       RequestOutputMas",
+      "evaluatedValue" : "7"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiButtonFlags_MouseButtonDefault_",
+      "docComment" : "[Internal]",
+      "qualType" : "ImGuiButtonFlags_",
+      "order" : 5,
+      "value" : "Fit (== expect user to submit it",
+      "evaluatedValue" : "1"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiColorEditFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_None",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 0,
+      "value" : " ",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoAlpha",
+      "docComment" : "// ColorEdit, ColorPicker, ColorButton: ignore Alpha component (will only read 3 components from the input pointer).",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 1,
+      "value" : "      ",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoPicker",
+      "docComment" : "// ColorEdit: disable picker when clicking on color square.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 2,
+      "value" : "eginTa",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoOptions",
+      "docComment" : "// ColorEdit: disable toggling options menu when right-clicking on inputs/small preview.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 3,
+      "value" : "      ",
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoSmallPreview",
+      "docComment" : "// ColorEdit, ColorPicker: disable color square preview next to the inputs. (e.g. to show only the inputs)",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 4,
+      "value" : "r a wi",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoInputs",
+      "docComment" : "// ColorEdit, ColorPicker: disable inputs sliders/text widgets (e.g. to show only the small preview color square).",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 5,
+      "value" : " (gene",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoTooltip",
+      "docComment" : "// ColorEdit, ColorPicker, ColorButton: disable tooltip when hovering the preview.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 6,
+      "value" : ";     ",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoLabel",
+      "docComment" : "// ColorEdit, ColorPicker: disable display of inline text label (the label is still forwarded to the tooltip and picker).",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 7,
+      "value" : ";\n    ",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoSidePreview",
+      "docComment" : "// ColorPicker: disable bigger color preview on right side of the picker, use small color square preview instead.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 8,
+      "value" : " RowBg",
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoDragDrop",
+      "docComment" : "// ColorEdit: disable drag and drop target. ColorButton: disable drag and drop source.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 9,
+      "value" : "this.\n",
+      "evaluatedValue" : "512"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_NoBorder",
+      "docComment" : "// ColorButton: disable border (which is enforced by default)",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 10,
+      "value" : "Strong;",
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_AlphaBar",
+      "docComment" : "// ColorEdit, ColorPicker: show vertical alpha bar/gradient in picker.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 11,
+      "value" : "       ",
+      "evaluatedValue" : "65536"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_AlphaPreview",
+      "docComment" : "// ColorEdit, ColorPicker, ColorButton: display preview as a transparent color over a checkerboard, instead of opaque.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 12,
+      "value" : "    // ",
+      "evaluatedValue" : "131072"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_AlphaPreviewHalf",
+      "docComment" : "// ColorEdit, ColorPicker, ColorButton: display half opaque / half checkerboard, instead of opaque.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 13,
+      "value" : "       ",
+      "evaluatedValue" : "262144"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_HDR",
+      "docComment" : "// (WIP) ColorEdit: Currently only disable 0.0f..1.0f limits in RGBA edition (note: you probably want to use ImGuiColorEditFlags_Float flag as well).",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 14,
+      "value" : "stRowHe",
+      "evaluatedValue" : "524288"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_DisplayRGB",
+      "docComment" : "[Display]    // ColorEdit: override _display_ type among RGB/HSV/Hex. ColorPicker: select any combination using one or more of RGB/HSV/Hex.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 15,
+      "value" : "at     ",
+      "evaluatedValue" : "1048576"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_DisplayHSV",
+      "docComment" : "[Display]    // \"",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 16,
+      "value" : " clippe",
+      "evaluatedValue" : "2097152"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_DisplayHex",
+      "docComment" : "[Display]    // \"",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 17,
+      "value" : "dow\n   ",
+      "evaluatedValue" : "4194304"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_Uint8",
+      "docComment" : "[DataType]   // ColorEdit, ColorPicker, ColorButton: _display_ values formatted as 0..255.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 18,
+      "value" : "       ",
+      "evaluatedValue" : "8388608"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_Float",
+      "docComment" : "[DataType]   // ColorEdit, ColorPicker, ColorButton: _display_ values formatted as 0.0f..1.0f floats instead of 0..255 integers. No round-trip of value via integers.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 19,
+      "value" : "low gro",
+      "evaluatedValue" : "16777216"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_PickerHueBar",
+      "docComment" : "[Picker]     // ColorPicker: bar for Hue, rectangle for Sat/Value.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 20,
+      "value" : " for no",
+      "evaluatedValue" : "33554432"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_PickerHueWheel",
+      "docComment" : "[Picker]     // ColorPicker: wheel for Hue, triangle for Sat/Value.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 21,
+      "value" : "ble().\n",
+      "evaluatedValue" : "67108864"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_InputRGB",
+      "docComment" : "[Input]      // ColorEdit, ColorPicker: input and output data in RGB format.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 22,
+      "value" : "for non",
+      "evaluatedValue" : "134217728"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_InputHSV",
+      "docComment" : "[Input]      // ColorEdit, ColorPicker: input and output data in HSV format.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 23,
+      "value" : ";\n    I",
+      "evaluatedValue" : "268435456"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_DefaultOptions_",
+      "docComment" : "Defaults Options. You can set application defaults using SetColorEditOptions(). The intent is that you probably don't want to override them in most of your calls. Let the user choose via the option menu and/or call SetColorEditOptions() once during startup.",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 24,
+      "value" : "lip rect for BG2 channel. This tends to be a correct, tight-fit, because output to BG2 are done by widgets relying on regula",
+      "evaluatedValue" : "177209344"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_DisplayMask_",
+      "docComment" : "[Internal] Masks",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 25,
+      "value" : "   // This is used to check if we can eventually merge our columns draw calls into the current d",
+      "evaluatedValue" : "7340032"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_DataTypeMask_",
+      "docComment" : "[Internal] Masks",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 26,
+      "value" : "                    HostBackupInnerClipRect;    // Ba",
+      "evaluatedValue" : "25165824"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_PickerMask_",
+      "docComment" : "[Internal] Masks",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 27,
+      "value" : "leBackground()/PopTableBackground()\n    ImGuiWindow*                O",
+      "evaluatedValue" : "100663296"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_InputMask_",
+      "docComment" : "[Internal] Masks",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 28,
+      "value" : "for the table\n    ImGuiWindow*                InnerWindow; ",
+      "evaluatedValue" : "402653184"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_RGB",
+      "docComment" : "[renamed in 1.69]",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 29,
+      "value" : "ColumnsNames;               //",
+      "evaluatedValue" : "1048576"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_HSV",
+      "docComment" : "[renamed in 1.69]",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 30,
+      "value" : "olumns names\n    ImDrawListSpl",
+      "evaluatedValue" : "2097152"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiColorEditFlags_HEX",
+      "docComment" : "[renamed in 1.69]",
+      "qualType" : "ImGuiColorEditFlags_",
+      "order" : 31,
+      "value" : "               // Shortcut to ",
+      "evaluatedValue" : "4194304"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiSliderFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for DragFloat(), DragInt(), SliderFloat(), SliderInt() etc."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " We use the same sets of flags for DragXXX() and SliderXXX() functions as the features are the same and it makes it easier to swap them."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSliderFlags_None",
+      "qualType" : "ImGuiSliderFlags_",
+      "order" : 0,
+      "value" : "o",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSliderFlags_AlwaysClamp",
+      "docComment" : "Clamp value to min/max bounds when input manually with CTRL+Click. By default CTRL+Click allows going out of bounds.",
+      "qualType" : "ImGuiSliderFlags_",
+      "order" : 1,
+      "value" : " specs",
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSliderFlags_Logarithmic",
+      "docComment" : "Make the widget logarithmic (linear otherwise). Consider using ImGuiSliderFlags_NoRoundToFormat with this if using a format-string with small amount of digits.",
+      "qualType" : "ImGuiSliderFlags_",
+      "order" : 2,
+      "value" : "ed col",
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSliderFlags_NoRoundToFormat",
+      "docComment" : "Disable rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits)",
+      "qualType" : "ImGuiSliderFlags_",
+      "order" : 3,
+      "value" : "pColum",
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSliderFlags_NoInput",
+      "docComment" : "Disable CTRL+Click or Enter key allowing to input text directly into the widget",
+      "qualType" : "ImGuiSliderFlags_",
+      "order" : 4,
+      "value" : "ght-mo",
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSliderFlags_InvalidMask_",
+      "docComment" : "[Internal] We treat using those bits as being potentially a 'float power' argument from the previous API that has got miscast to this enum, and will trigger an assert if needed.",
+      "qualType" : "ImGuiSliderFlags_",
+      "order" : 5,
+      "value" : "ng).\n    I",
+      "evaluatedValue" : "1879048207"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiSliderFlags_ClampOnInput",
+      "docComment" : "[renamed in 1.79]",
+      "qualType" : "ImGuiSliderFlags_",
+      "order" : 6,
+      "value" : " being resized from previous",
+      "evaluatedValue" : "16"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiMouseButton_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Identify a mouse button."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Those values are guaranteed to be stable and we frequently use 0/1 directly. Named enums provided for convenience."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseButton_Left",
+      "qualType" : "ImGuiMouseButton_",
+      "order" : 0,
+      "value" : "l",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseButton_Right",
+      "qualType" : "ImGuiMouseButton_",
+      "order" : 1,
+      "value" : ";",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseButton_Middle",
+      "qualType" : "ImGuiMouseButton_",
+      "order" : 2,
+      "value" : "T",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseButton_COUNT",
+      "qualType" : "ImGuiMouseButton_",
+      "order" : 3,
+      "value" : "n",
+      "evaluatedValue" : "5"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiMouseCursor_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Enumeration for GetMouseCursor()"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " User code may request backend to display given cursor by calling SetMouseCursor(), which is why we have some cursors that are marked unused here"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_None",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 0,
+      "value" : " s",
+      "evaluatedValue" : "-1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_Arrow",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 1,
+      "value" : "C",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_TextInput",
+      "docComment" : "When hovering over InputText, etc.",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 2,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_ResizeAll",
+      "docComment" : "(Unused by Dear ImGui functions)",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 3,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_ResizeNS",
+      "docComment" : "When hovering over an horizontal border",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 4,
+      "evaluatedValue" : "3"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_ResizeEW",
+      "docComment" : "When hovering over a vertical border or a column",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 5,
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_ResizeNESW",
+      "docComment" : "When hovering over the bottom-left corner of a window",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 6,
+      "evaluatedValue" : "5"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_ResizeNWSE",
+      "docComment" : "When hovering over the bottom-right corner of a window",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 7,
+      "evaluatedValue" : "6"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_Hand",
+      "docComment" : "(Unused by Dear ImGui functions. Use for e.g. hyperlinks)",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 8,
+      "evaluatedValue" : "7"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_NotAllowed",
+      "docComment" : "When hovering something with disallowed interaction. Usually a crossed circle.",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 9,
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiMouseCursor_COUNT",
+      "qualType" : "ImGuiMouseCursor_",
+      "order" : 10,
+      "evaluatedValue" : "9"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiCond_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Enumeration for ImGui::SetWindow***(), SetNextWindow***(), SetNextItem***() functions"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Represent a condition."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Important: Treat as a regular enum! Do NOT combine multiple values using binary operators! All the functions above treat 0 as a shortcut to ImGuiCond_Always."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCond_None",
+      "docComment" : "No condition (always set the variable), same as _Always",
+      "qualType" : "ImGuiCond_",
+      "order" : 0,
+      "value" : "]",
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCond_Always",
+      "docComment" : "No condition (always set the variable)",
+      "qualType" : "ImGuiCond_",
+      "order" : 1,
+      "value" : "ocked;",
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCond_Once",
+      "docComment" : "Set the variable once per runtime session (only the first call will succeed)",
+      "qualType" : "ImGuiCond_",
+      "order" : 2,
+      "value" : "e firs",
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCond_FirstUseEver",
+      "docComment" : "Set the variable if the object/window has no persistently saved data (no entry in .ini file)",
+      "qualType" : "ImGuiCond_",
+      "order" : 3,
+      "value" : ").\n   ",
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiCond_Appearing",
+      "docComment" : "Set the variable if the object/window is appearing after being hidden/inactive (or the first time)",
+      "qualType" : "ImGuiCond_",
+      "order" : 4,
+      "value" : "singHe",
+      "evaluatedValue" : "8"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImNewWrapper",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " IM_MALLOC(), IM_FREE(), IM_NEW(), IM_PLACEMENT_NEW(), IM_DELETE()"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " We call C++ constructor on own allocated memory via the placement \"new(ptr) Type()\" syntax."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Defining a custom placement new() with a custom parameter allows us to bypass including "
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "<new"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "> which on some platforms complains when user has disabled exceptions."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiTableTempData",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Transient data that are only needed between BeginTable() and EndTable(), those buffers are shared (1 per level of stacked table)."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Accessing those requires chasing an extra pointer so for very frequently used data we leave them in the main table structure."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - We also leave out of this structure data that tend to be particularly useful for debugging/metrics."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TableIndex",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LastTimeActive",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "UserOuterSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DrawSplitter",
+      "qualType" : "ImDrawListSplitter",
+      "desugaredQualType" : "ImDrawListSplitter"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupWorkRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupParentWorkRect",
+      "qualType" : "ImRect",
+      "desugaredQualType" : "ImRect"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupPrevLineSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupCurrLineSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupCursorMaxPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupColumnsOffset",
+      "qualType" : "ImVec1",
+      "desugaredQualType" : "ImVec1"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupItemWidth",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "HostBackupItemWidthStackSize",
+      "qualType" : "int",
       "desugaredQualType" : "int"
     } ]
   }, {
@@ -5590,38 +20009,38 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "UserID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Index",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "DisplayOrder",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SortOrder",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SortDirection",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "IsEnabled",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "IsStretch",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImU8",
+      "desugaredQualType" : "unsigned char"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -5638,12 +20057,12 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ID",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "SaveFlags",
-      "qualType" : "int",
+      "qualType" : "ImGuiTableFlags",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -5654,12 +20073,12 @@
       "@type" : "AstFieldDecl",
       "name" : "ColumnsCount",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "ColumnsCountMax",
       "qualType" : "ImGuiTableColumnIdx",
-      "desugaredQualType" : "int"
+      "desugaredQualType" : "signed char"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "WantApply",
@@ -5723,9 +20142,341 @@
       "resultType" : "ImGuiWindow *"
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "SetCurrentFont",
-      "resultType" : "IMGUI_API",
+      "name" : "FindWindowByID",
+      "resultType" : "ImGuiWindow *",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindWindowByName",
+      "resultType" : "ImGuiWindow *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "UpdateWindowParentAndRootLinks",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiWindowFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "parent_window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcWindowNextAutoFitSize",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowChildOf",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "potential_parent",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_hierarchy",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "dock_hierarchy",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowWithinBeginStackOf",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "potential_parent",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowAbove",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "potential_above",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "potential_below",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsWindowNavFocusable",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowPos",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowSize",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowCollapsed",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "collapsed",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowHitTestHole",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "WindowRectAbsToRel",
+      "resultType" : "ImRect",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "r",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "WindowRectRelToAbs",
+      "resultType" : "ImRect",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "r",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FocusWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Windows: Display Order and Focus Order"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FocusTopMostWindowUnderOne",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "under_this_window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "ignore_window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BringWindowToFocusFront",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BringWindowToDisplayFront",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BringWindowToDisplayBack",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BringWindowToDisplayBehind",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "above_window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindWindowDisplayIndex",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindBottomMostVisibleWindowWithinBeginStack",
+      "resultType" : "ImGuiWindow *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetCurrentFont",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "font",
+        "qualType" : "ImFont *",
+        "desugaredQualType" : "ImFont *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5734,20 +20485,44 @@
             "text" : " Fonts, drawing"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "font",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetDefaultFont",
-      "resultType" : "int *"
+      "resultType" : "ImFont *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetForegroundDrawList",
+      "resultType" : "ImDrawList *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Initialize",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "context",
+        "qualType" : "ImGuiContext *",
+        "desugaredQualType" : "ImGuiContext *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Init"
+          } ]
+        } ]
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "Shutdown",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "context",
@@ -5757,7 +20532,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "UpdateHoveredWindowAndCaptureFlags",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstFullComment",
         "decls" : [ {
@@ -5770,16 +20545,70 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "StartMouseMovingWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "StartMouseMovingWindowOrNode",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "node",
+        "qualType" : "ImGuiDockNode *",
+        "desugaredQualType" : "ImGuiDockNode *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "undock_floating_node",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "UpdateMouseMovingWindowNewFrame",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "UpdateMouseMovingWindowEndFrame",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddContextHook",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "context",
+        "qualType" : "ImGuiContext *",
+        "desugaredQualType" : "ImGuiContext *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "hook",
+        "qualType" : "const ImGuiContextHook *",
+        "desugaredQualType" : "const ImGuiContextHook *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Generic context hooks"
+          } ]
+        } ]
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RemoveContextHook",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "context",
@@ -5788,13 +20617,13 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "hook_to_remove",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "CallContextHooks",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "context",
@@ -5809,8 +20638,23 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TranslateWindowsInViewport",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "viewport",
+        "qualType" : "ImGuiViewportP *",
+        "desugaredQualType" : "ImGuiViewportP *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "old_pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "new_pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5819,26 +20663,11 @@
             "text" : " Viewports"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "viewport",
-        "qualType" : "ImGuiViewportP *",
-        "desugaredQualType" : "ImGuiViewportP *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "old_pos",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "new_pos",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ScaleWindowsInViewport",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "viewport",
@@ -5853,7 +20682,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DestroyPlatformWindow",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "viewport",
@@ -5862,8 +20691,33 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "SetCurrentViewport",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "viewport",
+        "qualType" : "ImGuiViewportP *",
+        "desugaredQualType" : "ImGuiViewportP *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetViewportPlatformMonitor",
+      "resultType" : "const ImGuiPlatformMonitor *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "viewport",
+        "qualType" : "ImGuiViewport *",
+        "desugaredQualType" : "ImGuiViewport *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "MarkIniSettingsDirty",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstFullComment",
         "decls" : [ {
@@ -5876,13 +20730,68 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "MarkIniSettingsDirty",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "ClearIniSettings",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CreateNewWindowSettings",
+      "resultType" : "ImGuiWindowSettings *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindWindowSettings",
+      "resultType" : "ImGuiWindowSettings *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindOrCreateWindowSettings",
+      "resultType" : "ImGuiWindowSettings *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindSettingsHandler",
+      "resultType" : "ImGuiSettingsHandler *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "type_name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextWindowScroll",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "scroll",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5891,17 +20800,88 @@
             "text" : " Scrolling"
           } ]
         } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollX",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "scroll",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "name" : "scroll_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollY",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scroll_y",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollFromPosX",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "local_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "center_x_ratio",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetScrollFromPosY",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "local_y",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "center_y_ratio",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ScrollToItem",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiScrollFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5910,6 +20890,21 @@
             "text" : " Early work-in-progress API (ScrollToItem() will become public)"
           } ]
         } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ScrollToRect",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rect",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
@@ -5919,68 +20914,193 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "SetFocusID",
-      "resultType" : "IMGUI_API",
+      "name" : "ScrollToRectEx",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rect",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiScrollFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ScrollToBringRectIntoView",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rect",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : "#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetItemID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Basic Accessors"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetItemStatusFlags",
+      "resultType" : "ImGuiItemStatusFlags"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetItemFlags",
+      "resultType" : "ImGuiItemFlags"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetActiveID",
+      "resultType" : "ImGuiID"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFocusID",
+      "resultType" : "ImGuiID"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetActiveID",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "window",
-        "qualType" : "struct ImGuiWindow *",
-        "desugaredQualType" : "struct ImGuiWindow *"
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetFocusID",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ClearActiveID",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetHoveredID",
+      "resultType" : "ImGuiID"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetHoveredID",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "KeepAliveID",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "MarkItemEdited",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushOverrideID",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetIDWithSeed",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id_begin",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "seed",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ItemSize",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_baseline_y",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "-1.0f"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -5989,22 +21109,11 @@
             "text" : " Basic Helpers for widget code"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "text_baseline_y",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "-1.0f"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ItemSize",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
@@ -6020,7 +21129,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ItemAdd",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
@@ -6029,8 +21138,8 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "nav_bb",
@@ -6047,7 +21156,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ItemHoverable",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
@@ -6056,13 +21165,13 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsClippedEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
@@ -6071,18 +21180,18 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetLastItemData",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "item_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "in_flags",
@@ -6101,13 +21210,33 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "CalcItemSize",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_w",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_h",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "CalcWrapWidthForPos",
-      "resultType" : "IMGUI_API",
+      "resultType" : "float",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "wrap_pos_x",
@@ -6117,7 +21246,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushMultiItemsWidths",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "components",
@@ -6132,11 +21261,15 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsItemToggledSelection",
-      "resultType" : "IMGUI_API"
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetContentRegionMaxAbs",
+      "resultType" : "ImVec2"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ShrinkWidths",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "items",
@@ -6156,17 +21289,8 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushItemFlag",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Parameter stacks"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "option",
         "qualType" : "ImGuiItemFlags",
@@ -6176,15 +21300,115 @@
         "name" : "enabled",
         "qualType" : "bool",
         "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Parameter stacks"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PopItemFlag",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FocusableItemRegister",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Currently refactoring focus/nav/tabbing system"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " If you have old/custom copy-and-pasted widgets that used FocusableItemRegister():"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  (Old) IMGUI_VERSION_NUM  "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "<"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " 18209: using 'ItemAdd(....)'                              and 'bool tab_focused = FocusableItemRegister(...)'"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  (Old) IMGUI_VERSION_NUM >= 18209: using 'ItemAdd(..., ImGuiItemAddFlags_Focusable)'  and 'bool tab_focused = (GetItemStatusFlags() "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "&"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " ImGuiItemStatusFlags_Focused) != 0'"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "  (New) IMGUI_VERSION_NUM >= 18413: using 'ItemAdd(..., ImGuiItemFlags_Inputable)'     and 'bool tab_focused = (GetItemStatusFlags() "
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "&"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " ImGuiItemStatusFlags_FocusedTabbing) != 0 || g.NavActivateInputId == id' (WIP)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Widget code are simplified as there's no need to call FocusableItemUnregister() while managing the transition from regular widget to TempInputText()"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FocusableItemUnregister",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "LogBegin",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "type",
+        "qualType" : "ImGuiLogType",
+        "desugaredQualType" : "ImGuiLogType"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "auto_open_depth",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Logging/Capture"
+          } ]
+        } ]
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "LogToBuffer",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "auto_open_depth",
@@ -6195,12 +21419,12 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "LogRenderedText",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ref_pos",
-        "qualType" : "const int *",
-        "desugaredQualType" : "const int *"
+        "qualType" : "const ImVec2 *",
+        "desugaredQualType" : "const ImVec2 *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
@@ -6216,7 +21440,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "LogSetNextTextDecoration",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "prefix",
@@ -6231,17 +21455,8 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginChildEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Popups, Modals, Tooltips"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "name",
         "qualType" : "const char *",
@@ -6249,13 +21464,13 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "size_arg",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "border",
@@ -6264,29 +21479,38 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiWindowFlags",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Popups, Modals, Tooltips"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "OpenPopupEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "popup_flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiPopupFlags",
         "desugaredQualType" : "int",
-        "defaultValue" : "="
+        "defaultValue" : "ImGuiPopupFlags_None"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ClosePopupToLevel",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "remaining",
@@ -6300,42 +21524,57 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "ClosePopupsOverWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ref_window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "restore_focus_to_window_under_popup",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "ClosePopupsExceptModals",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsPopupOpen",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "popup_flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiPopupFlags",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginPopupEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "extra_flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiWindowFlags",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginTooltipEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "tooltip_flags",
@@ -6344,23 +21583,77 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "extra_window_flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiWindowFlags",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "BeginViewportSideBar",
-      "resultType" : "IMGUI_API",
+      "name" : "GetPopupAllowedExtentRect",
+      "resultType" : "ImRect",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Menus"
-          } ]
-        } ]
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTopMostPopupModal",
+      "resultType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTopMostAndVisiblePopupModal",
+      "resultType" : "ImGuiWindow *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindBestWindowPosForPopup",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindBestWindowPosForPopupEx",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ref_pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "last_dir",
+        "qualType" : "ImGuiDir *",
+        "desugaredQualType" : "ImGuiDir *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "r_outer",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "r_avoid",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "policy",
+        "qualType" : "ImGuiPopupPositionPolicy",
+        "desugaredQualType" : "ImGuiPopupPositionPolicy"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginViewportSideBar",
+      "resultType" : "bool",
+      "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "name",
         "qualType" : "const char *",
@@ -6368,12 +21661,12 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "viewport",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImGuiViewport *",
+        "desugaredQualType" : "ImGuiViewport *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "dir",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -6383,13 +21676,22 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "window_flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiWindowFlags",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Menus"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginMenuEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -6410,7 +21712,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "MenuItemEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -6443,8 +21745,23 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginComboPopup",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "popup_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "bb",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiComboFlags",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6453,51 +21770,60 @@
             "text" : " Combos"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "popup_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginComboPreview",
-      "resultType" : "IMGUI_API"
+      "resultType" : "bool"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "EndComboPreview",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "NavInitWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "force_reinit",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Gamepad/Keyboard Navigation"
+          } ]
+        } ]
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "NavInitRequestApplyResult",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "NavMoveRequestButNoResultYet",
-      "resultType" : "IMGUI_API"
+      "resultType" : "bool"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "NavMoveRequestSubmit",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "move_dir",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "clip_dir",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -6513,16 +21839,16 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "NavMoveRequestForward",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "move_dir",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "clip_dir",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -6538,7 +21864,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "NavMoveRequestResolveWithLastItem",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "result",
@@ -6548,19 +21874,34 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "NavMoveRequestCancel",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "NavMoveRequestApplyResult",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "NavMoveRequestTryWrapping",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "move_flags",
+        "qualType" : "ImGuiNavMoveFlags",
+        "desugaredQualType" : "int"
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetNavInputAmount",
-      "resultType" : "IMGUI_API",
+      "resultType" : "float",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "n",
-        "qualType" : "int",
+        "qualType" : "ImGuiNavInput",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -6570,8 +21911,35 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "GetNavInputAmount2d",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dir_sources",
+        "qualType" : "ImGuiNavDirSourceFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "mode",
+        "qualType" : "ImGuiInputReadMode",
+        "desugaredQualType" : "ImGuiInputReadMode"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "slow_factor",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "0.0f"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "fast_factor",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "0.0f"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "CalcTypematicRepeatAmount",
-      "resultType" : "IMGUI_API",
+      "resultType" : "int",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "t0",
@@ -6596,22 +21964,22 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ActivateItem",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNavID",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "nav_layer",
@@ -6620,19 +21988,24 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "focus_scope_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "rect_rel",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushFocusScope",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6647,28 +22020,23 @@
             "text" : " patterns generally need to react (e.g. clear selection) when landing on an item of the set."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PopFocusScope",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetFocusedFocusScope",
-      "resultType" : "int"
+      "resultType" : "ImGuiID"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetFocusScope",
-      "resultType" : "int"
+      "resultType" : "ImGuiID"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetItemUsingMouseWheel",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstFullComment",
         "decls" : [ {
@@ -6685,7 +22053,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetActiveIdUsingNavAndKeys",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsActiveIdUsingNavDir",
@@ -6693,7 +22061,7 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "dir",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       } ]
     }, {
@@ -6703,7 +22071,7 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "input",
-        "qualType" : "int",
+        "qualType" : "ImGuiNavInput",
         "desugaredQualType" : "int"
       } ]
     }, {
@@ -6713,17 +22081,17 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "key",
-        "qualType" : "int",
+        "qualType" : "ImGuiKey",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsMouseDragPastThreshold",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "button",
-        "qualType" : "int",
+        "qualType" : "ImGuiMouseButton",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -6739,7 +22107,7 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "key",
-        "qualType" : "int",
+        "qualType" : "ImGuiKey",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -6755,7 +22123,7 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "n",
-        "qualType" : "int",
+        "qualType" : "ImGuiNavInput",
         "desugaredQualType" : "int"
       } ]
     }, {
@@ -6765,7 +22133,7 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "n",
-        "qualType" : "int",
+        "qualType" : "ImGuiNavInput",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -6775,9 +22143,18 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "GetMergedKeyModFlags",
+      "resultType" : "ImGuiKeyModFlags"
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "DockContextInitialize",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "ImGuiContext *",
+        "desugaredQualType" : "ImGuiContext *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -6789,16 +22166,11 @@
             "text" : " (some functions are only declared in imgui.cpp, see Docking section)"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "ctx",
-        "qualType" : "ImGuiContext *",
-        "desugaredQualType" : "ImGuiContext *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextShutdown",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6808,7 +22180,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextClearNodes",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6817,8 +22189,8 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "root_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "clear_settings_refs",
@@ -6828,7 +22200,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextRebuildNodes",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6838,7 +22210,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextNewFrameUpdateUndocking",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6848,7 +22220,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextNewFrameUpdateDocking",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6858,7 +22230,17 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextEndFrame",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "ImGuiContext *",
+        "desugaredQualType" : "ImGuiContext *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DockContextGenNodeID",
+      "resultType" : "ImGuiID",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6868,7 +22250,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextQueueDock",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6877,8 +22259,8 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "target",
-        "qualType" : "struct ImGuiWindow *",
-        "desugaredQualType" : "struct ImGuiWindow *"
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "target_node",
@@ -6887,12 +22269,12 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "payload",
-        "qualType" : "struct ImGuiWindow *",
-        "desugaredQualType" : "struct ImGuiWindow *"
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "split_dir",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -6908,7 +22290,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextQueueUndockWindow",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6917,13 +22299,13 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "window",
-        "qualType" : "struct ImGuiWindow *",
-        "desugaredQualType" : "struct ImGuiWindow *"
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockContextQueueUndockNode",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ctx",
@@ -6937,8 +22319,43 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "DockContextCalcDropPosForDocking",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "target",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "target_node",
+        "qualType" : "ImGuiDockNode *",
+        "desugaredQualType" : "ImGuiDockNode *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "payload",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "split_dir",
+        "qualType" : "ImGuiDir",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "split_outer",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_pos",
+        "qualType" : "ImVec2 *",
+        "desugaredQualType" : "ImVec2 *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "DockNodeBeginAmendTabBar",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node",
@@ -6948,7 +22365,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockNodeEndAmendTabBar",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockNodeGetRootNode",
@@ -6987,7 +22404,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockNodeGetWindowMenuButtonId",
-      "resultType" : "int",
+      "resultType" : "ImGuiID",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node",
@@ -7000,9 +22417,84 @@
       "resultType" : "ImGuiDockNode *"
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "DockBuilderDockWindow",
-      "resultType" : "IMGUI_API",
+      "name" : "GetWindowAlwaysWantOwnTabBar",
+      "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginDocked",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginDockableDragDropSource",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginDockableDragDropTarget",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowDock",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "dock_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DockBuilderDockWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window_name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "node_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -7035,46 +22527,63 @@
             "text" : " - Call DockBuilderFinish() after you are done."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "window_name",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DockBuilderGetNode",
+      "resultType" : "ImGuiDockNode *",
+      "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderGetCentralNode",
-      "resultType" : "struct ImGuiDockNode *",
+      "resultType" : "ImGuiDockNode *",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DockBuilderAddNode",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "node_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int",
+        "defaultValue" : "0"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiDockNodeFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderRemoveNode",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderRemoveNodeDockedWindows",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "clear_settings_refs",
@@ -7085,87 +22594,117 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderRemoveNodeChildNodes",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderSetNodePos",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderSetNodeSize",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "size",
-        "qualType" : "int",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DockBuilderSplitNode",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "node_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "split_dir",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size_ratio_for_node_at_dir",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_id_at_dir",
+        "qualType" : "ImGuiID *",
+        "desugaredQualType" : "ImGuiID *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_id_at_opposite_dir",
+        "qualType" : "ImGuiID *",
+        "desugaredQualType" : "ImGuiID *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderCopyDockSpace",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "src_dockspace_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "dst_dockspace_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "in_window_remap_pairs",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImVector<const char *> *",
+        "desugaredQualType" : "ImVector<const char *> *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderCopyNode",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "src_node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "dst_node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "out_node_remap_pairs",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImVector<ImGuiID> *",
+        "desugaredQualType" : "ImVector<ImGuiID> *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderCopyWindowSettings",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "src_name",
@@ -7180,18 +22719,28 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DockBuilderFinish",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginDragDropTargetCustom",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "bb",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -7200,29 +22749,43 @@
             "text" : " Drag and Drop"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ClearDragDrop",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsDragDropPayloadBeingAccepted",
-      "resultType" : "IMGUI_API"
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetWindowClipRectBeforeSetChannel",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "clip_rect",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Internal Columns API (this is not exposed because we will encourage transitioning to the Tables API)"
+          } ]
+        } ]
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginColumns",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "str_id",
@@ -7243,11 +22806,11 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "EndColumns",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushColumnClipRect",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "column_index",
@@ -7257,20 +22820,50 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushColumnsBackground",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PopColumnsBackground",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetColumnsID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindOrCreateColumns",
+      "resultType" : "ImGuiOldColumns *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetColumnOffsetFromNorm",
-      "resultType" : "IMGUI_API",
+      "resultType" : "float",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "columns",
-        "qualType" : "const struct ImGuiOldColumns *",
-        "desugaredQualType" : "const struct ImGuiOldColumns *"
+        "qualType" : "const ImGuiOldColumns *",
+        "desugaredQualType" : "const ImGuiOldColumns *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "offset_norm",
@@ -7280,12 +22873,12 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetColumnNormFromOffset",
-      "resultType" : "IMGUI_API",
+      "resultType" : "float",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "columns",
-        "qualType" : "const struct ImGuiOldColumns *",
-        "desugaredQualType" : "const struct ImGuiOldColumns *"
+        "qualType" : "const ImGuiOldColumns *",
+        "desugaredQualType" : "const ImGuiOldColumns *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "offset",
@@ -7295,8 +22888,14 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TableOpenContextMenu",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "-1"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -7305,17 +22904,11 @@
             "text" : " Tables: Candidates for public API"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "column_n",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "-1"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TableSetColumnWidth",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "column_n",
@@ -7330,7 +22923,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TableSetColumnSortDirection",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "column_n",
@@ -7339,7 +22932,7 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "sort_direction",
-        "qualType" : "int",
+        "qualType" : "ImGuiSortDirection",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -7350,19 +22943,19 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TableGetHoveredColumn",
-      "resultType" : "IMGUI_API"
+      "resultType" : "int"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TableGetHeaderRowHeight",
-      "resultType" : "IMGUI_API"
+      "resultType" : "float"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TablePushBackgroundChannel",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TablePopBackgroundChannel",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetCurrentTable",
@@ -7379,8 +22972,18 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "TableFindByID",
+      "resultType" : "ImGuiTable *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "BeginTableEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "name",
@@ -7389,8 +22992,8 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "columns_count",
@@ -7399,14 +23002,14 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiTableFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "outer_size",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
         "defaultValue" : "ImVec2(0, 0)"
       }, {
         "@type" : "AstParmVarDecl",
@@ -7417,28 +23020,264 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "TableGetColumnName",
-      "resultType" : "const IMGUI_API *",
+      "name" : "TableBeginInitMemory",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "table",
-        "qualType" : "const struct ImGuiTable *",
-        "desugaredQualType" : "const struct ImGuiTable *"
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "columns_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableBeginApplyRequests",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSetupDrawChannels",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableUpdateLayout",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableUpdateBorders",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableUpdateColumnsWeightFromWidth",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableDrawBorders",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableDrawContextMenu",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableMergeDrawChannels",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSortSpecsSanitize",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSortSpecsBuild",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetColumnNextSortDirection",
+      "resultType" : "ImGuiSortDirection",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "column",
+        "qualType" : "ImGuiTableColumn *",
+        "desugaredQualType" : "ImGuiTableColumn *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableFixColumnSortDirection",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column",
+        "qualType" : "ImGuiTableColumn *",
+        "desugaredQualType" : "ImGuiTableColumn *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetColumnWidthAuto",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column",
+        "qualType" : "ImGuiTableColumn *",
+        "desugaredQualType" : "ImGuiTableColumn *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableBeginRow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableEndRow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableBeginCell",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "column_n",
         "qualType" : "int",
         "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableEndCell",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetCellBgRect",
+      "resultType" : "ImRect",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "const ImGuiTable *",
+        "desugaredQualType" : "const ImGuiTable *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetColumnName",
+      "resultType" : "const char *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "const ImGuiTable *",
+        "desugaredQualType" : "const ImGuiTable *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetColumnResizeID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "const ImGuiTable *",
+        "desugaredQualType" : "const ImGuiTable *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "instance_no",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TableGetMaxColumnWidth",
-      "resultType" : "IMGUI_API",
+      "resultType" : "float",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "table",
-        "qualType" : "const struct ImGuiTable *",
-        "desugaredQualType" : "const struct ImGuiTable *"
+        "qualType" : "const ImGuiTable *",
+        "desugaredQualType" : "const ImGuiTable *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "column_n",
@@ -7447,8 +23286,53 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "TableSetColumnWidthAutoSingle",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "column_n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSetColumnWidthAutoAll",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableRemove",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "TableGcCompactTransientBuffers",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGcCompactTransientBuffers",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "table",
@@ -7458,11 +23342,60 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TableGcCompactSettings",
-      "resultType" : "IMGUI_API"
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableLoadSettings",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Tables: Settings"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSaveSettings",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableResetSettings",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableGetBoundSettings",
+      "resultType" : "ImGuiTableSettings *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TableSettingsInstallHandler",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "context",
@@ -7471,9 +23404,54 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "BeginTabBarEx",
-      "resultType" : "IMGUI_API",
+      "name" : "TableSettingsCreate",
+      "resultType" : "ImGuiTableSettings *",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "columns_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TableSettingsFindByID",
+      "resultType" : "ImGuiTableSettings *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginTabBarEx",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab_bar",
+        "qualType" : "ImGuiTabBar *",
+        "desugaredQualType" : "ImGuiTabBar *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "bb",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImGuiTabBarFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "dock_node",
+        "qualType" : "ImGuiDockNode *",
+        "desugaredQualType" : "ImGuiDockNode *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -7482,51 +23460,11 @@
             "text" : " Tab Bars"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "tab_bar",
-        "qualType" : "ImGuiTabBar *",
-        "desugaredQualType" : "ImGuiTabBar *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "dock_node",
-        "qualType" : "struct ImGuiDockNode *",
-        "desugaredQualType" : "struct ImGuiDockNode *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "TabBarAddTab",
-      "resultType" : "IMGUI_API",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "tab_bar",
-        "qualType" : "ImGuiTabBar *",
-        "desugaredQualType" : "ImGuiTabBar *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "tab_flags",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "window",
-        "qualType" : "struct ImGuiWindow *",
-        "desugaredQualType" : "struct ImGuiWindow *"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "TabBarRemoveTab",
-      "resultType" : "IMGUI_API",
+      "name" : "TabBarFindTabByID",
+      "resultType" : "ImGuiTabItem *",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "tab_bar",
@@ -7535,13 +23473,58 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "tab_id",
-        "qualType" : "int",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TabBarFindMostRecentlySelectedTabForActiveWindow",
+      "resultType" : "ImGuiTabItem *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab_bar",
+        "qualType" : "ImGuiTabBar *",
+        "desugaredQualType" : "ImGuiTabBar *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TabBarAddTab",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab_bar",
+        "qualType" : "ImGuiTabBar *",
+        "desugaredQualType" : "ImGuiTabBar *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab_flags",
+        "qualType" : "ImGuiTabItemFlags",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TabBarRemoveTab",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab_bar",
+        "qualType" : "ImGuiTabBar *",
+        "desugaredQualType" : "ImGuiTabBar *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "tab_id",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TabBarCloseTab",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "tab_bar",
@@ -7550,13 +23533,13 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "tab",
-        "qualType" : "struct ImGuiTabItem *",
-        "desugaredQualType" : "struct ImGuiTabItem *"
+        "qualType" : "ImGuiTabItem *",
+        "desugaredQualType" : "ImGuiTabItem *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TabBarQueueReorder",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "tab_bar",
@@ -7565,8 +23548,8 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "tab",
-        "qualType" : "const struct ImGuiTabItem *",
-        "desugaredQualType" : "const struct ImGuiTabItem *"
+        "qualType" : "const ImGuiTabItem *",
+        "desugaredQualType" : "const ImGuiTabItem *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "offset",
@@ -7576,7 +23559,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TabBarQueueReorderFromMousePos",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "tab_bar",
@@ -7585,18 +23568,18 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "tab",
-        "qualType" : "const struct ImGuiTabItem *",
-        "desugaredQualType" : "const struct ImGuiTabItem *"
+        "qualType" : "const ImGuiTabItem *",
+        "desugaredQualType" : "const ImGuiTabItem *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "mouse_pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TabBarProcessReorder",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "tab_bar",
@@ -7606,7 +23589,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TabItemEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "tab_bar",
@@ -7625,63 +23608,78 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiTabItemFlags",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "docked_window",
-        "qualType" : "struct ImGuiWindow *",
-        "desugaredQualType" : "struct ImGuiWindow *"
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TabItemCalcSize",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "has_close_button",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TabItemBackground",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiTabItemFlags",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TabItemLabelAndCloseButton",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiTabItemFlags",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "frame_padding",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -7690,13 +23688,13 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "tab_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "close_button_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "is_contents_visible",
@@ -7716,27 +23714,12 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderText",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Render helpers"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " AVOID USING OUTSIDE OF IMGUI.CPP! NOT FOR PUBLIC CONSUMPTION. THOSE FUNCTIONS ARE A MESS. THEIR SIGNATURE AND BEHAVIOR WILL CHANGE, THEY NEED TO BE REFACTORED INTO SOMETHING DECENT."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " NB: All position are in absolute pixels coordinates (we are never using window coordinates internally)"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
@@ -7754,16 +23737,31 @@
         "qualType" : "bool",
         "desugaredQualType" : "bool",
         "defaultValue" : "true"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Render helpers"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " AVOID USING OUTSIDE OF IMGUI.CPP! NOT FOR PUBLIC CONSUMPTION. THOSE FUNCTIONS ARE A MESS. THEIR SIGNATURE AND BEHAVIOR WILL CHANGE, THEY NEED TO BE REFACTORED INTO SOMETHING DECENT."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " NB: All position are in absolute pixels coordinates (we are never using window coordinates internally)"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderTextWrapped",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
@@ -7783,17 +23781,17 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderTextClipped",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "pos_min",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos_max",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
@@ -7807,40 +23805,40 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "text_size_if_known",
-        "qualType" : "const int *",
-        "desugaredQualType" : "const int *"
+        "qualType" : "const ImVec2 *",
+        "desugaredQualType" : "const ImVec2 *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "align",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
         "defaultValue" : "ImVec2(0, 0)"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "clip_rect",
-        "qualType" : "const struct ImRect *",
-        "desugaredQualType" : "const struct ImRect *",
+        "qualType" : "const ImRect *",
+        "desugaredQualType" : "const ImRect *",
         "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderTextClippedEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos_min",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos_max",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
@@ -7854,40 +23852,40 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "text_size_if_known",
-        "qualType" : "const int *",
-        "desugaredQualType" : "const int *"
+        "qualType" : "const ImVec2 *",
+        "desugaredQualType" : "const ImVec2 *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "align",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
         "defaultValue" : "ImVec2(0, 0)"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "clip_rect",
-        "qualType" : "const struct ImRect *",
-        "desugaredQualType" : "const struct ImRect *",
+        "qualType" : "const ImRect *",
+        "desugaredQualType" : "const ImRect *",
         "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderTextEllipsis",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos_min",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos_max",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "clip_max_x",
@@ -7911,28 +23909,28 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "text_size_if_known",
-        "qualType" : "const int *",
-        "desugaredQualType" : "const int *"
+        "qualType" : "const ImVec2 *",
+        "desugaredQualType" : "const ImVec2 *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderFrame",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "p_min",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "p_max",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "fill_col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "border",
@@ -7949,17 +23947,17 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderFrameBorder",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "p_min",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "p_max",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "rounding",
@@ -7970,27 +23968,27 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderColorRectWithAlphaCheckerboard",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "p_min",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "p_max",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "fill_col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "grid_step",
@@ -7999,8 +23997,8 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "grid_off",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "rounding",
@@ -8010,24 +24008,24 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImDrawFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderNavHighlight",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
@@ -8038,7 +24036,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "FindRenderedTextEnd",
-      "resultType" : "const IMGUI_API *",
+      "resultType" : "const char *",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "text",
@@ -8054,8 +24052,34 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderArrow",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "draw_list",
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "dir",
+        "qualType" : "ImGuiDir",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "1.0f"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -8064,72 +24088,46 @@
             "text" : " Render helpers (those functions don't access any ImGui state!)"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "dir",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "scale",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "1.0f"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderBullet",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderCheckMark",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "sz",
@@ -8139,17 +24137,17 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderMouseCursor",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "scale",
@@ -8158,68 +24156,68 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "mouse_cursor",
-        "qualType" : "int",
+        "qualType" : "ImGuiMouseCursor",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col_fill",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col_border",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col_shadow",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderArrowPointingAt",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "half_sz",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "direction",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderArrowDockMenu",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "p_min",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "sz",
@@ -8228,28 +24226,28 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderRectFilledRangeH",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "rect",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "x_start_norm",
@@ -8269,27 +24267,27 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "RenderRectFilledWithHole",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "outer",
-        "qualType" : "struct ImRect",
+        "qualType" : "ImRect",
         "desugaredQualType" : "ImRect"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "inner",
-        "qualType" : "struct ImRect",
+        "qualType" : "ImRect",
         "desugaredQualType" : "ImRect"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "rounding",
@@ -8298,9 +24296,45 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "CalcRoundingFlagsForRectInRect",
+      "resultType" : "ImDrawFlags",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "r_in",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "r_outer",
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "threshold",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "RenderArrow",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "dir",
+        "qualType" : "ImGuiDir",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "1.0f"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -8309,22 +24343,6 @@
             "text" : " [1.71: 2019/06/07: Updating prototypes of some of the internal functions. Leaving those for reference for a short while]"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "dir",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "scale",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "1.0f"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -8333,23 +24351,14 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TextEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Widgets"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
         "qualType" : "const char *",
@@ -8366,11 +24375,20 @@
         "qualType" : "ImGuiTextFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ButtonEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -8379,55 +24397,55 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "size_arg",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &",
         "defaultValue" : "ImVec2(0, 0)"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiButtonFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "CloseButton",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "CollapseButton",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "pos",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "dock_node",
-        "qualType" : "struct ImGuiDockNode *",
-        "desugaredQualType" : "struct ImGuiDockNode *"
+        "qualType" : "ImGuiDockNode *",
+        "desugaredQualType" : "ImGuiDockNode *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ArrowButtonEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "str_id",
@@ -8436,24 +24454,24 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "dir",
-        "qualType" : "int",
+        "qualType" : "ImGuiDir",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "size_arg",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiButtonFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "Scrollbar",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "axis",
@@ -8463,17 +24481,17 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ScrollbarEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "axis",
@@ -8482,73 +24500,133 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "p_scroll_v",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImS64 *",
+        "desugaredQualType" : "ImS64 *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "avail_v",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImS64",
+        "desugaredQualType" : "long long"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "contents_v",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImS64",
+        "desugaredQualType" : "long long"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImDrawFlags",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ImageButtonEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "texture_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImTextureID",
+        "desugaredQualType" : "void *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "size",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "uv0",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "uv1",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "padding",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "bg_col",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "tint_col",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowScrollbarRect",
+      "resultType" : "ImRect",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "axis",
+        "qualType" : "ImGuiAxis",
+        "desugaredQualType" : "ImGuiAxis"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowScrollbarID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "axis",
+        "qualType" : "ImGuiAxis",
+        "desugaredQualType" : "ImGuiAxis"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowResizeCornerID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowResizeBorderID",
+      "resultType" : "ImGuiID",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "dir",
+        "qualType" : "ImGuiDir",
+        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SeparatorEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
@@ -8558,7 +24636,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "CheckboxFlags",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -8567,18 +24645,18 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImS64 *",
+        "desugaredQualType" : "ImS64 *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags_value",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImS64",
+        "desugaredQualType" : "long long"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "CheckboxFlags",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -8587,37 +24665,28 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImU64 *",
+        "desugaredQualType" : "ImU64 *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags_value",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU64",
+        "desugaredQualType" : "unsigned long long"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ButtonBehavior",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Widgets low-level behaviors"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "out_hovered",
@@ -8631,23 +24700,32 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiButtonFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Widgets low-level behaviors"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DragBehavior",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -8677,27 +24755,27 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiSliderFlags",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SliderBehavior",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -8722,28 +24800,28 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiSliderFlags",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "out_grab_bb",
-        "qualType" : "struct ImRect *",
-        "desugaredQualType" : "struct ImRect *"
+        "qualType" : "ImRect *",
+        "desugaredQualType" : "ImRect *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SplitterBehavior",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "axis",
@@ -8784,23 +24862,23 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "bg_col",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int",
         "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TreeNodeBehavior",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiTreeNodeFlags",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -8817,93 +24895,52 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TreeNodeBehaviorIsOpen",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiTreeNodeFlags",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TreePushOverrideID",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "ScaleValueFromRatioT",
-      "resultType" : "int",
+      "name" : "DataTypeGetInfo",
+      "resultType" : "const ImGuiDataTypeInfo *",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "t",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "v_min",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "v_max",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "is_logarithmic",
-        "qualType" : "bool",
-        "desugaredQualType" : "bool"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "logarithmic_zero_epsilon",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "zero_deadzone_size",
-        "qualType" : "float",
-        "desugaredQualType" : "float"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "RoundScalarWithFormatT",
-      "resultType" : "int",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "format",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "data_type",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "v",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Data type helpers"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DataTypeFormatString",
-      "resultType" : "IMGUI_API",
+      "resultType" : "int",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "buf",
@@ -8917,7 +24954,7 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -8933,11 +24970,11 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DataTypeApplyOp",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -8963,7 +25000,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DataTypeApplyOpFromText",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "buf",
@@ -8977,7 +25014,7 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -8993,11 +25030,11 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DataTypeCompare",
-      "resultType" : "IMGUI_API",
+      "resultType" : "int",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -9013,11 +25050,11 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DataTypeClamp",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -9038,17 +25075,8 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "InputTextEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " InputText"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -9071,18 +25099,18 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "size_arg",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiInputTextFlags",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "callback",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
+        "qualType" : "ImGuiInputTextCallback",
+        "desugaredQualType" : "int (*)(ImGuiInputTextCallbackData *)",
         "defaultValue" : "NULL"
       }, {
         "@type" : "AstParmVarDecl",
@@ -9090,21 +25118,30 @@
         "qualType" : "void *",
         "desugaredQualType" : "void *",
         "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " InputText"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TempInputText",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -9123,23 +25160,23 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiInputTextFlags",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "TempInputScalar",
-      "resultType" : "IMGUI_API",
+      "resultType" : "bool",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -9148,7 +25185,7 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -9180,8 +25217,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -9190,23 +25227,14 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ColorTooltip",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Color"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
         "qualType" : "const char *",
@@ -9219,13 +25247,22 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiColorEditFlags",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Color"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ColorEditOptionsPopup",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "col",
@@ -9234,13 +25271,13 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiColorEditFlags",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ColorPickerOptionsPopup",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "ref_col",
@@ -9249,23 +25286,14 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "flags",
-        "qualType" : "int",
+        "qualType" : "ImGuiColorEditFlags",
         "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PlotEx",
-      "resultType" : "IMGUI_API",
+      "resultType" : "int",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Plot"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "plot_type",
         "qualType" : "ImGuiPlotType",
@@ -9313,27 +25341,27 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "frame_size",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "ShadeVertsLinearColorGradientKeepAlpha",
-      "resultType" : "IMGUI_API",
-      "decls" : [ {
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
           "decls" : [ {
             "@type" : "AstTextComment",
-            "text" : " Shade functions (write over already created vertices)"
+            "text" : " Plot"
           } ]
         } ]
-      }, {
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ShadeVertsLinearColorGradientKeepAlpha",
+      "resultType" : "void",
+      "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "vert_start_idx",
@@ -9347,33 +25375,42 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "gradient_p0",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "gradient_p1",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col0",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "col1",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Shade functions (write over already created vertices)"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ShadeVertsLinearUV",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "vert_start_idx",
@@ -9387,23 +25424,23 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "a",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "b",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "uv_a",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "uv_b",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "clamp",
@@ -9413,7 +25450,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GcCompactTransientMiscBuffers",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstFullComment",
         "decls" : [ {
@@ -9426,18 +25463,29 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "ErrorCheckEndFrameRecover",
-      "resultType" : "IMGUI_API",
+      "name" : "GcCompactTransientWindowBuffers",
+      "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Debug Tools"
-          } ]
-        } ]
-      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GcAwakeTransientWindowBuffers",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ErrorCheckEndFrameRecover",
+      "resultType" : "void",
+      "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "log_callback",
         "qualType" : "ImGuiErrorLogCallback",
@@ -9448,11 +25496,20 @@
         "qualType" : "void *",
         "desugaredQualType" : "void *",
         "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Debug Tools"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ErrorCheckEndWindowRecover",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "log_callback",
@@ -9472,9 +25529,9 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "col",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IM_COL32(255,0,0,255)"
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int",
+        "defaultValue" : "IM_COL32"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -9483,26 +25540,26 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ShowFontAtlas",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "atlas",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImFontAtlas *",
+        "desugaredQualType" : "ImFontAtlas *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DebugHookIdInfo",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "data_type",
-        "qualType" : "int",
+        "qualType" : "ImGuiDataType",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
@@ -9517,23 +25574,73 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "DebugNodeDrawCmdShowMeshAndBoundingBox",
-      "resultType" : "IMGUI_API",
+      "name" : "DebugNodeColumns",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
-        "name" : "out_draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "name" : "columns",
+        "qualType" : "ImGuiOldColumns *",
+        "desugaredQualType" : "ImGuiOldColumns *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DebugNodeDockNode",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "node",
+        "qualType" : "ImGuiDockNode *",
+        "desugaredQualType" : "ImGuiDockNode *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DebugNodeDrawList",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "viewport",
+        "qualType" : "ImGuiViewportP *",
+        "desugaredQualType" : "ImGuiViewportP *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "const int *",
-        "desugaredQualType" : "const int *"
+        "qualType" : "const ImDrawList *",
+        "desugaredQualType" : "const ImDrawList *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DebugNodeDrawCmdShowMeshAndBoundingBox",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_draw_list",
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "draw_list",
+        "qualType" : "const ImDrawList *",
+        "desugaredQualType" : "const ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "draw_cmd",
-        "qualType" : "const int *",
-        "desugaredQualType" : "const int *"
+        "qualType" : "const ImDrawCmd *",
+        "desugaredQualType" : "const ImDrawCmd *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "show_mesh",
@@ -9548,22 +25655,22 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DebugNodeFont",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "font",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImFont *",
+        "desugaredQualType" : "ImFont *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DebugNodeStorage",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "storage",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImGuiStorage *",
+        "desugaredQualType" : "ImGuiStorage *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -9573,7 +25680,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DebugNodeTabBar",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "tab_bar",
@@ -9587,13 +25694,33 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "DebugNodeWindowsList",
-      "resultType" : "IMGUI_API",
+      "name" : "DebugNodeTable",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
-        "name" : "windows",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "name" : "table",
+        "qualType" : "ImGuiTable *",
+        "desugaredQualType" : "ImGuiTable *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DebugNodeTableSettings",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "settings",
+        "qualType" : "ImGuiTableSettings *",
+        "desugaredQualType" : "ImGuiTableSettings *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DebugNodeWindow",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "window",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
@@ -9602,8 +25729,53 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
+      "name" : "DebugNodeWindowSettings",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "settings",
+        "qualType" : "ImGuiWindowSettings *",
+        "desugaredQualType" : "ImGuiWindowSettings *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DebugNodeWindowsList",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "windows",
+        "qualType" : "ImVector<ImGuiWindow *> *",
+        "desugaredQualType" : "ImVector<ImGuiWindow *> *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DebugNodeWindowsListByBeginStackParent",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "windows",
+        "qualType" : "ImGuiWindow **",
+        "desugaredQualType" : "ImGuiWindow **"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "windows_size",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "parent_in_begin_stack",
+        "qualType" : "ImGuiWindow *",
+        "desugaredQualType" : "ImGuiWindow *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
       "name" : "DebugNodeViewport",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "viewport",
@@ -9613,12 +25785,12 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DebugRenderViewportThumbnail",
-      "resultType" : "IMGUI_API",
+      "resultType" : "void",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "draw_list",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "viewport",
@@ -9627,8 +25799,1438 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "bb",
-        "qualType" : "const struct ImRect &",
-        "desugaredQualType" : "const struct ImRect &"
+        "qualType" : "const ImRect &",
+        "desugaredQualType" : "const ImRect &"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiStyle",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " [SECTION] ImGuiStyle"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " You may modify the ImGui::GetStyle() main instance during initialization and before NewFrame()."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " During the frame, use ImGui::PushStyleVar(ImGuiStyleVar_XXXX)/PopStyleVar() to alter the main style values,"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " and ImGui::PushStyleColor(ImGuiCol_XXX)/PopStyleColor() for colors."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Alpha",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisabledAlpha",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowPadding",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowRounding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowBorderSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowMinSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowTitleAlign",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WindowMenuButtonPosition",
+      "qualType" : "ImGuiDir",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ChildRounding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ChildBorderSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PopupRounding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PopupBorderSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FramePadding",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FrameRounding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FrameBorderSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ItemSpacing",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ItemInnerSpacing",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CellPadding",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TouchExtraPadding",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IndentSpacing",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnsMinSpacing",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollbarSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ScrollbarRounding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GrabMinSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GrabRounding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LogSliderDeadzone",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TabRounding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TabBorderSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TabMinWidthForCloseButton",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColorButtonPosition",
+      "qualType" : "ImGuiDir",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ButtonTextAlign",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SelectableTextAlign",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplayWindowPadding",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplaySafeAreaPadding",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseCursorScale",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AntiAliasedLines",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AntiAliasedLinesUseTex",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AntiAliasedFill",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurveTessellationTol",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CircleTessellationMaxError",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Colors",
+      "qualType" : "ImVec4[55]",
+      "desugaredQualType" : "ImVec4[55]"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ScaleAllSizes",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale_factor",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiIO",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " [SECTION] ImGuiIO"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Communicate most settings and inputs/outputs to Dear ImGui using this structure."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Access via ImGui::GetIO(). Read 'Programmer guide' section in .cpp file for general usage."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigFlags",
+      "qualType" : "ImGuiConfigFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackendFlags",
+      "qualType" : "ImGuiBackendFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplaySize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DeltaTime",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IniSavingRate",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IniFilename",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LogFilename",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDoubleClickTime",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDoubleClickMaxDist",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDragThreshold",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeyMap",
+      "qualType" : "int[22]",
+      "desugaredQualType" : "int[22]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeyRepeatDelay",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeyRepeatRate",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "UserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Fonts",
+      "qualType" : "ImFontAtlas *",
+      "desugaredQualType" : "ImFontAtlas *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontGlobalScale",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontAllowUserScaling",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontDefault",
+      "qualType" : "ImFont *",
+      "desugaredQualType" : "ImFont *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplayFramebufferScale",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigDockingNoSplit",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigDockingWithShift",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigDockingAlwaysTabBar",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigDockingTransparentPayload",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigViewportsNoAutoMerge",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigViewportsNoTaskBarIcon",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigViewportsNoDecoration",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigViewportsNoDefaultParent",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDrawCursor",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigMacOSXBehaviors",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigInputTextCursorBlink",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigDragClickToInputText",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigWindowsResizeFromEdges",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigWindowsMoveFromTitleBarOnly",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigMemoryCompactTimer",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackendPlatformName",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackendRendererName",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackendPlatformUserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackendRendererUserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BackendLanguageUserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GetClipboardTextFn",
+      "qualType" : "const char *(*)(void *)",
+      "desugaredQualType" : "const char *(*)(void *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SetClipboardTextFn",
+      "qualType" : "void (*)(void *, const char *)",
+      "desugaredQualType" : "void (*)(void *, const char *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ClipboardUserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MousePos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDown",
+      "qualType" : "bool[5]",
+      "desugaredQualType" : "bool[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseWheel",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseWheelH",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseHoveredViewport",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeyCtrl",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeyShift",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeyAlt",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeySuper",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeysDown",
+      "qualType" : "bool[512]",
+      "desugaredQualType" : "bool[512]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavInputs",
+      "qualType" : "float[20]",
+      "desugaredQualType" : "float[20]"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddInputCharacter",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "unsigned int",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Functions"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddInputCharacterUTF16",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "ImWchar16",
+        "desugaredQualType" : "unsigned short"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddInputCharactersUTF8",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddFocusEvent",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "focused",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearInputCharacters",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearInputKeys",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantCaptureMouse",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantCaptureKeyboard",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantTextInput",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantSetMousePos",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantSaveIniSettings",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavActive",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavVisible",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Framerate",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MetricsRenderVertices",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MetricsRenderIndices",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MetricsRenderWindows",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MetricsActiveWindows",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MetricsActiveAllocations",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDelta",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WantCaptureMouseUnlessPopupClose",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeyMods",
+      "qualType" : "ImGuiKeyModFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeyModsPrev",
+      "qualType" : "ImGuiKeyModFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MousePosPrev",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseClickedPos",
+      "qualType" : "ImVec2[5]",
+      "desugaredQualType" : "ImVec2[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseClickedTime",
+      "qualType" : "double[5]",
+      "desugaredQualType" : "double[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseClicked",
+      "qualType" : "bool[5]",
+      "desugaredQualType" : "bool[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDoubleClicked",
+      "qualType" : "bool[5]",
+      "desugaredQualType" : "bool[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseClickedCount",
+      "qualType" : "ImU16[5]",
+      "desugaredQualType" : "ImU16[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseClickedLastCount",
+      "qualType" : "ImU16[5]",
+      "desugaredQualType" : "ImU16[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseReleased",
+      "qualType" : "bool[5]",
+      "desugaredQualType" : "bool[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDownOwned",
+      "qualType" : "bool[5]",
+      "desugaredQualType" : "bool[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDownOwnedUnlessPopupClose",
+      "qualType" : "bool[5]",
+      "desugaredQualType" : "bool[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDownDuration",
+      "qualType" : "float[5]",
+      "desugaredQualType" : "float[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDownDurationPrev",
+      "qualType" : "float[5]",
+      "desugaredQualType" : "float[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDragMaxDistanceAbs",
+      "qualType" : "ImVec2[5]",
+      "desugaredQualType" : "ImVec2[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MouseDragMaxDistanceSqr",
+      "qualType" : "float[5]",
+      "desugaredQualType" : "float[5]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeysDownDuration",
+      "qualType" : "float[512]",
+      "desugaredQualType" : "float[512]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "KeysDownDurationPrev",
+      "qualType" : "float[512]",
+      "desugaredQualType" : "float[512]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavInputsDownDuration",
+      "qualType" : "float[20]",
+      "desugaredQualType" : "float[20]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "NavInputsDownDurationPrev",
+      "qualType" : "float[20]",
+      "desugaredQualType" : "float[20]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PenPressure",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AppFocusLost",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InputQueueSurrogate",
+      "qualType" : "ImWchar16",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InputQueueCharacters",
+      "qualType" : "ImVector<ImWchar>",
+      "desugaredQualType" : "ImVector<unsigned short>"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiInputTextCallbackData",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Shared state of InputText(), passed as an argument to your callback when a ImGuiInputTextFlags_Callback* flag is used."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " The callback function should return 0 by default."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Callbacks (follow a flag name and see comments in ImGuiInputTextFlags_ declarations for more details)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - ImGuiInputTextFlags_CallbackEdit:        Callback on buffer edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - ImGuiInputTextFlags_CallbackAlways:      Callback on each iteration"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - ImGuiInputTextFlags_CallbackCompletion:  Callback on pressing TAB"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - ImGuiInputTextFlags_CallbackHistory:     Callback on pressing Up/Down arrows"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - ImGuiInputTextFlags_CallbackCharFilter:  Callback on character inputs to replace or discard them. Modify 'EventChar' to replace or discard, or return 1 in callback to discard."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - ImGuiInputTextFlags_CallbackResize:      Callback on buffer capacity changes request (beyond 'buf_size' parameter value), allowing the string to grow."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "EventFlag",
+      "qualType" : "ImGuiInputTextFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImGuiInputTextFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "UserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "EventChar",
+      "qualType" : "ImWchar",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "EventKey",
+      "qualType" : "ImGuiKey",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Buf",
+      "qualType" : "char *",
+      "desugaredQualType" : "char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BufTextLen",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BufSize",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "BufDirty",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CursorPos",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SelectionStart",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SelectionEnd",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DeleteChars",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "bytes_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "InsertChars",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "ID i"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SelectAll",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearSelection",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "HasSelection",
+      "resultType" : "bool"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiSizeCallbackData",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Resizing callback data to apply custom constraint. As enabled by SetNextWindowSizeConstraints(). Callback is called during the next Begin()."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " NB: For basic min/max size constraint on each axis you don't need to use the callback! The SetNextWindowSizeConstraints() parameters are enough."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "UserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Pos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CurrentSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DesiredSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiWindowClass",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " [ALPHA] Rarely used / very advanced uses only. Use with SetNextWindowClass() and DockSpace() functions."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Important: the content of this class is still highly WIP and likely to change and be refactored"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " before we stabilize Docking features. Please be mindful if using this."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Provide hints:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - To the platform backend via altered viewport flags (enable/disable OS decoration, OS task bar icons, etc.)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - To the platform backend for OS level parent/child relationships of viewport."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - To the docking system for various options and filtering."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ClassId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ParentViewportId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ViewportFlagsOverrideSet",
+      "qualType" : "ImGuiViewportFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ViewportFlagsOverrideClear",
+      "qualType" : "ImGuiViewportFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TabItemFlagsOverrideSet",
+      "qualType" : "ImGuiTabItemFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockNodeFlagsOverrideSet",
+      "qualType" : "ImGuiDockNodeFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockingAlwaysTabBar",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DockingAllowUnclassed",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiPayload",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Data payload for Drag and Drop operations: AcceptDragDropPayload(), GetDragDropPayload()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Data",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DataSize",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SourceId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SourceParentId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DataFrameCount",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DataType",
+      "qualType" : "char[33]",
+      "desugaredQualType" : "char[33]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Preview",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Delivery",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Clear",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsDataType",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "type",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsPreview",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsDelivery",
+      "resultType" : "bool"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiTableColumnSortSpecs",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Sorting specification for one column of a table (sizeof == 12 bytes)"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnUserID",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ColumnIndex",
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SortOrder",
+      "qualType" : "ImS16",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SortDirection",
+      "qualType" : "ImGuiSortDirection",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiTableSortSpecs",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Sorting specifications for a table (often handling sort specs for a single column, occasionally more)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Obtained by calling TableGetSortSpecs()."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " When 'SpecsDirty == true' you can sort your data. It will be true with sorting specs have changed since last call, or the first time."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Make sure to set 'SpecsDirty = false' after sorting, else you may wastefully sort your data every frame!"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Specs",
+      "qualType" : "const ImGuiTableColumnSortSpecs *",
+      "desugaredQualType" : "const ImGuiTableColumnSortSpecs *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SpecsCount",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SpecsDirty",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiOnceUponAFrame",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper: Execute a block of code at maximum once a frame. Convenient if you want to quickly create an UI within deep-nested code that runs multiple times every frame."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Usage: static ImGuiOnceUponAFrame oaf; if (oaf) ImGui::Text(\"This will be called only once per frame\");"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RefFrame",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiTextFilter",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper: Parse and apply text filters. In format \"aaaaa[,bbbb][,ccccc]\""
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Draw",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "_API void          "
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "width",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "Font"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PassFilter",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "d   "
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Build",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Clear",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsActive",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstRecordDecl",
+      "name" : "ImGuiTextRange",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " [Internal]"
+          } ]
+        } ]
+      }, {
+        "@type" : "AstFieldDecl",
+        "name" : "b",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstFieldDecl",
+        "name" : "e",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstFunctionDecl",
+        "name" : "empty",
+        "resultType" : "bool"
+      }, {
+        "@type" : "AstFunctionDecl",
+        "name" : "split",
+        "resultType" : "void",
+        "decls" : [ {
+          "@type" : "AstParmVarDecl",
+          "name" : "separator",
+          "qualType" : "char",
+          "desugaredQualType" : "char"
+        }, {
+          "@type" : "AstParmVarDecl",
+          "name" : "out",
+          "qualType" : "ImVector<ImGuiTextRange> *",
+          "desugaredQualType" : "ImVector<ImGuiTextRange> *"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "InputBuf",
+      "qualType" : "char[256]",
+      "desugaredQualType" : "char[256]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Filters",
+      "qualType" : "ImVector<ImGuiTextRange>",
+      "desugaredQualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CountGrep",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiTextBuffer",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper: Growable text buffer for logging/accumulating text"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (this could be called 'ImGuiTextBuilder' / 'ImGuiStringBuilder')"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Buf",
+      "qualType" : "ImVector<char>",
+      "desugaredQualType" : "ImVector<char>"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "begin",
+      "resultType" : "const char *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "end",
+      "resultType" : "const char *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "size",
+      "resultType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "empty",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "clear",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "reserve",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "capacity",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "c_str",
+      "resultType" : "const char *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "append",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "arke"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "appendf",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "appendfv",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "args",
+        "qualType" : "__va_list_tag *",
+        "desugaredQualType" : "__va_list_tag *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "#FORMAT_ATTR_MARKER#",
+        "qualType" : "#FORMAT_ATTR_MARKER#",
+        "desugaredQualType" : "#FORMAT_ATTR_MARKER#"
       } ]
     } ]
   }, {
@@ -9646,38 +27248,52 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "FontBuilder_Build",
-      "qualType" : "bool (*)(int *)",
-      "desugaredQualType" : "bool (*)(int *)"
+      "qualType" : "bool (*)(ImFontAtlas *)",
+      "desugaredQualType" : "bool (*)(ImFontAtlas *)"
+    } ]
+  }, {
+    "@type" : "AstFunctionDecl",
+    "name" : "ImFontAtlasGetBuilderForStbTruetype",
+    "resultType" : "const ImFontBuilderIO *",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper for font builder"
+        } ]
+      } ]
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFontAtlasBuildInit",
-    "resultType" : "IMGUI_API",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "atlas",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFontAtlas *",
+      "desugaredQualType" : "ImFontAtlas *"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFontAtlasBuildSetupFont",
-    "resultType" : "IMGUI_API",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "atlas",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFontAtlas *",
+      "desugaredQualType" : "ImFontAtlas *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "font",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFont *",
+      "desugaredQualType" : "ImFont *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "font_config",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFontConfig *",
+      "desugaredQualType" : "ImFontConfig *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "ascent",
@@ -9692,12 +27308,12 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFontAtlasBuildPackCustomRects",
-    "resultType" : "IMGUI_API",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "atlas",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFontAtlas *",
+      "desugaredQualType" : "ImFontAtlas *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "stbrp_context_opaque",
@@ -9707,22 +27323,22 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFontAtlasBuildFinish",
-    "resultType" : "IMGUI_API",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "atlas",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFontAtlas *",
+      "desugaredQualType" : "ImFontAtlas *"
     } ]
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFontAtlasBuildRender8bppRectFromString",
-    "resultType" : "IMGUI_API",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "atlas",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFontAtlas *",
+      "desugaredQualType" : "ImFontAtlas *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "x",
@@ -9762,12 +27378,12 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFontAtlasBuildRender32bppRectFromString",
-    "resultType" : "IMGUI_API",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "atlas",
-      "qualType" : "int *",
-      "desugaredQualType" : "int *"
+      "qualType" : "ImFontAtlas *",
+      "desugaredQualType" : "ImFontAtlas *"
     }, {
       "@type" : "AstParmVarDecl",
       "name" : "x",
@@ -9807,7 +27423,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFontAtlasBuildMultiplyCalcLookupTable",
-    "resultType" : "IMGUI_API",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "out_table",
@@ -9822,7 +27438,7 @@
   }, {
     "@type" : "AstFunctionDecl",
     "name" : "ImFontAtlasBuildMultiplyRectAlpha8",
-    "resultType" : "IMGUI_API",
+    "resultType" : "void",
     "decls" : [ {
       "@type" : "AstParmVarDecl",
       "name" : "table",
@@ -9858,6 +27474,4962 @@
       "name" : "stride",
       "qualType" : "int",
       "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiStorage",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper: Key->Value storage"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Typically you don't have to worry about this since a storage is held within each Window."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " We use it to e.g. store collapse state for a tree (Int 0/1)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " This is optimized for efficient lookup (dichotomy into a contiguous buffer) and rare insertion (typically tied to user interactions aka max once a frame)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " You can use it as custom user storage for temporary values. Declare your own storage if, for example:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - You want to manipulate the open/close state of a particular sub-tree in your interface (tree node uses Int 0/1 to store their state)."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - You want to store custom debug data easily without adding or editing structures in your code (probably not efficient, but convenient)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Types are NOT stored, so it is up to you to make sure your Key don't collide with different types."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstRecordDecl",
+      "name" : "ImGuiStoragePair",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " [Internal]"
+          } ]
+        } ]
+      }, {
+        "@type" : "AstFieldDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Data",
+      "qualType" : "ImVector<ImGuiStoragePair>",
+      "desugaredQualType" : "ImVector<ImGuiStorage::ImGuiStoragePair>"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Clear",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " - Get***() functions find pair, never add/allocate. Pairs are sorted so a query is O(log N)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Set***() functions find pair, insertion on demand if missing."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Sorted insertion is costly, paid once. A typical frame shouldn't need to insert any new pair."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetInt",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_val",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "-"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetInt",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "val",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetBool",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_val",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "ma GC"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetBool",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "val",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFloat",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_val",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetFloat",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "val",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetVoidPtr",
+      "resultType" : "void *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetVoidPtr",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "val",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetIntRef",
+      "resultType" : "int *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_val",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " - Get***Ref() functions finds pair, insert on demand if missing, return pointer. Useful if you intend to do Get+Set."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - References are only valid until a new value is added to the storage. Calling a Set***() function or a Get***Ref() function invalidates the pointer."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - A typical use case where this is convenient for quick hacking (e.g. add storage during a live Edit"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "&Continue"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " session if you can't modify existing struct)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "      float* pvar = ImGui::GetFloatRef(key); ImGui::SliderFloat(\"var\", pvar, 0, 100.0f); some_var += *pvar;"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetBoolRef",
+      "resultType" : "bool *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_val",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetFloatRef",
+      "resultType" : "float *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_val",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetVoidPtrRef",
+      "resultType" : "void **",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key",
+        "qualType" : "ImGuiID",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "default_val",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetAllInt",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "val",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Use on your own storage if you know only integer are being stored (open/close all tree nodes)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BuildSortByKey",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " For quicker full rebuild of a storage (instead of an incremental one), you may add all your contents and then sort once."
+          } ]
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiListClipper",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper: Manually clip large list of items."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " If you have lots evenly spaced items and you have a random access to the list, you can perform coarse"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " clipping based on visibility to only submit items that are in view."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " The clipper calculates the range of visible items and advance the cursor to compensate for the non-visible items we have skipped."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (Dear ImGui already clip items based on their bounds but: it needs to first layout the item to do so, and generally"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  fetching/submitting your own data incurs additional cost. Coarse clipping using ImGuiListClipper allows you to easily"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  scale using lists with tens of thousands of items without a problem)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Usage:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   ImGuiListClipper clipper;"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   clipper.Begin(1000);         // We have 1000 elements, evenly spaced."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   while (clipper.Step())"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "       for (int i = clipper.DisplayStart; i "
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "<"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " clipper.DisplayEnd; i++)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "           ImGui::Text(\"line number %d\", i);"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Generally what happens is:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Clipper lets you process the first element (DisplayStart = 0, DisplayEnd = 1) regardless of it being visible or not."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - User code submit that one element."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Clipper can measure the height of the first element"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Clipper calculate the actual range of elements to display based on the current clipping rectangle, position the cursor before the first visible element."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - User code submit visible elements."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - The clipper also handles various subtleties related to keyboard/gamepad navigation, wrapping etc."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplayStart",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplayEnd",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ItemsCount",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ItemsHeight",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "StartPosY",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TempData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Begin",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_height",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "End",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Step",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ForceDisplayRangeByIndices",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "item_min",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "item_max",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Call ForceDisplayRangeByIndices() before first call to Step() if you need a range of items to be displayed regardless of visibility."
+          } ]
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImColor",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper: ImColor() implicitly converts colors to either ImU32 (packed 4x1 byte) or ImVec4 (4x1 float)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Prefer using IM_COL32() macros if you want a guaranteed compile-time ImU32 for usage with ImDrawList API."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " **Avoid storing ImColor! Store either u32 of ImVec4. This is not a full-featured color class. MAY OBSOLETE."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " **None of the ImGui API are using ImColor directly but you can use it as a convenience to pass colors in either ImU32 or ImVec4 formats. Explicitly cast to ImU32 or ImVec4 if needed."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Value",
+      "qualType" : "ImVec4",
+      "desugaredQualType" : "ImVec4"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetHSV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "h",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "s",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "a",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " FIXME-OBSOLETE: May need to obsolete/cleanup those helpers."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "HSV",
+      "resultType" : "ImColor",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "h",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "s",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "a",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawCmd",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Typically, 1 command = 1 GPU draw call (unless command is a callback)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - VtxOffset/IdxOffset: When 'io.BackendFlags "
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "&"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " ImGuiBackendFlags_RendererHasVtxOffset' is enabled,"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   those fields allow us to render meshes larger than 64K vertices while keeping 16-bit indices."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   Pre-1.71 backends will typically ignore the VtxOffset/IdxOffset fields."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - The ClipRect/TextureId/VtxOffset fields must be contiguous as we memcmp() them together (this is asserted for)."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ClipRect",
+      "qualType" : "ImVec4",
+      "desugaredQualType" : "ImVec4"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TextureId",
+      "qualType" : "ImTextureID",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "VtxOffset",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IdxOffset",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ElemCount",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "UserCallback",
+      "qualType" : "ImDrawCallback",
+      "desugaredQualType" : "void (*)(const ImDrawList *, const ImDrawCmd *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "UserCallbackData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTexID",
+      "resultType" : "ImTextureID",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Since 1.83: returns ImTextureID associated with this draw call. Warning: DO NOT assume this is always same as 'TextureId' (we will change this function for an upcoming feature)"
+          } ]
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawVert",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "pos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "uv",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "col",
+      "qualType" : "ImU32",
+      "desugaredQualType" : "unsigned int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawCmdHeader",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " [Internal] For use by ImDrawList"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ClipRect",
+      "qualType" : "ImVec4",
+      "desugaredQualType" : "ImVec4"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TextureId",
+      "qualType" : "ImTextureID",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "VtxOffset",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawChannel",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " [Internal] For use by ImDrawListSplitter"
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawListSplitter",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Split/Merge functions are used to split the draw list into different layers which can be drawn into out of order."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " This is used by the Columns/Tables API, so items of each column can be batched together in a same draw call."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Clear",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearFreeMemory",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Split",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "draw_list",
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Merge",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "draw_list",
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetCurrentChannel",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "draw_list",
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "channel_idx",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImDrawFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImDrawList functions"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (Legacy: bit 0 must always correspond to ImDrawFlags_Closed to be backward compatible with old API using a bool. Bits 1..3 must be unused)"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_None",
+      "qualType" : "ImDrawFlags_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_Closed",
+      "docComment" : "PathStroke(), AddPolyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason)",
+      "qualType" : "ImDrawFlags_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersTopLeft",
+      "docComment" : "AddRect(), AddRectFilled(), PathRect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01.",
+      "qualType" : "ImDrawFlags_",
+      "order" : 2,
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersTopRight",
+      "docComment" : "AddRect(), AddRectFilled(), PathRect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02.",
+      "qualType" : "ImDrawFlags_",
+      "order" : 3,
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersBottomLeft",
+      "docComment" : "AddRect(), AddRectFilled(), PathRect(): enable rounding bottom-left corner only (when rounding > 0.0f, we default to all corners). Was 0x04.",
+      "qualType" : "ImDrawFlags_",
+      "order" : 4,
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersBottomRight",
+      "docComment" : "AddRect(), AddRectFilled(), PathRect(): enable rounding bottom-right corner only (when rounding > 0.0f, we default to all corners). Wax 0x08.",
+      "qualType" : "ImDrawFlags_",
+      "order" : 5,
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersNone",
+      "docComment" : "AddRect(), AddRectFilled(), PathRect(): disable rounding on all corners (when rounding > 0.0f). This is NOT zero, NOT an implicit flag!",
+      "qualType" : "ImDrawFlags_",
+      "order" : 6,
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersTop",
+      "qualType" : "ImDrawFlags_",
+      "order" : 7,
+      "evaluatedValue" : "48"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersBottom",
+      "qualType" : "ImDrawFlags_",
+      "order" : 8,
+      "evaluatedValue" : "192"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersLeft",
+      "qualType" : "ImDrawFlags_",
+      "order" : 9,
+      "evaluatedValue" : "80"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersRight",
+      "qualType" : "ImDrawFlags_",
+      "order" : 10,
+      "evaluatedValue" : "160"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersAll",
+      "qualType" : "ImDrawFlags_",
+      "order" : 11,
+      "evaluatedValue" : "240"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersDefault_",
+      "docComment" : "Default to ALL corners if none of the _RoundCornersXX flags are specified.",
+      "qualType" : "ImDrawFlags_",
+      "order" : 12,
+      "evaluatedValue" : "240"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawFlags_RoundCornersMask_",
+      "qualType" : "ImDrawFlags_",
+      "order" : 13,
+      "evaluatedValue" : "496"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImDrawListFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImDrawList instance. Those are set automatically by ImGui:: functions from ImGuiIO settings, and generally not manipulated directly."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " It is however possible to temporarily alter flags between calls to ImDrawList:: functions."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawListFlags_None",
+      "qualType" : "ImDrawListFlags_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawListFlags_AntiAliasedLines",
+      "docComment" : "Enable anti-aliased lines/borders (*2 the number of triangles for 1.0f wide line or lines thin enough to be drawn using textures, otherwise *3 the number of triangles)",
+      "qualType" : "ImDrawListFlags_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawListFlags_AntiAliasedLinesUseTex",
+      "docComment" : "Enable anti-aliased lines/borders using textures when possible. Require backend to render with bilinear filtering.",
+      "qualType" : "ImDrawListFlags_",
+      "order" : 2,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawListFlags_AntiAliasedFill",
+      "docComment" : "Enable anti-aliased edge around filled shapes (rounded rectangles, circles).",
+      "qualType" : "ImDrawListFlags_",
+      "order" : 3,
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawListFlags_AllowVtxOffset",
+      "docComment" : "Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled.",
+      "qualType" : "ImDrawListFlags_",
+      "order" : 4,
+      "evaluatedValue" : "8"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawList",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Draw command list"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " This is the low-level list of polygons that ImGui:: functions are filling. At the end of the frame,"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " all command lists are passed to your ImGuiIO::RenderDrawListFn function for rendering."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Each dear imgui window contains its own ImDrawList. You can use ImGui::GetWindowDrawList() to"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " access the current window draw list and draw custom primitives."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " You can interleave normal ImGui:: calls and adding primitives to the current draw list."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " In single viewport mode, top-left is == GetMainViewport()->Pos (generally 0,0), bottom-right is == GetMainViewport()->Pos+Size (generally io.DisplaySize)."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " You are totally free to apply whatever transformation matrix to want to the data (depending on the use of the transformation you may want to apply it to ClipRect as well!)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Important: Primitives are always added to the list and not culled (culling is done at higher-level by ImGui:: functions), if you use this API a lot consider coarse culling your drawn objects."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CmdBuffer",
+      "qualType" : "ImVector<ImDrawCmd>",
+      "desugaredQualType" : "ImVector<ImDrawCmd>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IdxBuffer",
+      "qualType" : "ImVector<ImDrawIdx>",
+      "desugaredQualType" : "ImVector<unsigned short>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "VtxBuffer",
+      "qualType" : "ImVector<ImDrawVert>",
+      "desugaredQualType" : "ImVector<ImDrawVert>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImDrawListFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushClipRect",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "clip_rect_min",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "clip_rect_max",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "intersect_with_current_clip_rect",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushClipRectFullScreen",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopClipRect",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PushTextureID",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "texture_id",
+        "qualType" : "ImTextureID",
+        "desugaredQualType" : "void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PopTextureID",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetClipRectMin",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetClipRectMax",
+      "resultType" : "ImVec2"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddLine",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Primitives"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - For rectangular primitives, \"p_min\" and \"p_max\" represent the upper-left and lower-right corners."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - For circle primitives, use \"num_segments == 0\" to automatically calculate tessellation (preferred)."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   In older versions (until Dear ImGui 1.77) the AddCircle functions defaulted to num_segments == 12."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   In future versions we will use textures to provide cheaper and higher-quality circles."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   Use AddNgon() and AddNgonFilled() functions if you need to guaranteed a specific number of sides."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddRect",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rounding",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImDrawFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddRectFilled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rounding",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImDrawFlags",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddRectFilledMultiColor",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col_upr_left",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col_upr_right",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col_bot_right",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col_bot_left",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddQuad",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p4",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddQuadFilled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p4",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddTriangle",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddTriangleFilled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddCircle",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "center",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "radius",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddCircleFilled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "center",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "radius",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddNgon",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "center",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "radius",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddNgonFilled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "center",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "radius",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddText",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_begin",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddText",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "font",
+        "qualType" : "const ImFont *",
+        "desugaredQualType" : "const ImFont *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_size",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_begin",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "wrap_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cpu_fine_clip_rect",
+        "qualType" : "const ImVec4 *",
+        "desugaredQualType" : "const ImVec4 *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddPolyline",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "points",
+        "qualType" : "const ImVec2 *",
+        "desugaredQualType" : "const ImVec2 *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_points",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImDrawFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddConvexPolyFilled",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "points",
+        "qualType" : "const ImVec2 *",
+        "desugaredQualType" : "const ImVec2 *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_points",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddBezierCubic",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p4",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddBezierQuadratic",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddImage",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_texture_id",
+        "qualType" : "ImTextureID",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Image primitives"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Read FAQ to understand what ImTextureID is."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - \"p_min\" and \"p_max\" represent the upper-left and lower-right corners of the rectangle."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - \"uv_min\" and \"uv_max\" represent the normalized texture coordinates to use for those corners. Using (0,0)->(1,1) texture coordinates will generally display the entire texture."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddImageQuad",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_texture_id",
+        "qualType" : "ImTextureID",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p4",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv4",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddImageRounded",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "user_texture_id",
+        "qualType" : "ImTextureID",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rounding",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImDrawFlags",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathClear",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Stateful path API, add points then finish with PathFillConvex() or PathStroke()"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathLineTo",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathLineToMergeDuplicate",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathFillConvex",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathStroke",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImDrawFlags",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathArcTo",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "center",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "radius",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "a_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "a_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathArcToFast",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "center",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "radius",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "a_min_of_12",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "a_max_of_12",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathBezierCubicCurveTo",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p4",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathBezierQuadraticCurveTo",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathRect",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "rect_min",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rect_max",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rounding",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImDrawFlags",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddCallback",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "callback",
+        "qualType" : "ImDrawCallback",
+        "desugaredQualType" : "void (*)(const ImDrawList *, const ImDrawCmd *)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "callback_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Advanced"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddDrawCmd",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CloneOutput",
+      "resultType" : "ImDrawList *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ChannelsSplit",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Advanced: Channels"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use to split render into layers. By switching channels to can render out-of-order (e.g. submit FG primitives before BG primitives)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Use to minimize draw calls (e.g. if going back-and-forth between multiple clipping rectangles, prefer to append into separate channels then merge at the end)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - FIXME-OBSOLETE: This API shouldn't have been in ImDrawList in the first place!"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   Prefer using your own persistent instance of ImDrawListSplitter as you can stack them."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   Using the ImDrawList::ChannelsXXXX you cannot stack a split over another."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ChannelsMerge",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ChannelsSetCurrent",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PrimReserve",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "vtx_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Advanced: Primitives allocations"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - We render triangles (three vertices)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - All primitives needs to be reserved via PrimReserve() beforehand."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PrimUnreserve",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "vtx_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PrimRect",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "a",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "b",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PrimRectUV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "a",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "b",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_a",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_b",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PrimQuadUV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "a",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "b",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "d",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_a",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_b",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_c",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv_d",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PrimWriteVtx",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PrimWriteIdx",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImDrawIdx",
+        "desugaredQualType" : "unsigned short"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PrimVtx",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "uv",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddBezierCurve",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p1",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p4",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "thickness",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "PathBezierCurveTo",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p2",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p3",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p4",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "num_segments",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImDrawData",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " All draw data to render a Dear ImGui frame"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (NB: the style and the naming convention here is a little inconsistent, we currently preserve them for backward compatibility purpose,"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " as this is one of the oldest structure exposed by the library! Basically, ImDrawList == CmdList)"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Valid",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CmdListsCount",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TotalIdxCount",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TotalVtxCount",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CmdLists",
+      "qualType" : "ImDrawList **",
+      "desugaredQualType" : "ImDrawList **"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplayPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DisplaySize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FramebufferScale",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OwnerViewport",
+      "qualType" : "ImGuiViewport *",
+      "desugaredQualType" : "ImGuiViewport *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Clear",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DeIndexAllBuffers",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ScaleClipRects",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fb_scale",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImFontConfig",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " [SECTION] Font API (ImFontConfig, ImFontGlyph, ImFontAtlasFlags, ImFontAtlas, ImFontGlyphRangesBuilder, ImFont)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "-----------------------------------------------------------------------------"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontDataSize",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontDataOwnedByAtlas",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontNo",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "SizePixels",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OversampleH",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "OversampleV",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PixelSnapH",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GlyphExtraSpacing",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GlyphOffset",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GlyphRanges",
+      "qualType" : "const ImWchar *",
+      "desugaredQualType" : "const ImWchar *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GlyphMinAdvanceX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GlyphMaxAdvanceX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MergeMode",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontBuilderFlags",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RasterizerMultiply",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "EllipsisChar",
+      "qualType" : "ImWchar",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Name",
+      "qualType" : "char[40]",
+      "desugaredQualType" : "char[40]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DstFont",
+      "qualType" : "ImFont *",
+      "desugaredQualType" : "ImFont *"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImFontGlyph",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Hold rendering data for one glyph."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " (Note: some language parsers may fail to convert the 31+1 bitfield members, in this case maybe drop store a single u32 or we can rework this)"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Colored",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Visible",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Codepoint",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "AdvanceX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "X0",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Y0",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "X1",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Y1",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "U0",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "V0",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "U1",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "V1",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImFontGlyphRangesBuilder",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Helper to build glyph ranges from text/string data. Feed your application strings/characters to it then call BuildRanges()."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " This is essentially a tightly packed of vector of 64k booleans = 8KB storage."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "UsedChars",
+      "qualType" : "ImVector<ImU32>",
+      "desugaredQualType" : "ImVector<unsigned int>"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Clear",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetBit",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetBit",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "n",
+        "qualType" : "size_t",
+        "desugaredQualType" : "unsigned long"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddChar",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddText",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddRanges",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ranges",
+        "qualType" : "const ImWchar *",
+        "desugaredQualType" : "const ImWchar *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BuildRanges",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_ranges",
+        "qualType" : "ImVector<ImWchar> *",
+        "desugaredQualType" : "ImVector<ImWchar> *"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImFontAtlasCustomRect",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " See ImFontAtlas::AddCustomRectXXX functions."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Width",
+      "qualType" : "unsigned short",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Height",
+      "qualType" : "unsigned short",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "X",
+      "qualType" : "unsigned short",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Y",
+      "qualType" : "unsigned short",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GlyphID",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GlyphAdvanceX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "GlyphOffset",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Font",
+      "qualType" : "ImFont *",
+      "desugaredQualType" : "ImFont *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsPacked",
+      "resultType" : "bool"
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImFontAtlasFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for ImFontAtlas build"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImFontAtlasFlags_None",
+      "qualType" : "ImFontAtlasFlags_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImFontAtlasFlags_NoPowerOfTwoHeight",
+      "docComment" : "Don't round the height to next power of two",
+      "qualType" : "ImFontAtlasFlags_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImFontAtlasFlags_NoMouseCursors",
+      "docComment" : "Don't build software mouse cursors into the atlas (save a little texture memory)",
+      "qualType" : "ImFontAtlasFlags_",
+      "order" : 2,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImFontAtlasFlags_NoBakedLines",
+      "docComment" : "Don't build thick line textures into the atlas (save a little texture memory). The AntiAliasedLinesUseTex features uses them, otherwise they will be rendered using polygons (more expensive for CPU/GPU).",
+      "qualType" : "ImFontAtlasFlags_",
+      "order" : 3,
+      "evaluatedValue" : "4"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImFontAtlas",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Load and rasterize multiple TTF/OTF fonts into a same texture. The font atlas will build a single texture holding:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - One or more fonts."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Custom graphics data needed to render the shapes needed by Dear ImGui."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Mouse cursor shapes for software cursor rendering (unless setting 'Flags |= ImFontAtlasFlags_NoMouseCursors' in the font atlas)."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " It is the user-code responsibility to setup/build the atlas, then upload the pixel data into a texture accessible by your graphics api."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Optionally, call any of the AddFont*** functions. If you don't call any, the default font embedded in the code will be loaded for you."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Call GetTexDataAsAlpha8() or GetTexDataAsRGBA32() to build and retrieve pixels data."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Upload the pixels data into a texture within your graphics system (see imgui_impl_xxxx.cpp examples)"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "  - Call SetTexID(my_tex_id); and pass the pointer/identifier to your texture in a format natural to your graphics API."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    This value will be passed back to you during rendering to identify the texture. Read FAQ entry about ImTextureID for more details."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " Common pitfalls:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - If you pass a 'glyph_ranges' array to AddFont*** functions, you need to make sure that your array persist up until the"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   atlas is build (when calling GetTexData*** or Build()). We only copy the pointer, not the data."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Important: By default, AddFontFromMemoryTTF() takes ownership of the data. Even though we are not writing to it, we will free the pointer on destruction."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   You can set font_cfg->FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed,"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - Even though many functions are suffixed with \"TTF\", OTF data is supported just as well."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - This is an old API and it is currently awkward for those and and various other reasons! We will address them in the future!"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddFont",
+      "resultType" : "ImFont *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_cfg",
+        "qualType" : "const ImFontConfig *",
+        "desugaredQualType" : "const ImFontConfig *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddFontDefault",
+      "resultType" : "ImFont *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_cfg",
+        "qualType" : "const ImFontConfig *",
+        "desugaredQualType" : "const ImFontConfig *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddFontFromFileTTF",
+      "resultType" : "ImFont *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "filename",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size_pixels",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_cfg",
+        "qualType" : "const ImFontConfig *",
+        "desugaredQualType" : "const ImFontConfig *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "glyph_ranges",
+        "qualType" : "const ImWchar *",
+        "desugaredQualType" : "const ImWchar *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddFontFromMemoryTTF",
+      "resultType" : "ImFont *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_size",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size_pixels",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_cfg",
+        "qualType" : "const ImFontConfig *",
+        "desugaredQualType" : "const ImFontConfig *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "glyph_ranges",
+        "qualType" : "const ImWchar *",
+        "desugaredQualType" : "const ImWchar *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddFontFromMemoryCompressedTTF",
+      "resultType" : "ImFont *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "compressed_font_data",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "compressed_font_size",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size_pixels",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_cfg",
+        "qualType" : "const ImFontConfig *",
+        "desugaredQualType" : "const ImFontConfig *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "glyph_ranges",
+        "qualType" : "const ImWchar *",
+        "desugaredQualType" : "const ImWchar *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddFontFromMemoryCompressedBase85TTF",
+      "resultType" : "ImFont *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "compressed_font_data_base85",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size_pixels",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "font_cfg",
+        "qualType" : "const ImFontConfig *",
+        "desugaredQualType" : "const ImFontConfig *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "glyph_ranges",
+        "qualType" : "const ImWchar *",
+        "desugaredQualType" : "const ImWchar *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearInputData",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearTexData",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearFonts",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Clear",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "Build",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Build atlas, retrieve pixel data."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " User is in charge of copying the pixels into graphics memory (e.g. create a texture with your engine). Then store your texture handle with SetTexID()."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " The pitch is always = Width * BytesPerPixels (1 or 4)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Building in RGBA32 format is provided for convenience and compatibility, but note that unless you manually manipulate or copy color data into"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " the texture (e.g. when using the AddCustomRect*** api), then the RGB pixels emitted will always be white (~75% of memory/bandwidth waste."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTexDataAsAlpha8",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_pixels",
+        "qualType" : "unsigned char **",
+        "desugaredQualType" : "unsigned char **"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_width",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_height",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_bytes_per_pixel",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetTexDataAsRGBA32",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_pixels",
+        "qualType" : "unsigned char **",
+        "desugaredQualType" : "unsigned char **"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_width",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_height",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_bytes_per_pixel",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsBuilt",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetTexID",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImTextureID",
+        "desugaredQualType" : "void *"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetGlyphRangesDefault",
+      "resultType" : "const ImWchar *",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Helpers to retrieve list of common Unicode ranges (2 value per range, values are inclusive, zero-terminated list)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " NB: Make sure that your string are UTF-8 and NOT in your local code page. In C++11, you can create UTF-8 string literal using the u8\"Hello world\" syntax. See FAQ for details."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " NB: Consider using ImFontGlyphRangesBuilder to build glyph ranges from textual data."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetGlyphRangesKorean",
+      "resultType" : "const ImWchar *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetGlyphRangesJapanese",
+      "resultType" : "const ImWchar *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetGlyphRangesChineseFull",
+      "resultType" : "const ImWchar *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetGlyphRangesChineseSimplifiedCommon",
+      "resultType" : "const ImWchar *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetGlyphRangesCyrillic",
+      "resultType" : "const ImWchar *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetGlyphRangesThai",
+      "resultType" : "const ImWchar *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetGlyphRangesVietnamese",
+      "resultType" : "const ImWchar *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddCustomRectRegular",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "width",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "height",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " You can request arbitrary rectangles to be packed into the atlas, for your own purposes."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - After calling Build(), you can query the rectangle position and render your pixels."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - If you render colored output, set 'atlas->TexPixelsUseColors = true' as this may help some backends decide of prefered texture format."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - You can also request your rectangles to be mapped as font glyph (given a font + Unicode point),"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : "   so you can render e.g. custom colorful icons and use them as regular glyphs."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Read docs/FONTS.md for more details about using colorful icons."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " - Note: this API may be redesigned later in order to support multi-monitor varying DPI settings."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddCustomRectFontGlyph",
+      "resultType" : "int",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "font",
+        "qualType" : "ImFont *",
+        "desugaredQualType" : "ImFont *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "width",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "height",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "advance_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "offset",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCustomRectByIndex",
+      "resultType" : "ImFontAtlasCustomRect *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "index",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcCustomRectUV",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "rect",
+        "qualType" : "const ImFontAtlasCustomRect *",
+        "desugaredQualType" : "const ImFontAtlasCustomRect *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_uv_min",
+        "qualType" : "ImVec2 *",
+        "desugaredQualType" : "ImVec2 *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_uv_max",
+        "qualType" : "ImVec2 *",
+        "desugaredQualType" : "ImVec2 *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " [Internal]"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetMouseCursorTexData",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "cursor",
+        "qualType" : "ImGuiMouseCursor",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_offset",
+        "qualType" : "ImVec2 *",
+        "desugaredQualType" : "ImVec2 *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_size",
+        "qualType" : "ImVec2 *",
+        "desugaredQualType" : "ImVec2 *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_uv_border",
+        "qualType" : "ImVec2 *",
+        "desugaredQualType" : "ImVec2 *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_uv_fill",
+        "qualType" : "ImVec2 *",
+        "desugaredQualType" : "ImVec2 *"
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImFontAtlasFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexID",
+      "qualType" : "ImTextureID",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexDesiredWidth",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexGlyphPadding",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Locked",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexReady",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexPixelsUseColors",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexPixelsAlpha8",
+      "qualType" : "unsigned char *",
+      "desugaredQualType" : "unsigned char *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexPixelsRGBA32",
+      "qualType" : "unsigned int *",
+      "desugaredQualType" : "unsigned int *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexWidth",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexHeight",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexUvScale",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexUvWhitePixel",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Fonts",
+      "qualType" : "ImVector<ImFont *>",
+      "desugaredQualType" : "ImVector<ImFont *>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "CustomRects",
+      "qualType" : "ImVector<ImFontAtlasCustomRect>",
+      "desugaredQualType" : "ImVector<ImFontAtlasCustomRect>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigData",
+      "qualType" : "ImVector<ImFontConfig>",
+      "desugaredQualType" : "ImVector<ImFontConfig>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "TexUvLines",
+      "qualType" : "ImVec4[64]",
+      "desugaredQualType" : "ImVec4[64]"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontBuilderIO",
+      "qualType" : "const ImFontBuilderIO *",
+      "desugaredQualType" : "const ImFontBuilderIO *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontBuilderFlags",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PackIdMouseCursors",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PackIdLines",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImFont",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Font runtime data and rendering"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " ImFontAtlas automatically loads a default embedded font for you when you call GetTexDataAsAlpha8() or GetTexDataAsRGBA32()."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IndexAdvanceX",
+      "qualType" : "ImVector<float>",
+      "desugaredQualType" : "ImVector<float>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FallbackAdvanceX",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FontSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "IndexLookup",
+      "qualType" : "ImVector<ImWchar>",
+      "desugaredQualType" : "ImVector<unsigned short>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Glyphs",
+      "qualType" : "ImVector<ImFontGlyph>",
+      "desugaredQualType" : "ImVector<ImFontGlyph>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FallbackGlyph",
+      "qualType" : "const ImFontGlyph *",
+      "desugaredQualType" : "const ImFontGlyph *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ContainerAtlas",
+      "qualType" : "ImFontAtlas *",
+      "desugaredQualType" : "ImFontAtlas *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigData",
+      "qualType" : "const ImFontConfig *",
+      "desugaredQualType" : "const ImFontConfig *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ConfigDataCount",
+      "qualType" : "short",
+      "desugaredQualType" : "short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FallbackChar",
+      "qualType" : "ImWchar",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "EllipsisChar",
+      "qualType" : "ImWchar",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DotChar",
+      "qualType" : "ImWchar",
+      "desugaredQualType" : "unsigned short"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DirtyLookupTables",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Scale",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Ascent",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Descent",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MetricsTotalSurface",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Used4kPagesMap",
+      "qualType" : "ImU8[2]",
+      "desugaredQualType" : "ImU8[2]"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindGlyph",
+      "resultType" : "const ImFontGlyph *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "FindGlyphNoFallback",
+      "resultType" : "const ImFontGlyph *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCharAdvance",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsLoaded",
+      "resultType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetDebugName",
+      "resultType" : "const char *"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcTextSizeA",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "max_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "wrap_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_begin",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "remaining",
+        "qualType" : "const char **",
+        "desugaredQualType" : "const char **"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcWordWrapPositionA",
+      "resultType" : "const char *",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "scale",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "wrap_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "RenderChar",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "draw_list",
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "RenderText",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "draw_list",
+        "qualType" : "ImDrawList *",
+        "desugaredQualType" : "ImDrawList *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "pos",
+        "qualType" : "ImVec2",
+        "desugaredQualType" : "ImVec2"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "ImU32",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "clip_rect",
+        "qualType" : "const ImVec4 &",
+        "desugaredQualType" : "const ImVec4 &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_begin",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "text_end",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "wrap_width",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cpu_fine_clip",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BuildLookupTable",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " [Internal] Don't use!"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ClearOutputData",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GrowIndex",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "new_size",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddGlyph",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "src_cfg",
+        "qualType" : "const ImFontConfig *",
+        "desugaredQualType" : "const ImFontConfig *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "x0",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "y0",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "x1",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "y1",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "u0",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v0",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "u1",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v1",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "advance_x",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "AddRemapChar",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "src",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "overwrite_dst",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetGlyphVisible",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c",
+        "qualType" : "ImWchar",
+        "desugaredQualType" : "unsigned short"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "visible",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "IsGlyphRangeUnused",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "c_begin",
+        "qualType" : "unsigned int",
+        "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "c_last",
+        "qualType" : "unsigned int",
+        "desugaredQualType" : "unsigned int"
+      } ]
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImGuiViewportFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags stored in ImGuiViewport::Flags, giving indications to the platform backends."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_None",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 0,
+      "evaluatedValue" : "0"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_IsPlatformWindow",
+      "docComment" : "Represent a Platform Window",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 1,
+      "evaluatedValue" : "1"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_IsPlatformMonitor",
+      "docComment" : "Represent a Platform Monitor (unused yet)",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 2,
+      "evaluatedValue" : "2"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_OwnedByApp",
+      "docComment" : "Platform Window: is created/managed by the application (rather than a dear imgui backend)",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 3,
+      "evaluatedValue" : "4"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_NoDecoration",
+      "docComment" : "Platform Window: Disable platform decorations: title bar, borders, etc. (generally set all windows, but if ImGuiConfigFlags_ViewportsDecoration is set we only set this on popups/tooltips)",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 4,
+      "evaluatedValue" : "8"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_NoTaskBarIcon",
+      "docComment" : "Platform Window: Disable platform task bar icon (generally set on popups/tooltips, or all windows if ImGuiConfigFlags_ViewportsNoTaskBarIcon is set)",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 5,
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_NoFocusOnAppearing",
+      "docComment" : "Platform Window: Don't take focus when created.",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 6,
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_NoFocusOnClick",
+      "docComment" : "Platform Window: Don't take focus when clicked on.",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 7,
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_NoInputs",
+      "docComment" : "Platform Window: Make mouse pass through so we can drag this window while peaking behind it.",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 8,
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_NoRendererClear",
+      "docComment" : "Platform Window: Renderer doesn't need to clear the framebuffer ahead (because we will fill it entirely).",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 9,
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_TopMost",
+      "docComment" : "Platform Window: Display on top (for tooltips only).",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 10,
+      "evaluatedValue" : "512"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_Minimized",
+      "docComment" : "Platform Window: Window is minimized, can skip render. When minimized we tend to avoid using the viewport pos/size for clipping window or testing if they are contained in the viewport.",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 11,
+      "evaluatedValue" : "1024"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_NoAutoMerge",
+      "docComment" : "Platform Window: Avoid merging this window into another host window. This can only be set via ImGuiWindowClass viewport flags override (because we need to now ahead if we are going to create a viewport in the first place!).",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 12,
+      "evaluatedValue" : "2048"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImGuiViewportFlags_CanHostOtherWindows",
+      "docComment" : "Main viewport: can host multiple imgui windows (secondary viewports are associated to a single window).",
+      "qualType" : "ImGuiViewportFlags_",
+      "order" : 13,
+      "evaluatedValue" : "4096"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiViewport",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " - Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - With multi-viewport enabled, we extend this concept to have multiple active viewports."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - In the future we will extend this concept further to also represent Platform Monitor and support a \"no main platform window\" operation mode."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " - About Main Area vs Work Area:"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   - Main Area = entire viewport."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   - Work Area = entire viewport minus sections used by main menu bars (for platform windows), or by task bar (for platform monitor)."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "   - Windows are generally trying to stay within the Work Area of their host viewport."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ID",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImGuiViewportFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Pos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Size",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WorkPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WorkSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DpiScale",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ParentViewportId",
+      "qualType" : "ImGuiID",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DrawData",
+      "qualType" : "ImDrawData *",
+      "desugaredQualType" : "ImDrawData *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "RendererUserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PlatformUserData",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PlatformHandle",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PlatformHandleRaw",
+      "qualType" : "void *",
+      "desugaredQualType" : "void *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PlatformRequestMove",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PlatformRequestResize",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "PlatformRequestClose",
+      "qualType" : "bool",
+      "desugaredQualType" : "bool"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetCenter",
+      "resultType" : "ImVec2",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Helpers"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWorkCenter",
+      "resultType" : "ImVec2"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiPlatformIO",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " (Optional) Access via ImGui::GetPlatformIO()"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_CreateWindow",
+      "qualType" : "void (*)(ImGuiViewport *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_DestroyWindow",
+      "qualType" : "void (*)(ImGuiViewport *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_ShowWindow",
+      "qualType" : "void (*)(ImGuiViewport *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_SetWindowPos",
+      "qualType" : "void (*)(ImGuiViewport *, ImVec2)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, ImVec2)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_GetWindowPos",
+      "qualType" : "ImVec2 (*)(ImGuiViewport *)",
+      "desugaredQualType" : "ImVec2 (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_SetWindowSize",
+      "qualType" : "void (*)(ImGuiViewport *, ImVec2)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, ImVec2)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_GetWindowSize",
+      "qualType" : "ImVec2 (*)(ImGuiViewport *)",
+      "desugaredQualType" : "ImVec2 (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_SetWindowFocus",
+      "qualType" : "void (*)(ImGuiViewport *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_GetWindowFocus",
+      "qualType" : "bool (*)(ImGuiViewport *)",
+      "desugaredQualType" : "bool (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_GetWindowMinimized",
+      "qualType" : "bool (*)(ImGuiViewport *)",
+      "desugaredQualType" : "bool (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_SetWindowTitle",
+      "qualType" : "void (*)(ImGuiViewport *, const char *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, const char *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_SetWindowAlpha",
+      "qualType" : "void (*)(ImGuiViewport *, float)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, float)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_UpdateWindow",
+      "qualType" : "void (*)(ImGuiViewport *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_RenderWindow",
+      "qualType" : "void (*)(ImGuiViewport *, void *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, void *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_SwapBuffers",
+      "qualType" : "void (*)(ImGuiViewport *, void *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, void *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_GetWindowDpiScale",
+      "qualType" : "float (*)(ImGuiViewport *)",
+      "desugaredQualType" : "float (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_OnChangedViewport",
+      "qualType" : "void (*)(ImGuiViewport *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_SetImeInputPos",
+      "qualType" : "void (*)(ImGuiViewport *, ImVec2)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, ImVec2)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Platform_CreateVkSurface",
+      "qualType" : "int (*)(ImGuiViewport *, ImU64, const void *, ImU64 *)",
+      "desugaredQualType" : "int (*)(ImGuiViewport *, ImU64, const void *, ImU64 *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Renderer_CreateWindow",
+      "qualType" : "void (*)(ImGuiViewport *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Renderer_DestroyWindow",
+      "qualType" : "void (*)(ImGuiViewport *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Renderer_SetWindowSize",
+      "qualType" : "void (*)(ImGuiViewport *, ImVec2)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, ImVec2)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Renderer_RenderWindow",
+      "qualType" : "void (*)(ImGuiViewport *, void *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, void *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Renderer_SwapBuffers",
+      "qualType" : "void (*)(ImGuiViewport *, void *)",
+      "desugaredQualType" : "void (*)(ImGuiViewport *, void *)"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Monitors",
+      "qualType" : "ImVector<ImGuiPlatformMonitor>",
+      "desugaredQualType" : "ImVector<ImGuiPlatformMonitor>"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Viewports",
+      "qualType" : "ImVector<ImGuiViewport *>",
+      "desugaredQualType" : "ImVector<ImGuiViewport *>"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "ImGuiPlatformMonitor",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " (Optional) This is required when enabling multi-viewport. Represent the bounds of each connected monitor/display and their DPI."
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " We use this information for multiple DPI support + clamping the position of popups and tooltips so they don't straddle multiple monitors."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MainPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MainSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WorkPos",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "WorkSize",
+      "qualType" : "ImVec2",
+      "desugaredQualType" : "ImVec2"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "DpiScale",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    } ]
+  }, {
+    "@type" : "AstNamespaceDecl",
+    "name" : "ImGui",
+    "decls" : [ {
+      "@type" : "AstFunctionDecl",
+      "name" : "CalcListClipping",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_height",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_items_display_start",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "out_items_display_end",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.86 (from November 2021)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetWindowContentRegionWidth",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.85 (from August 2021)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ListBoxHeader",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "items_count",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "height_in_items",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.81 (from February 2021)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ListBoxHeader",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const ImVec2 &",
+        "desugaredQualType" : "const ImVec2 &"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "ListBoxFooter",
+      "resultType" : "void"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "OpenPopupContextItem",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "mb",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.79 (from August 2020)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragScalar",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.78 (from June 2020)"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " Old drag/sliders functions that took a 'float power = 1.0' argument instead of flags."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " For shared code, you can version check at compile-time with `#if IMGUI_VERSION_NUM >= 17704`."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragScalarN",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "components",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloat",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloat2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloat3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "DragFloat4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_speed",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderScalar",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderScalarN",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_type",
+        "qualType" : "ImGuiDataType",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_data",
+        "qualType" : "void *",
+        "desugaredQualType" : "void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "components",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_min",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_max",
+        "qualType" : "const void *",
+        "desugaredQualType" : "const void *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderFloat",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderFloat2",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderFloat3",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SliderFloat4",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_min",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v_max",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "format",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "power",
+        "qualType" : "float",
+        "desugaredQualType" : "float"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginPopupContextWindow",
+      "resultType" : "bool",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "str_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "mb",
+        "qualType" : "ImGuiMouseButton",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "over_items",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.77 (from June 2020)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "TreeAdvanceToLabelPos",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.72 (from April 2019)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetNextTreeNodeOpen",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "open",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cond",
+        "qualType" : "ImGuiCond",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.71 (from June 2019)"
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "GetContentRegionAvailWidth",
+      "resultType" : "float",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " OBSOLETED in 1.70 (from May 2019)"
+          } ]
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImDrawCornerFlags_",
+    "decls" : [ {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_None",
+      "docComment" : "Was == 0 prior to 1.82, this is now == ImDrawFlags_RoundCornersNone which is != 0 and not implicit",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 0,
+      "evaluatedValue" : "256"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_TopLeft",
+      "docComment" : "Was == 0x01 (1 < < 0) prior to 1.82. Order matches ImDrawFlags_NoRoundCorner* flag (we exploit this internally).",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 1,
+      "evaluatedValue" : "16"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_TopRight",
+      "docComment" : "Was == 0x02 (1 < < 1) prior to 1.82.",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 2,
+      "evaluatedValue" : "32"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_BotLeft",
+      "docComment" : "Was == 0x04 (1 < < 2) prior to 1.82.",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 3,
+      "evaluatedValue" : "64"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_BotRight",
+      "docComment" : "Was == 0x08 (1 < < 3) prior to 1.82.",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 4,
+      "evaluatedValue" : "128"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_All",
+      "docComment" : "Was == 0x0F prior to 1.82",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 5,
+      "evaluatedValue" : "240"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_Top",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 6,
+      "evaluatedValue" : "48"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_Bot",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 7,
+      "evaluatedValue" : "192"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_Left",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 8,
+      "evaluatedValue" : "80"
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImDrawCornerFlags_Right",
+      "qualType" : "ImDrawCornerFlags_",
+      "order" : 9,
+      "evaluatedValue" : "160"
     } ]
   } ]
 }

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui_node_editor.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui_node_editor.json
@@ -7,525 +7,6 @@
   },
   "decls" : [ {
     "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
     "name" : "ax",
     "decls" : [ {
       "@type" : "AstFullComment",
@@ -608,36 +89,6 @@
           "evaluatedValue" : "16"
         } ]
       }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator|",
-        "resultType" : "SaveReasonFlags",
-        "decls" : [ {
-          "@type" : "AstParmVarDecl",
-          "name" : "lhs",
-          "qualType" : "SaveReasonFlags",
-          "desugaredQualType" : "ax::NodeEditor::SaveReasonFlags"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "rhs",
-          "qualType" : "SaveReasonFlags",
-          "desugaredQualType" : "ax::NodeEditor::SaveReasonFlags"
-        } ]
-      }, {
-        "@type" : "AstFunctionDecl",
-        "name" : "operator&",
-        "resultType" : "SaveReasonFlags",
-        "decls" : [ {
-          "@type" : "AstParmVarDecl",
-          "name" : "lhs",
-          "qualType" : "SaveReasonFlags",
-          "desugaredQualType" : "ax::NodeEditor::SaveReasonFlags"
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "rhs",
-          "qualType" : "SaveReasonFlags",
-          "desugaredQualType" : "ax::NodeEditor::SaveReasonFlags"
-        } ]
-      }, {
         "@type" : "AstRecordDecl",
         "name" : "Config",
         "decls" : [ {
@@ -717,12 +168,14 @@
           "@type" : "AstEnumConstantDecl",
           "name" : "Input",
           "qualType" : "ax::NodeEditor::PinKind",
-          "order" : 0
+          "order" : 0,
+          "evaluatedValue" : "0"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "Output",
           "qualType" : "ax::NodeEditor::PinKind",
-          "order" : 1
+          "order" : 1,
+          "evaluatedValue" : "1"
         } ]
       }, {
         "@type" : "AstEnumDecl",
@@ -731,12 +184,14 @@
           "@type" : "AstEnumConstantDecl",
           "name" : "Forward",
           "qualType" : "ax::NodeEditor::FlowDirection",
-          "order" : 0
+          "order" : 0,
+          "evaluatedValue" : "0"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "Backward",
           "qualType" : "ax::NodeEditor::FlowDirection",
-          "order" : 1
+          "order" : 1,
+          "evaluatedValue" : "1"
         } ]
       }, {
         "@type" : "AstEnumDecl",
@@ -754,97 +209,116 @@
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_Bg",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 0
+          "order" : 0,
+          "evaluatedValue" : "0"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_Grid",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 1
+          "order" : 1,
+          "evaluatedValue" : "1"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_NodeBg",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 2
+          "order" : 2,
+          "evaluatedValue" : "2"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_NodeBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 3
+          "order" : 3,
+          "evaluatedValue" : "3"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_HovNodeBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 4
+          "order" : 4,
+          "evaluatedValue" : "4"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_SelNodeBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 5
+          "order" : 5,
+          "evaluatedValue" : "5"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_NodeSelRect",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 6
+          "order" : 6,
+          "evaluatedValue" : "6"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_NodeSelRectBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 7
+          "order" : 7,
+          "evaluatedValue" : "7"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_HovLinkBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 8
+          "order" : 8,
+          "evaluatedValue" : "8"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_SelLinkBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 9
+          "order" : 9,
+          "evaluatedValue" : "9"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_LinkSelRect",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 10
+          "order" : 10,
+          "evaluatedValue" : "10"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_LinkSelRectBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 11
+          "order" : 11,
+          "evaluatedValue" : "11"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_PinRect",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 12
+          "order" : 12,
+          "evaluatedValue" : "12"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_PinRectBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 13
+          "order" : 13,
+          "evaluatedValue" : "13"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_Flow",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 14
+          "order" : 14,
+          "evaluatedValue" : "14"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_FlowMarker",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 15
+          "order" : 15,
+          "evaluatedValue" : "15"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_GroupBg",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 16
+          "order" : 16,
+          "evaluatedValue" : "16"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_GroupBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 17
+          "order" : 17,
+          "evaluatedValue" : "17"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_Count",
           "qualType" : "ax::NodeEditor::StyleColor",
-          "order" : 18
+          "order" : 18,
+          "evaluatedValue" : "18"
         } ]
       }, {
         "@type" : "AstEnumDecl",
@@ -853,122 +327,146 @@
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_NodePadding",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 0
+          "order" : 0,
+          "evaluatedValue" : "0"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_NodeRounding",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 1
+          "order" : 1,
+          "evaluatedValue" : "1"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_NodeBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 2
+          "order" : 2,
+          "evaluatedValue" : "2"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_HoveredNodeBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 3
+          "order" : 3,
+          "evaluatedValue" : "3"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_SelectedNodeBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 4
+          "order" : 4,
+          "evaluatedValue" : "4"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinRounding",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 5
+          "order" : 5,
+          "evaluatedValue" : "5"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 6
+          "order" : 6,
+          "evaluatedValue" : "6"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_LinkStrength",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 7
+          "order" : 7,
+          "evaluatedValue" : "7"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_SourceDirection",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 8
+          "order" : 8,
+          "evaluatedValue" : "8"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_TargetDirection",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 9
+          "order" : 9,
+          "evaluatedValue" : "9"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_ScrollDuration",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 10
+          "order" : 10,
+          "evaluatedValue" : "10"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_FlowMarkerDistance",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 11
+          "order" : 11,
+          "evaluatedValue" : "11"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_FlowSpeed",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 12
+          "order" : 12,
+          "evaluatedValue" : "12"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_FlowDuration",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 13
+          "order" : 13,
+          "evaluatedValue" : "13"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PivotAlignment",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 14
+          "order" : 14,
+          "evaluatedValue" : "14"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PivotSize",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 15
+          "order" : 15,
+          "evaluatedValue" : "15"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PivotScale",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 16
+          "order" : 16,
+          "evaluatedValue" : "16"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinCorners",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 17
+          "order" : 17,
+          "evaluatedValue" : "17"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinRadius",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 18
+          "order" : 18,
+          "evaluatedValue" : "18"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinArrowSize",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 19
+          "order" : 19,
+          "evaluatedValue" : "19"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinArrowWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 20
+          "order" : 20,
+          "evaluatedValue" : "20"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_GroupRounding",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 21
+          "order" : 21,
+          "evaluatedValue" : "21"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_GroupBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 22
+          "order" : 22,
+          "evaluatedValue" : "22"
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_Count",
           "qualType" : "ax::NodeEditor::StyleVar",
-          "order" : 23
+          "order" : 23,
+          "evaluatedValue" : "23"
         } ]
       }, {
         "@type" : "AstRecordDecl",
@@ -1112,6 +610,11 @@
         "name" : "SetCurrentEditor",
         "resultType" : "void",
         "decls" : [ {
+          "@type" : "AstParmVarDecl",
+          "name" : "ctx",
+          "qualType" : "EditorContext *",
+          "desugaredQualType" : "EditorContext *"
+        }, {
           "@type" : "AstFullComment",
           "decls" : [ {
             "@type" : "AstParagraphComment",
@@ -1120,11 +623,6 @@
               "text" : "------------------------------------------------------------------------------"
             } ]
           } ]
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "ctx",
-          "qualType" : "EditorContext *",
-          "desugaredQualType" : "EditorContext *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1405,6 +903,11 @@
         "name" : "GetNodeBackgroundDrawList",
         "resultType" : "int *",
         "decls" : [ {
+          "@type" : "AstParmVarDecl",
+          "name" : "nodeId",
+          "qualType" : "NodeId",
+          "desugaredQualType" : "ax::NodeEditor::NodeId"
+        }, {
           "@type" : "AstFullComment",
           "decls" : [ {
             "@type" : "AstParagraphComment",
@@ -1413,11 +916,6 @@
               "text" : " TODO: Add a way to manage node background channels"
             } ]
           } ]
-        }, {
-          "@type" : "AstParmVarDecl",
-          "name" : "nodeId",
-          "qualType" : "NodeId",
-          "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2211,230 +1709,5 @@
         "name" : "PinId"
       } ]
     } ]
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "__darwin_pthread_handler_rec",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__routine",
-      "qualType" : "void (*)(void *)",
-      "desugaredQualType" : "void (*)(void *)"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__arg",
-      "qualType" : "void *",
-      "desugaredQualType" : "void *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__next",
-      "qualType" : "struct __darwin_pthread_handler_rec *",
-      "desugaredQualType" : "struct __darwin_pthread_handler_rec *"
-    } ]
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_attr_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[56]",
-      "desugaredQualType" : "char[56]"
-    } ]
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_cond_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[40]",
-      "desugaredQualType" : "char[40]"
-    } ]
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_condattr_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[8]",
-      "desugaredQualType" : "char[8]"
-    } ]
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_mutex_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[56]",
-      "desugaredQualType" : "char[56]"
-    } ]
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_mutexattr_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[8]",
-      "desugaredQualType" : "char[8]"
-    } ]
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_once_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[8]",
-      "desugaredQualType" : "char[8]"
-    } ]
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_rwlock_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[192]",
-      "desugaredQualType" : "char[192]"
-    } ]
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_rwlockattr_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[16]",
-      "desugaredQualType" : "char[16]"
-    } ]
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "_opaque_pthread_t",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "__sig",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__cleanup_stack",
-      "qualType" : "struct __darwin_pthread_handler_rec *",
-      "desugaredQualType" : "struct __darwin_pthread_handler_rec *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "__opaque",
-      "qualType" : "char[8176]",
-      "desugaredQualType" : "char[8176]"
-    } ]
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "std"
   } ]
 }

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui_node_editor.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui_node_editor.json
@@ -51,42 +51,42 @@
           "qualType" : "ax::NodeEditor::SaveReasonFlags",
           "order" : 0,
           "value" : "0x00000000",
-          "evaluatedValue" : "0"
+          "evaluatedValue" : 0
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "Navigation",
           "qualType" : "ax::NodeEditor::SaveReasonFlags",
           "order" : 1,
           "value" : "0x00000001",
-          "evaluatedValue" : "1"
+          "evaluatedValue" : 1
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "Position",
           "qualType" : "ax::NodeEditor::SaveReasonFlags",
           "order" : 2,
           "value" : "0x00000002",
-          "evaluatedValue" : "2"
+          "evaluatedValue" : 2
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "Size",
           "qualType" : "ax::NodeEditor::SaveReasonFlags",
           "order" : 3,
           "value" : "0x00000004",
-          "evaluatedValue" : "4"
+          "evaluatedValue" : 4
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "Selection",
           "qualType" : "ax::NodeEditor::SaveReasonFlags",
           "order" : 4,
           "value" : "0x00000008",
-          "evaluatedValue" : "8"
+          "evaluatedValue" : 8
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "User",
           "qualType" : "ax::NodeEditor::SaveReasonFlags",
           "order" : 5,
           "value" : "0x00000010",
-          "evaluatedValue" : "16"
+          "evaluatedValue" : 16
         } ]
       }, {
         "@type" : "AstRecordDecl",
@@ -169,13 +169,13 @@
           "name" : "Input",
           "qualType" : "ax::NodeEditor::PinKind",
           "order" : 0,
-          "evaluatedValue" : "0"
+          "evaluatedValue" : 0
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "Output",
           "qualType" : "ax::NodeEditor::PinKind",
           "order" : 1,
-          "evaluatedValue" : "1"
+          "evaluatedValue" : 1
         } ]
       }, {
         "@type" : "AstEnumDecl",
@@ -185,13 +185,13 @@
           "name" : "Forward",
           "qualType" : "ax::NodeEditor::FlowDirection",
           "order" : 0,
-          "evaluatedValue" : "0"
+          "evaluatedValue" : 0
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "Backward",
           "qualType" : "ax::NodeEditor::FlowDirection",
           "order" : 1,
-          "evaluatedValue" : "1"
+          "evaluatedValue" : 1
         } ]
       }, {
         "@type" : "AstEnumDecl",
@@ -210,115 +210,115 @@
           "name" : "StyleColor_Bg",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 0,
-          "evaluatedValue" : "0"
+          "evaluatedValue" : 0
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_Grid",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 1,
-          "evaluatedValue" : "1"
+          "evaluatedValue" : 1
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_NodeBg",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 2,
-          "evaluatedValue" : "2"
+          "evaluatedValue" : 2
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_NodeBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 3,
-          "evaluatedValue" : "3"
+          "evaluatedValue" : 3
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_HovNodeBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 4,
-          "evaluatedValue" : "4"
+          "evaluatedValue" : 4
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_SelNodeBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 5,
-          "evaluatedValue" : "5"
+          "evaluatedValue" : 5
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_NodeSelRect",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 6,
-          "evaluatedValue" : "6"
+          "evaluatedValue" : 6
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_NodeSelRectBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 7,
-          "evaluatedValue" : "7"
+          "evaluatedValue" : 7
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_HovLinkBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 8,
-          "evaluatedValue" : "8"
+          "evaluatedValue" : 8
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_SelLinkBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 9,
-          "evaluatedValue" : "9"
+          "evaluatedValue" : 9
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_LinkSelRect",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 10,
-          "evaluatedValue" : "10"
+          "evaluatedValue" : 10
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_LinkSelRectBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 11,
-          "evaluatedValue" : "11"
+          "evaluatedValue" : 11
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_PinRect",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 12,
-          "evaluatedValue" : "12"
+          "evaluatedValue" : 12
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_PinRectBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 13,
-          "evaluatedValue" : "13"
+          "evaluatedValue" : 13
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_Flow",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 14,
-          "evaluatedValue" : "14"
+          "evaluatedValue" : 14
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_FlowMarker",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 15,
-          "evaluatedValue" : "15"
+          "evaluatedValue" : 15
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_GroupBg",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 16,
-          "evaluatedValue" : "16"
+          "evaluatedValue" : 16
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_GroupBorder",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 17,
-          "evaluatedValue" : "17"
+          "evaluatedValue" : 17
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleColor_Count",
           "qualType" : "ax::NodeEditor::StyleColor",
           "order" : 18,
-          "evaluatedValue" : "18"
+          "evaluatedValue" : 18
         } ]
       }, {
         "@type" : "AstEnumDecl",
@@ -328,145 +328,145 @@
           "name" : "StyleVar_NodePadding",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 0,
-          "evaluatedValue" : "0"
+          "evaluatedValue" : 0
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_NodeRounding",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 1,
-          "evaluatedValue" : "1"
+          "evaluatedValue" : 1
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_NodeBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 2,
-          "evaluatedValue" : "2"
+          "evaluatedValue" : 2
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_HoveredNodeBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 3,
-          "evaluatedValue" : "3"
+          "evaluatedValue" : 3
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_SelectedNodeBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 4,
-          "evaluatedValue" : "4"
+          "evaluatedValue" : 4
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinRounding",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 5,
-          "evaluatedValue" : "5"
+          "evaluatedValue" : 5
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 6,
-          "evaluatedValue" : "6"
+          "evaluatedValue" : 6
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_LinkStrength",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 7,
-          "evaluatedValue" : "7"
+          "evaluatedValue" : 7
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_SourceDirection",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 8,
-          "evaluatedValue" : "8"
+          "evaluatedValue" : 8
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_TargetDirection",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 9,
-          "evaluatedValue" : "9"
+          "evaluatedValue" : 9
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_ScrollDuration",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 10,
-          "evaluatedValue" : "10"
+          "evaluatedValue" : 10
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_FlowMarkerDistance",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 11,
-          "evaluatedValue" : "11"
+          "evaluatedValue" : 11
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_FlowSpeed",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 12,
-          "evaluatedValue" : "12"
+          "evaluatedValue" : 12
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_FlowDuration",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 13,
-          "evaluatedValue" : "13"
+          "evaluatedValue" : 13
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PivotAlignment",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 14,
-          "evaluatedValue" : "14"
+          "evaluatedValue" : 14
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PivotSize",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 15,
-          "evaluatedValue" : "15"
+          "evaluatedValue" : 15
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PivotScale",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 16,
-          "evaluatedValue" : "16"
+          "evaluatedValue" : 16
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinCorners",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 17,
-          "evaluatedValue" : "17"
+          "evaluatedValue" : 17
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinRadius",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 18,
-          "evaluatedValue" : "18"
+          "evaluatedValue" : 18
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinArrowSize",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 19,
-          "evaluatedValue" : "19"
+          "evaluatedValue" : 19
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_PinArrowWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 20,
-          "evaluatedValue" : "20"
+          "evaluatedValue" : 20
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_GroupRounding",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 21,
-          "evaluatedValue" : "21"
+          "evaluatedValue" : 21
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_GroupBorderWidth",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 22,
-          "evaluatedValue" : "22"
+          "evaluatedValue" : 22
         }, {
           "@type" : "AstEnumConstantDecl",
           "name" : "StyleVar_Count",
           "qualType" : "ax::NodeEditor::StyleVar",
           "order" : 23,
-          "evaluatedValue" : "23"
+          "evaluatedValue" : 23
         } ]
       }, {
         "@type" : "AstRecordDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imnodes.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imnodes.json
@@ -19,142 +19,170 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_NodeBackgroundHovered",
       "qualType" : "ImNodesCol_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_NodeBackgroundSelected",
       "qualType" : "ImNodesCol_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_NodeOutline",
       "qualType" : "ImNodesCol_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_TitleBar",
       "qualType" : "ImNodesCol_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_TitleBarHovered",
       "qualType" : "ImNodesCol_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_TitleBarSelected",
       "qualType" : "ImNodesCol_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_Link",
       "qualType" : "ImNodesCol_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_LinkHovered",
       "qualType" : "ImNodesCol_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_LinkSelected",
       "qualType" : "ImNodesCol_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_Pin",
       "qualType" : "ImNodesCol_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_PinHovered",
       "qualType" : "ImNodesCol_",
-      "order" : 11
+      "order" : 11,
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_BoxSelector",
       "qualType" : "ImNodesCol_",
-      "order" : 12
+      "order" : 12,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_BoxSelectorOutline",
       "qualType" : "ImNodesCol_",
-      "order" : 13
+      "order" : 13,
+      "evaluatedValue" : "13"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_GridBackground",
       "qualType" : "ImNodesCol_",
-      "order" : 14
+      "order" : 14,
+      "evaluatedValue" : "14"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_GridLine",
       "qualType" : "ImNodesCol_",
-      "order" : 15
+      "order" : 15,
+      "evaluatedValue" : "15"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapBackground",
       "qualType" : "ImNodesCol_",
-      "order" : 16
+      "order" : 16,
+      "evaluatedValue" : "16"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapBackgroundHovered",
       "qualType" : "ImNodesCol_",
-      "order" : 17
+      "order" : 17,
+      "evaluatedValue" : "17"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapOutline",
       "qualType" : "ImNodesCol_",
-      "order" : 18
+      "order" : 18,
+      "evaluatedValue" : "18"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapOutlineHovered",
       "qualType" : "ImNodesCol_",
-      "order" : 19
+      "order" : 19,
+      "evaluatedValue" : "19"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapNodeBackground",
       "qualType" : "ImNodesCol_",
-      "order" : 20
+      "order" : 20,
+      "evaluatedValue" : "20"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapNodeBackgroundHovered",
       "qualType" : "ImNodesCol_",
-      "order" : 21
+      "order" : 21,
+      "evaluatedValue" : "21"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapNodeBackgroundSelected",
       "qualType" : "ImNodesCol_",
-      "order" : 22
+      "order" : 22,
+      "evaluatedValue" : "22"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapNodeOutline",
       "qualType" : "ImNodesCol_",
-      "order" : 23
+      "order" : 23,
+      "evaluatedValue" : "23"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapLink",
       "qualType" : "ImNodesCol_",
-      "order" : 24
+      "order" : 24,
+      "evaluatedValue" : "24"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapLinkSelected",
       "qualType" : "ImNodesCol_",
-      "order" : 25
+      "order" : 25,
+      "evaluatedValue" : "25"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapCanvas",
       "qualType" : "ImNodesCol_",
-      "order" : 26
+      "order" : 26,
+      "evaluatedValue" : "26"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapCanvasOutline",
       "qualType" : "ImNodesCol_",
-      "order" : 27
+      "order" : 27,
+      "evaluatedValue" : "27"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_COUNT",
       "qualType" : "ImNodesCol_",
-      "order" : 28
+      "order" : 28,
+      "evaluatedValue" : "28"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -170,77 +198,92 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_NodeCornerRounding",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_NodePadding",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_NodeBorderThickness",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_LinkThickness",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_LinkLineSegmentsPerLength",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_LinkHoverDistance",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinCircleRadius",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinQuadSideLength",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinTriangleSideLength",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinLineThickness",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinHoverRadius",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 11
+      "order" : 11,
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinOffset",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 12
+      "order" : 12,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_MiniMapPadding",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 13
+      "order" : 13,
+      "evaluatedValue" : "13"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_MiniMapOffset",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 14
+      "order" : 14,
+      "evaluatedValue" : "14"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_COUNT",
       "qualType" : "ImNodesStyleVar_",
-      "order" : 15
+      "order" : 15,
+      "evaluatedValue" : "15"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -274,32 +317,38 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_Circle",
       "qualType" : "ImNodesPinShape_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_CircleFilled",
       "qualType" : "ImNodesPinShape_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_Triangle",
       "qualType" : "ImNodesPinShape_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_TriangleFilled",
       "qualType" : "ImNodesPinShape_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_Quad",
       "qualType" : "ImNodesPinShape_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_QuadFilled",
       "qualType" : "ImNodesPinShape_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -475,22 +524,26 @@
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesMiniMapLocation_BottomLeft",
       "qualType" : "ImNodesMiniMapLocation_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesMiniMapLocation_BottomRight",
       "qualType" : "ImNodesMiniMapLocation_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesMiniMapLocation_TopLeft",
       "qualType" : "ImNodesMiniMapLocation_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesMiniMapLocation_TopRight",
       "qualType" : "ImNodesMiniMapLocation_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -525,6 +578,11 @@
       "name" : "SetImGuiContext",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "ImGuiContext *",
+        "desugaredQualType" : "ImGuiContext *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -536,11 +594,6 @@
             "text" : " function sets the GImGui global variable, which is not shared across dll boundaries."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "ctx",
-        "qualType" : "ImGuiContext *",
-        "desugaredQualType" : "ImGuiContext *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -673,18 +726,6 @@
       "name" : "MiniMap",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Add a navigable minimap to the editor; call before EndNodeEditor after all"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " nodes and links have been specified"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "minimap_size_fraction",
         "qualType" : "const float",
@@ -708,21 +749,24 @@
         "qualType" : "const ImNodesMiniMapNodeHoveringCallbackUserData",
         "desugaredQualType" : "void *const",
         "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Add a navigable minimap to the editor; call before EndNodeEditor after all"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " nodes and links have been specified"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushColorStyle",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Use PushColorStyle and PopColorStyle to modify ImNodesStyle::Colors mid-frame."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "item",
         "qualType" : "ImNodesCol",
@@ -732,6 +776,15 @@
         "name" : "color",
         "qualType" : "unsigned int",
         "desugaredQualType" : "unsigned int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Use PushColorStyle and PopColorStyle to modify ImNodesStyle::Colors mid-frame."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -783,6 +836,11 @@
       "name" : "BeginNode",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -791,11 +849,6 @@
             "text" : " id can be any positive or negative integer, but INT_MIN is currently reserved for internal use."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -840,15 +893,6 @@
       "name" : "BeginInputAttribute",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Create an input attribute block. The pin is rendered on left side."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
         "qualType" : "int",
@@ -859,6 +903,15 @@
         "qualType" : "ImNodesPinShape",
         "desugaredQualType" : "int",
         "defaultValue" : "ImNodesPinShape_CircleFilled"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Create an input attribute block. The pin is rendered on left side."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -869,15 +922,6 @@
       "name" : "BeginOutputAttribute",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Create an output attribute block. The pin is rendered on the right side."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
         "qualType" : "int",
@@ -888,6 +932,15 @@
         "qualType" : "ImNodesPinShape",
         "desugaredQualType" : "int",
         "defaultValue" : "ImNodesPinShape_CircleFilled"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Create an output attribute block. The pin is rendered on the right side."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -898,6 +951,11 @@
       "name" : "BeginStaticAttribute",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "id",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -912,11 +970,6 @@
             "text" : " attribute activity."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -927,6 +980,11 @@
       "name" : "PushAttributeFlag",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "flag",
+        "qualType" : "ImNodesAttributeFlags",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -935,11 +993,6 @@
             "text" : " Push a single AttributeFlags value. By default, only AttributeFlags_None is set."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flag",
-        "qualType" : "ImNodesAttributeFlags",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -950,21 +1003,6 @@
       "name" : "Link",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Render a link between attributes."
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " The attributes ids used here must match the ids used in Begin(Input|Output)Attribute function"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " calls. The order of start_attr and end_attr doesn't make a difference for rendering the link."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
         "qualType" : "int",
@@ -979,21 +1017,27 @@
         "name" : "end_attribute_id",
         "qualType" : "int",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Render a link between attributes."
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " The attributes ids used here must match the ids used in Begin(Input|Output)Attribute function"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " calls. The order of start_attr and end_attr doesn't make a difference for rendering the link."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNodeDraggable",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Enable or disable the ability to click and drag a specific node."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
         "qualType" : "int",
@@ -1003,21 +1047,21 @@
         "name" : "draggable",
         "qualType" : "const bool",
         "desugaredQualType" : "const bool"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Enable or disable the ability to click and drag a specific node."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNodeScreenSpacePos",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Use the following functions to get and set the node's coordinates in these coordinate systems."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "node_id",
         "qualType" : "int",
@@ -1027,6 +1071,15 @@
         "name" : "screen_space_pos",
         "qualType" : "const ImVec2 &",
         "desugaredQualType" : "const ImVec2 &"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Use the following functions to get and set the node's coordinates in these coordinate systems."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1110,6 +1163,11 @@
       "name" : "IsNodeHovered",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "node_id",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1124,11 +1182,6 @@
             "text" : " after EndNodeEditor() has been called."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "node_id",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1176,6 +1229,11 @@
       "name" : "GetSelectedNodes",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "node_ids",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1190,11 +1248,6 @@
             "text" : " returned."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "node_ids",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1229,6 +1282,11 @@
       "name" : "SelectNode",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "node_id",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1252,11 +1310,6 @@
             "text" : " known."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "node_id",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1330,6 +1383,12 @@
       "name" : "IsAnyAttributeActive",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "attribute_id",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *",
+        "defaultValue" : "NULL"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1338,18 +1397,17 @@
             "text" : " Was any attribute active? If so, sets the active attribute id to the output function argument."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "attribute_id",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *",
-        "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsLinkStarted",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "started_at_attribute_id",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1358,17 +1416,24 @@
             "text" : " Did the user start dragging a new link from a pin?"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "started_at_attribute_id",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsLinkDropped",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "started_at_attribute_id",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *",
+        "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "including_detached_links",
+        "qualType" : "bool",
+        "desugaredQualType" : "bool",
+        "defaultValue" : "true"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1392,33 +1457,12 @@
             "text" : " detaches a link and drops it."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "started_at_attribute_id",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *",
-        "defaultValue" : "NULL"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "including_detached_links",
-        "qualType" : "bool",
-        "desugaredQualType" : "bool",
-        "defaultValue" : "true"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsLinkCreated",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Did the user finish creating a new link?"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "started_at_attribute_id",
         "qualType" : "int *",
@@ -1434,6 +1478,15 @@
         "qualType" : "bool *",
         "desugaredQualType" : "bool *",
         "defaultValue" : "NULL"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Did the user finish creating a new link?"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1471,6 +1524,11 @@
       "name" : "IsLinkDestroyed",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "link_id",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1482,17 +1540,18 @@
             "text" : " output argument link_id."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "link_id",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SaveCurrentEditorStateToIniString",
       "resultType" : "const char *",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "data_size",
+        "qualType" : "size_t *",
+        "desugaredQualType" : "size_t *",
+        "defaultValue" : "NULL"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1504,12 +1563,6 @@
             "text" : " file. The editor context is serialized in the INI file format."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "data_size",
-        "qualType" : "size_t *",
-        "desugaredQualType" : "size_t *",
-        "defaultValue" : "NULL"
       } ]
     }, {
       "@type" : "AstFunctionDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imnodes.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imnodes.json
@@ -14,175 +14,175 @@
       "qualType" : "ImNodesCol_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_NodeBackgroundHovered",
       "qualType" : "ImNodesCol_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_NodeBackgroundSelected",
       "qualType" : "ImNodesCol_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_NodeOutline",
       "qualType" : "ImNodesCol_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_TitleBar",
       "qualType" : "ImNodesCol_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_TitleBarHovered",
       "qualType" : "ImNodesCol_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_TitleBarSelected",
       "qualType" : "ImNodesCol_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_Link",
       "qualType" : "ImNodesCol_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_LinkHovered",
       "qualType" : "ImNodesCol_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_LinkSelected",
       "qualType" : "ImNodesCol_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_Pin",
       "qualType" : "ImNodesCol_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_PinHovered",
       "qualType" : "ImNodesCol_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_BoxSelector",
       "qualType" : "ImNodesCol_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_BoxSelectorOutline",
       "qualType" : "ImNodesCol_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_GridBackground",
       "qualType" : "ImNodesCol_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_GridLine",
       "qualType" : "ImNodesCol_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapBackground",
       "qualType" : "ImNodesCol_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapBackgroundHovered",
       "qualType" : "ImNodesCol_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapOutline",
       "qualType" : "ImNodesCol_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapOutlineHovered",
       "qualType" : "ImNodesCol_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapNodeBackground",
       "qualType" : "ImNodesCol_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapNodeBackgroundHovered",
       "qualType" : "ImNodesCol_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapNodeBackgroundSelected",
       "qualType" : "ImNodesCol_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapNodeOutline",
       "qualType" : "ImNodesCol_",
       "order" : 23,
-      "evaluatedValue" : "23"
+      "evaluatedValue" : 23
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapLink",
       "qualType" : "ImNodesCol_",
       "order" : 24,
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapLinkSelected",
       "qualType" : "ImNodesCol_",
       "order" : 25,
-      "evaluatedValue" : "25"
+      "evaluatedValue" : 25
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapCanvas",
       "qualType" : "ImNodesCol_",
       "order" : 26,
-      "evaluatedValue" : "26"
+      "evaluatedValue" : 26
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_MiniMapCanvasOutline",
       "qualType" : "ImNodesCol_",
       "order" : 27,
-      "evaluatedValue" : "27"
+      "evaluatedValue" : 27
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesCol_COUNT",
       "qualType" : "ImNodesCol_",
       "order" : 28,
-      "evaluatedValue" : "28"
+      "evaluatedValue" : 28
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -193,97 +193,97 @@
       "qualType" : "ImNodesStyleVar_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_NodeCornerRounding",
       "qualType" : "ImNodesStyleVar_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_NodePadding",
       "qualType" : "ImNodesStyleVar_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_NodeBorderThickness",
       "qualType" : "ImNodesStyleVar_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_LinkThickness",
       "qualType" : "ImNodesStyleVar_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_LinkLineSegmentsPerLength",
       "qualType" : "ImNodesStyleVar_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_LinkHoverDistance",
       "qualType" : "ImNodesStyleVar_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinCircleRadius",
       "qualType" : "ImNodesStyleVar_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinQuadSideLength",
       "qualType" : "ImNodesStyleVar_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinTriangleSideLength",
       "qualType" : "ImNodesStyleVar_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinLineThickness",
       "qualType" : "ImNodesStyleVar_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinHoverRadius",
       "qualType" : "ImNodesStyleVar_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_PinOffset",
       "qualType" : "ImNodesStyleVar_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_MiniMapPadding",
       "qualType" : "ImNodesStyleVar_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_MiniMapOffset",
       "qualType" : "ImNodesStyleVar_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleVar_COUNT",
       "qualType" : "ImNodesStyleVar_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -294,21 +294,21 @@
       "qualType" : "ImNodesStyleFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleFlags_NodeOutline",
       "qualType" : "ImNodesStyleFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesStyleFlags_GridLines",
       "qualType" : "ImNodesStyleFlags_",
       "order" : 2,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -318,37 +318,37 @@
       "name" : "ImNodesPinShape_Circle",
       "qualType" : "ImNodesPinShape_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_CircleFilled",
       "qualType" : "ImNodesPinShape_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_Triangle",
       "qualType" : "ImNodesPinShape_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_TriangleFilled",
       "qualType" : "ImNodesPinShape_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_Quad",
       "qualType" : "ImNodesPinShape_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesPinShape_QuadFilled",
       "qualType" : "ImNodesPinShape_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -368,7 +368,7 @@
       "qualType" : "ImNodesAttributeFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesAttributeFlags_EnableLinkDetachWithDragClick",
@@ -376,7 +376,7 @@
       "qualType" : "ImNodesAttributeFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesAttributeFlags_EnableLinkCreationOnSnap",
@@ -384,7 +384,7 @@
       "qualType" : "ImNodesAttributeFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -525,25 +525,25 @@
       "name" : "ImNodesMiniMapLocation_BottomLeft",
       "qualType" : "ImNodesMiniMapLocation_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesMiniMapLocation_BottomRight",
       "qualType" : "ImNodesMiniMapLocation_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesMiniMapLocation_TopLeft",
       "qualType" : "ImNodesMiniMapLocation_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImNodesMiniMapLocation_TopRight",
       "qualType" : "ImNodesMiniMapLocation_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     } ]
   }, {
     "@type" : "AstRecordDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-implot.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-implot.json
@@ -37,7 +37,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_NoTitle",
@@ -45,7 +45,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_NoLegend",
@@ -53,7 +53,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_NoMenus",
@@ -61,7 +61,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_NoBoxSelect",
@@ -69,7 +69,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_NoMousePos",
@@ -77,7 +77,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_NoHighlight",
@@ -85,7 +85,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_NoChild",
@@ -93,7 +93,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_Equal",
@@ -101,7 +101,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_YAxis2",
@@ -109,7 +109,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_YAxis3",
@@ -117,7 +117,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_Query",
@@ -125,7 +125,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_Crosshairs",
@@ -133,7 +133,7 @@
       "qualType" : "ImPlotFlags_",
       "order" : 12,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_AntiAliased",
@@ -141,14 +141,14 @@
       "qualType" : "ImPlotFlags_",
       "order" : 13,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotFlags_CanvasOnly",
       "qualType" : "ImPlotFlags_",
       "order" : 14,
       "value" : "ImPlotFlags_NoTitle | ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect | ImPlotFlags_NoMousePos",
-      "evaluatedValue" : "31"
+      "evaluatedValue" : 31
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -169,7 +169,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_NoLabel",
@@ -177,7 +177,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_NoGridLines",
@@ -185,7 +185,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_NoTickMarks",
@@ -193,7 +193,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_NoTickLabels",
@@ -201,7 +201,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_Foreground",
@@ -209,7 +209,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_LogScale",
@@ -217,7 +217,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_Time",
@@ -225,7 +225,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_Invert",
@@ -233,7 +233,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_NoInitialFit",
@@ -241,7 +241,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_AutoFit",
@@ -249,7 +249,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_RangeFit",
@@ -257,7 +257,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_LockMin",
@@ -265,7 +265,7 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 12,
       "value" : "1 << 11",
-      "evaluatedValue" : "2048"
+      "evaluatedValue" : 2048
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_LockMax",
@@ -273,21 +273,21 @@
       "qualType" : "ImPlotAxisFlags_",
       "order" : 13,
       "value" : "1 << 12",
-      "evaluatedValue" : "4096"
+      "evaluatedValue" : 4096
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_Lock",
       "qualType" : "ImPlotAxisFlags_",
       "order" : 14,
       "value" : "ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax",
-      "evaluatedValue" : "6144"
+      "evaluatedValue" : 6144
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotAxisFlags_NoDecorations",
       "qualType" : "ImPlotAxisFlags_",
       "order" : 15,
       "value" : "ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoTickLabels",
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -308,7 +308,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_NoTitle",
@@ -316,7 +316,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_NoLegend",
@@ -324,7 +324,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_NoMenus",
@@ -332,7 +332,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_NoResize",
@@ -340,7 +340,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_NoAlign",
@@ -348,7 +348,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 5,
       "value" : "1 << 4",
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_ShareItems",
@@ -356,7 +356,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 6,
       "value" : "1 << 5",
-      "evaluatedValue" : "32"
+      "evaluatedValue" : 32
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_LinkRows",
@@ -364,7 +364,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 7,
       "value" : "1 << 6",
-      "evaluatedValue" : "64"
+      "evaluatedValue" : 64
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_LinkCols",
@@ -372,7 +372,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 8,
       "value" : "1 << 7",
-      "evaluatedValue" : "128"
+      "evaluatedValue" : 128
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_LinkAllX",
@@ -380,7 +380,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 9,
       "value" : "1 << 8",
-      "evaluatedValue" : "256"
+      "evaluatedValue" : 256
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_LinkAllY",
@@ -388,7 +388,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 10,
       "value" : "1 << 9",
-      "evaluatedValue" : "512"
+      "evaluatedValue" : 512
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotSubplotFlags_ColMajor",
@@ -396,7 +396,7 @@
       "qualType" : "ImPlotSubplotFlags_",
       "order" : 11,
       "value" : "1 << 10",
-      "evaluatedValue" : "1024"
+      "evaluatedValue" : 1024
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -416,174 +416,174 @@
       "docComment" : "plot line/outline color (defaults to next unused color in current colormap)",
       "qualType" : "ImPlotCol_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_Fill",
       "docComment" : "plot fill color for bars (defaults to the current line color)",
       "qualType" : "ImPlotCol_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_MarkerOutline",
       "docComment" : "marker outline color (defaults to the current line color)",
       "qualType" : "ImPlotCol_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_MarkerFill",
       "docComment" : "marker fill color (defaults to the current line color)",
       "qualType" : "ImPlotCol_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_ErrorBar",
       "docComment" : "error bar color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_FrameBg",
       "docComment" : "plot frame background color (defaults to ImGuiCol_FrameBg)",
       "qualType" : "ImPlotCol_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_PlotBg",
       "docComment" : "plot area background color (defaults to ImGuiCol_WindowBg)",
       "qualType" : "ImPlotCol_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_PlotBorder",
       "docComment" : "plot area border color (defaults to ImGuiCol_Border)",
       "qualType" : "ImPlotCol_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_LegendBg",
       "docComment" : "legend background color (defaults to ImGuiCol_PopupBg)",
       "qualType" : "ImPlotCol_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_LegendBorder",
       "docComment" : "legend border color (defaults to ImPlotCol_PlotBorder)",
       "qualType" : "ImPlotCol_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_LegendText",
       "docComment" : "legend text color (defaults to ImPlotCol_InlayText)",
       "qualType" : "ImPlotCol_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_TitleText",
       "docComment" : "plot title text color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_InlayText",
       "docComment" : "color of text appearing inside of plots (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_XAxis",
       "docComment" : "x-axis label and tick lables color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_XAxisGrid",
       "docComment" : "x-axis grid color (defaults to 25% ImPlotCol_XAxis)",
       "qualType" : "ImPlotCol_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxis",
       "docComment" : "y-axis label and tick labels color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxisGrid",
       "docComment" : "y-axis grid color (defaults to 25% ImPlotCol_YAxis)",
       "qualType" : "ImPlotCol_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxis2",
       "docComment" : "2nd y-axis label and tick labels color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxisGrid2",
       "docComment" : "2nd y-axis grid/label color (defaults to 25% ImPlotCol_YAxis2)",
       "qualType" : "ImPlotCol_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxis3",
       "docComment" : "3rd y-axis label and tick labels color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxisGrid3",
       "docComment" : "3rd y-axis grid/label color (defaults to 25% ImPlotCol_YAxis3)",
       "qualType" : "ImPlotCol_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_Selection",
       "docComment" : "box-selection color (defaults to yellow)",
       "qualType" : "ImPlotCol_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_Query",
       "docComment" : "box-query color (defaults to green)",
       "qualType" : "ImPlotCol_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_Crosshairs",
       "docComment" : "crosshairs color (defaults to ImPlotCol_PlotBorder)",
       "qualType" : "ImPlotCol_",
       "order" : 23,
-      "evaluatedValue" : "23"
+      "evaluatedValue" : 23
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_COUNT",
       "qualType" : "ImPlotCol_",
       "order" : 24,
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -603,195 +603,195 @@
       "docComment" : "float,  plot item line weight in pixels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_Marker",
       "docComment" : "int,    marker specification",
       "qualType" : "ImPlotStyleVar_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MarkerSize",
       "docComment" : "float,  marker size in pixels (roughly the marker's \"radius\")",
       "qualType" : "ImPlotStyleVar_",
       "order" : 2,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MarkerWeight",
       "docComment" : "float,  plot outline weight of markers in pixels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 3,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_FillAlpha",
       "docComment" : "float,  alpha modifier applied to all plot item fills",
       "qualType" : "ImPlotStyleVar_",
       "order" : 4,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_ErrorBarSize",
       "docComment" : "float,  error bar whisker width in pixels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 5,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_ErrorBarWeight",
       "docComment" : "float,  error bar whisker weight in pixels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 6,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_DigitalBitHeight",
       "docComment" : "float,  digital channels bit height (at 1) in pixels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 7,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_DigitalBitGap",
       "docComment" : "float,  digital channels bit padding gap in pixels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 8,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_PlotBorderSize",
       "docComment" : "float,  thickness of border around plot area",
       "qualType" : "ImPlotStyleVar_",
       "order" : 9,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MinorAlpha",
       "docComment" : "float,  alpha multiplier applied to minor axis grid lines",
       "qualType" : "ImPlotStyleVar_",
       "order" : 10,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MajorTickLen",
       "docComment" : "ImVec2, major tick lengths for X and Y axes",
       "qualType" : "ImPlotStyleVar_",
       "order" : 11,
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MinorTickLen",
       "docComment" : "ImVec2, minor tick lengths for X and Y axes",
       "qualType" : "ImPlotStyleVar_",
       "order" : 12,
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MajorTickSize",
       "docComment" : "ImVec2, line thickness of major ticks",
       "qualType" : "ImPlotStyleVar_",
       "order" : 13,
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MinorTickSize",
       "docComment" : "ImVec2, line thickness of minor ticks",
       "qualType" : "ImPlotStyleVar_",
       "order" : 14,
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MajorGridSize",
       "docComment" : "ImVec2, line thickness of major grid lines",
       "qualType" : "ImPlotStyleVar_",
       "order" : 15,
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MinorGridSize",
       "docComment" : "ImVec2, line thickness of minor grid lines",
       "qualType" : "ImPlotStyleVar_",
       "order" : 16,
-      "evaluatedValue" : "16"
+      "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_PlotPadding",
       "docComment" : "ImVec2, padding between widget frame and plot area, labels, or outside legends (i.e. main padding)",
       "qualType" : "ImPlotStyleVar_",
       "order" : 17,
-      "evaluatedValue" : "17"
+      "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_LabelPadding",
       "docComment" : "ImVec2, padding between axes labels, tick labels, and plot edge",
       "qualType" : "ImPlotStyleVar_",
       "order" : 18,
-      "evaluatedValue" : "18"
+      "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_LegendPadding",
       "docComment" : "ImVec2, legend padding from plot edges",
       "qualType" : "ImPlotStyleVar_",
       "order" : 19,
-      "evaluatedValue" : "19"
+      "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_LegendInnerPadding",
       "docComment" : "ImVec2, legend inner padding from legend edges",
       "qualType" : "ImPlotStyleVar_",
       "order" : 20,
-      "evaluatedValue" : "20"
+      "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_LegendSpacing",
       "docComment" : "ImVec2, spacing between legend entries",
       "qualType" : "ImPlotStyleVar_",
       "order" : 21,
-      "evaluatedValue" : "21"
+      "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MousePosPadding",
       "docComment" : "ImVec2, padding between plot edge and interior info text",
       "qualType" : "ImPlotStyleVar_",
       "order" : 22,
-      "evaluatedValue" : "22"
+      "evaluatedValue" : 22
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_AnnotationPadding",
       "docComment" : "ImVec2, text padding around annotation labels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 23,
-      "evaluatedValue" : "23"
+      "evaluatedValue" : 23
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_FitPadding",
       "docComment" : "ImVec2, additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)",
       "qualType" : "ImPlotStyleVar_",
       "order" : 24,
-      "evaluatedValue" : "24"
+      "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_PlotDefaultSize",
       "docComment" : "ImVec2, default size used when ImVec2(0,0) is passed to BeginPlot",
       "qualType" : "ImPlotStyleVar_",
       "order" : 25,
-      "evaluatedValue" : "25"
+      "evaluatedValue" : 25
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_PlotMinSize",
       "docComment" : "ImVec2, minimum size plot frame can be when shrunk",
       "qualType" : "ImPlotStyleVar_",
       "order" : 26,
-      "evaluatedValue" : "26"
+      "evaluatedValue" : 26
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_COUNT",
       "qualType" : "ImPlotStyleVar_",
       "order" : 27,
-      "evaluatedValue" : "27"
+      "evaluatedValue" : 27
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -812,83 +812,83 @@
       "qualType" : "ImPlotMarker_",
       "order" : 0,
       "value" : "-1",
-      "evaluatedValue" : "-1"
+      "evaluatedValue" : -1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Circle",
       "docComment" : "a circle marker",
       "qualType" : "ImPlotMarker_",
       "order" : 1,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Square",
       "docComment" : "a square maker",
       "qualType" : "ImPlotMarker_",
       "order" : 2,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Diamond",
       "docComment" : "a diamond marker",
       "qualType" : "ImPlotMarker_",
       "order" : 3,
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Up",
       "docComment" : "an upward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
       "order" : 4,
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Down",
       "docComment" : "an downward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
       "order" : 5,
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Left",
       "docComment" : "an leftward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
       "order" : 6,
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Right",
       "docComment" : "an rightward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
       "order" : 7,
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Cross",
       "docComment" : "a cross marker (not fillable)",
       "qualType" : "ImPlotMarker_",
       "order" : 8,
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Plus",
       "docComment" : "a plus marker (not fillable)",
       "qualType" : "ImPlotMarker_",
       "order" : 9,
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Asterisk",
       "docComment" : "a asterisk marker (not fillable)",
       "qualType" : "ImPlotMarker_",
       "order" : 10,
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_COUNT",
       "qualType" : "ImPlotMarker_",
       "order" : 11,
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -909,7 +909,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Dark",
@@ -917,7 +917,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 1,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Pastel",
@@ -925,7 +925,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 2,
       "value" : "2",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Paired",
@@ -933,7 +933,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 3,
       "value" : "3",
-      "evaluatedValue" : "3"
+      "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Viridis",
@@ -941,7 +941,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 4,
       "value" : "4",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Plasma",
@@ -949,7 +949,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 5,
       "value" : "5",
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Hot",
@@ -957,7 +957,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 6,
       "value" : "6",
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Cool",
@@ -965,7 +965,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 7,
       "value" : "7",
-      "evaluatedValue" : "7"
+      "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Pink",
@@ -973,7 +973,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 8,
       "value" : "8",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Jet",
@@ -981,7 +981,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 9,
       "value" : "9",
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Twilight",
@@ -989,7 +989,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 10,
       "value" : "10",
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_RdBu",
@@ -997,7 +997,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 11,
       "value" : "11",
-      "evaluatedValue" : "11"
+      "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_BrBG",
@@ -1005,7 +1005,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 12,
       "value" : "12",
-      "evaluatedValue" : "12"
+      "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_PiYG",
@@ -1013,7 +1013,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 13,
       "value" : "13",
-      "evaluatedValue" : "13"
+      "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Spectral",
@@ -1021,7 +1021,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 14,
       "value" : "14",
-      "evaluatedValue" : "14"
+      "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotColormap_Greys",
@@ -1029,7 +1029,7 @@
       "qualType" : "ImPlotColormap_",
       "order" : 15,
       "value" : "15",
-      "evaluatedValue" : "15"
+      "evaluatedValue" : 15
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1050,7 +1050,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotLocation_North",
@@ -1058,7 +1058,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 1,
       "value" : "1 << 0",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotLocation_South",
@@ -1066,7 +1066,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 2,
       "value" : "1 << 1",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotLocation_West",
@@ -1074,7 +1074,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 3,
       "value" : "1 << 2",
-      "evaluatedValue" : "4"
+      "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotLocation_East",
@@ -1082,7 +1082,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 4,
       "value" : "1 << 3",
-      "evaluatedValue" : "8"
+      "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotLocation_NorthWest",
@@ -1090,7 +1090,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 5,
       "value" : "ImPlotLocation_North | ImPlotLocation_West",
-      "evaluatedValue" : "5"
+      "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotLocation_NorthEast",
@@ -1098,7 +1098,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 6,
       "value" : "ImPlotLocation_North | ImPlotLocation_East",
-      "evaluatedValue" : "9"
+      "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotLocation_SouthWest",
@@ -1106,7 +1106,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 7,
       "value" : "ImPlotLocation_South | ImPlotLocation_West",
-      "evaluatedValue" : "6"
+      "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotLocation_SouthEast",
@@ -1114,7 +1114,7 @@
       "qualType" : "ImPlotLocation_",
       "order" : 8,
       "value" : "ImPlotLocation_South | ImPlotLocation_East",
-      "evaluatedValue" : "10"
+      "evaluatedValue" : 10
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1134,14 +1134,14 @@
       "docComment" : "left/right",
       "qualType" : "ImPlotOrientation_",
       "order" : 0,
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotOrientation_Vertical",
       "docComment" : "up/down",
       "qualType" : "ImPlotOrientation_",
       "order" : 1,
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1162,7 +1162,7 @@
       "qualType" : "ImPlotYAxis_",
       "order" : 0,
       "value" : "0",
-      "evaluatedValue" : "0"
+      "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotYAxis_2",
@@ -1170,7 +1170,7 @@
       "qualType" : "ImPlotYAxis_",
       "order" : 1,
       "value" : "1",
-      "evaluatedValue" : "1"
+      "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotYAxis_3",
@@ -1178,7 +1178,7 @@
       "qualType" : "ImPlotYAxis_",
       "order" : 2,
       "value" : "2",
-      "evaluatedValue" : "2"
+      "evaluatedValue" : 2
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1199,7 +1199,7 @@
       "qualType" : "ImPlotBin_",
       "order" : 0,
       "value" : "-1",
-      "evaluatedValue" : "-1"
+      "evaluatedValue" : -1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotBin_Sturges",
@@ -1207,7 +1207,7 @@
       "qualType" : "ImPlotBin_",
       "order" : 1,
       "value" : "-2",
-      "evaluatedValue" : "-2"
+      "evaluatedValue" : -2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotBin_Rice",
@@ -1215,7 +1215,7 @@
       "qualType" : "ImPlotBin_",
       "order" : 2,
       "value" : "-3",
-      "evaluatedValue" : "-3"
+      "evaluatedValue" : -3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotBin_Scott",
@@ -1223,7 +1223,7 @@
       "qualType" : "ImPlotBin_",
       "order" : 3,
       "value" : "-4",
-      "evaluatedValue" : "-4"
+      "evaluatedValue" : -4
     } ]
   }, {
     "@type" : "AstRecordDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-implot.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-implot.json
@@ -415,150 +415,175 @@
       "name" : "ImPlotCol_Line",
       "docComment" : "plot line/outline color (defaults to next unused color in current colormap)",
       "qualType" : "ImPlotCol_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_Fill",
       "docComment" : "plot fill color for bars (defaults to the current line color)",
       "qualType" : "ImPlotCol_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_MarkerOutline",
       "docComment" : "marker outline color (defaults to the current line color)",
       "qualType" : "ImPlotCol_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_MarkerFill",
       "docComment" : "marker fill color (defaults to the current line color)",
       "qualType" : "ImPlotCol_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_ErrorBar",
       "docComment" : "error bar color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_FrameBg",
       "docComment" : "plot frame background color (defaults to ImGuiCol_FrameBg)",
       "qualType" : "ImPlotCol_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_PlotBg",
       "docComment" : "plot area background color (defaults to ImGuiCol_WindowBg)",
       "qualType" : "ImPlotCol_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_PlotBorder",
       "docComment" : "plot area border color (defaults to ImGuiCol_Border)",
       "qualType" : "ImPlotCol_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_LegendBg",
       "docComment" : "legend background color (defaults to ImGuiCol_PopupBg)",
       "qualType" : "ImPlotCol_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_LegendBorder",
       "docComment" : "legend border color (defaults to ImPlotCol_PlotBorder)",
       "qualType" : "ImPlotCol_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_LegendText",
       "docComment" : "legend text color (defaults to ImPlotCol_InlayText)",
       "qualType" : "ImPlotCol_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_TitleText",
       "docComment" : "plot title text color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
-      "order" : 11
+      "order" : 11,
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_InlayText",
       "docComment" : "color of text appearing inside of plots (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
-      "order" : 12
+      "order" : 12,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_XAxis",
       "docComment" : "x-axis label and tick lables color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
-      "order" : 13
+      "order" : 13,
+      "evaluatedValue" : "13"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_XAxisGrid",
       "docComment" : "x-axis grid color (defaults to 25% ImPlotCol_XAxis)",
       "qualType" : "ImPlotCol_",
-      "order" : 14
+      "order" : 14,
+      "evaluatedValue" : "14"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxis",
       "docComment" : "y-axis label and tick labels color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
-      "order" : 15
+      "order" : 15,
+      "evaluatedValue" : "15"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxisGrid",
       "docComment" : "y-axis grid color (defaults to 25% ImPlotCol_YAxis)",
       "qualType" : "ImPlotCol_",
-      "order" : 16
+      "order" : 16,
+      "evaluatedValue" : "16"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxis2",
       "docComment" : "2nd y-axis label and tick labels color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
-      "order" : 17
+      "order" : 17,
+      "evaluatedValue" : "17"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxisGrid2",
       "docComment" : "2nd y-axis grid/label color (defaults to 25% ImPlotCol_YAxis2)",
       "qualType" : "ImPlotCol_",
-      "order" : 18
+      "order" : 18,
+      "evaluatedValue" : "18"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxis3",
       "docComment" : "3rd y-axis label and tick labels color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
-      "order" : 19
+      "order" : 19,
+      "evaluatedValue" : "19"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_YAxisGrid3",
       "docComment" : "3rd y-axis grid/label color (defaults to 25% ImPlotCol_YAxis3)",
       "qualType" : "ImPlotCol_",
-      "order" : 20
+      "order" : 20,
+      "evaluatedValue" : "20"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_Selection",
       "docComment" : "box-selection color (defaults to yellow)",
       "qualType" : "ImPlotCol_",
-      "order" : 21
+      "order" : 21,
+      "evaluatedValue" : "21"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_Query",
       "docComment" : "box-query color (defaults to green)",
       "qualType" : "ImPlotCol_",
-      "order" : 22
+      "order" : 22,
+      "evaluatedValue" : "22"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_Crosshairs",
       "docComment" : "crosshairs color (defaults to ImPlotCol_PlotBorder)",
       "qualType" : "ImPlotCol_",
-      "order" : 23
+      "order" : 23,
+      "evaluatedValue" : "23"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotCol_COUNT",
       "qualType" : "ImPlotCol_",
-      "order" : 24
+      "order" : 24,
+      "evaluatedValue" : "24"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -577,168 +602,196 @@
       "name" : "ImPlotStyleVar_LineWeight",
       "docComment" : "float,  plot item line weight in pixels",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_Marker",
       "docComment" : "int,    marker specification",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MarkerSize",
       "docComment" : "float,  marker size in pixels (roughly the marker's \"radius\")",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 2
+      "order" : 2,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MarkerWeight",
       "docComment" : "float,  plot outline weight of markers in pixels",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 3
+      "order" : 3,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_FillAlpha",
       "docComment" : "float,  alpha modifier applied to all plot item fills",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 4
+      "order" : 4,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_ErrorBarSize",
       "docComment" : "float,  error bar whisker width in pixels",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 5
+      "order" : 5,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_ErrorBarWeight",
       "docComment" : "float,  error bar whisker weight in pixels",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 6
+      "order" : 6,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_DigitalBitHeight",
       "docComment" : "float,  digital channels bit height (at 1) in pixels",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 7
+      "order" : 7,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_DigitalBitGap",
       "docComment" : "float,  digital channels bit padding gap in pixels",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 8
+      "order" : 8,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_PlotBorderSize",
       "docComment" : "float,  thickness of border around plot area",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 9
+      "order" : 9,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MinorAlpha",
       "docComment" : "float,  alpha multiplier applied to minor axis grid lines",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 10
+      "order" : 10,
+      "evaluatedValue" : "10"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MajorTickLen",
       "docComment" : "ImVec2, major tick lengths for X and Y axes",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 11
+      "order" : 11,
+      "evaluatedValue" : "11"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MinorTickLen",
       "docComment" : "ImVec2, minor tick lengths for X and Y axes",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 12
+      "order" : 12,
+      "evaluatedValue" : "12"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MajorTickSize",
       "docComment" : "ImVec2, line thickness of major ticks",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 13
+      "order" : 13,
+      "evaluatedValue" : "13"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MinorTickSize",
       "docComment" : "ImVec2, line thickness of minor ticks",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 14
+      "order" : 14,
+      "evaluatedValue" : "14"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MajorGridSize",
       "docComment" : "ImVec2, line thickness of major grid lines",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 15
+      "order" : 15,
+      "evaluatedValue" : "15"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MinorGridSize",
       "docComment" : "ImVec2, line thickness of minor grid lines",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 16
+      "order" : 16,
+      "evaluatedValue" : "16"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_PlotPadding",
       "docComment" : "ImVec2, padding between widget frame and plot area, labels, or outside legends (i.e. main padding)",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 17
+      "order" : 17,
+      "evaluatedValue" : "17"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_LabelPadding",
       "docComment" : "ImVec2, padding between axes labels, tick labels, and plot edge",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 18
+      "order" : 18,
+      "evaluatedValue" : "18"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_LegendPadding",
       "docComment" : "ImVec2, legend padding from plot edges",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 19
+      "order" : 19,
+      "evaluatedValue" : "19"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_LegendInnerPadding",
       "docComment" : "ImVec2, legend inner padding from legend edges",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 20
+      "order" : 20,
+      "evaluatedValue" : "20"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_LegendSpacing",
       "docComment" : "ImVec2, spacing between legend entries",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 21
+      "order" : 21,
+      "evaluatedValue" : "21"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_MousePosPadding",
       "docComment" : "ImVec2, padding between plot edge and interior info text",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 22
+      "order" : 22,
+      "evaluatedValue" : "22"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_AnnotationPadding",
       "docComment" : "ImVec2, text padding around annotation labels",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 23
+      "order" : 23,
+      "evaluatedValue" : "23"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_FitPadding",
       "docComment" : "ImVec2, additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 24
+      "order" : 24,
+      "evaluatedValue" : "24"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_PlotDefaultSize",
       "docComment" : "ImVec2, default size used when ImVec2(0,0) is passed to BeginPlot",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 25
+      "order" : 25,
+      "evaluatedValue" : "25"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_PlotMinSize",
       "docComment" : "ImVec2, minimum size plot frame can be when shrunk",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 26
+      "order" : 26,
+      "evaluatedValue" : "26"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotStyleVar_COUNT",
       "qualType" : "ImPlotStyleVar_",
-      "order" : 27
+      "order" : 27,
+      "evaluatedValue" : "27"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -757,7 +810,7 @@
       "name" : "ImPlotMarker_None",
       "docComment" : "no marker",
       "qualType" : "ImPlotMarker_",
-      "order" : -1,
+      "order" : 0,
       "value" : "-1",
       "evaluatedValue" : "-1"
     }, {
@@ -765,66 +818,77 @@
       "name" : "ImPlotMarker_Circle",
       "docComment" : "a circle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 0
+      "order" : 1,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Square",
       "docComment" : "a square maker",
       "qualType" : "ImPlotMarker_",
-      "order" : 1
+      "order" : 2,
+      "evaluatedValue" : "1"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Diamond",
       "docComment" : "a diamond marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 2
+      "order" : 3,
+      "evaluatedValue" : "2"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Up",
       "docComment" : "an upward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 3
+      "order" : 4,
+      "evaluatedValue" : "3"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Down",
       "docComment" : "an downward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 4
+      "order" : 5,
+      "evaluatedValue" : "4"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Left",
       "docComment" : "an leftward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 5
+      "order" : 6,
+      "evaluatedValue" : "5"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Right",
       "docComment" : "an rightward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 6
+      "order" : 7,
+      "evaluatedValue" : "6"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Cross",
       "docComment" : "a cross marker (not fillable)",
       "qualType" : "ImPlotMarker_",
-      "order" : 7
+      "order" : 8,
+      "evaluatedValue" : "7"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Plus",
       "docComment" : "a plus marker (not fillable)",
       "qualType" : "ImPlotMarker_",
-      "order" : 8
+      "order" : 9,
+      "evaluatedValue" : "8"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Asterisk",
       "docComment" : "a asterisk marker (not fillable)",
       "qualType" : "ImPlotMarker_",
-      "order" : 9
+      "order" : 10,
+      "evaluatedValue" : "9"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_COUNT",
       "qualType" : "ImPlotMarker_",
-      "order" : 10
+      "order" : 11,
+      "evaluatedValue" : "10"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1069,13 +1133,15 @@
       "name" : "ImPlotOrientation_Horizontal",
       "docComment" : "left/right",
       "qualType" : "ImPlotOrientation_",
-      "order" : 0
+      "order" : 0,
+      "evaluatedValue" : "0"
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotOrientation_Vertical",
       "docComment" : "up/down",
       "qualType" : "ImPlotOrientation_",
-      "order" : 1
+      "order" : 1,
+      "evaluatedValue" : "1"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1131,7 +1197,7 @@
       "name" : "ImPlotBin_Sqrt",
       "docComment" : "k = sqrt(n)",
       "qualType" : "ImPlotBin_",
-      "order" : -1,
+      "order" : 0,
       "value" : "-1",
       "evaluatedValue" : "-1"
     }, {
@@ -1139,7 +1205,7 @@
       "name" : "ImPlotBin_Sturges",
       "docComment" : "k = 1 + log2(n)",
       "qualType" : "ImPlotBin_",
-      "order" : -2,
+      "order" : 1,
       "value" : "-2",
       "evaluatedValue" : "-2"
     }, {
@@ -1147,7 +1213,7 @@
       "name" : "ImPlotBin_Rice",
       "docComment" : "k = 2 * cbrt(n)",
       "qualType" : "ImPlotBin_",
-      "order" : -1,
+      "order" : 2,
       "value" : "-3",
       "evaluatedValue" : "-3"
     }, {
@@ -1155,7 +1221,7 @@
       "name" : "ImPlotBin_Scott",
       "docComment" : "w = 3.49 * sigma / cbrt(n)",
       "qualType" : "ImPlotBin_",
-      "order" : -4,
+      "order" : 3,
       "value" : "-4",
       "evaluatedValue" : "-4"
     } ]
@@ -1181,26 +1247,6 @@
       "name" : "y",
       "qualType" : "double",
       "desugaredQualType" : "double"
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "operator[]",
-      "resultType" : "double",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "idx",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "operator[]",
-      "resultType" : "double &",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "idx",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      } ]
     } ]
   }, {
     "@type" : "AstRecordDecl",
@@ -1510,6 +1556,12 @@
       "name" : "DestroyContext",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "ImPlotContext *",
+        "desugaredQualType" : "ImPlotContext *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1518,12 +1570,6 @@
             "text" : " Destroys an ImPlot context. Call this before ImGui::DestroyContext. NULL = destroy current context."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "ctx",
-        "qualType" : "ImPlotContext *",
-        "desugaredQualType" : "ImPlotContext *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1544,6 +1590,11 @@
       "name" : "SetCurrentContext",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "ImPlotContext *",
+        "desugaredQualType" : "ImPlotContext *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1552,17 +1603,17 @@
             "text" : " Sets the current ImPlot context."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "ctx",
-        "qualType" : "ImPlotContext *",
-        "desugaredQualType" : "ImPlotContext *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetImGuiContext",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ctx",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1580,17 +1631,77 @@
             "text" : " See GImGui documentation in imgui.cpp for more details."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "ctx",
-        "qualType" : "int *",
-        "desugaredQualType" : "int *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginPlot",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "title_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "x_label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "="
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "y_label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "="
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const int &",
+        "desugaredQualType" : "const int &",
+        "defaultValue" : "ImVec2(-1,0)"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImPlotFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "ImPlotFlags_None"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "x_flags",
+        "qualType" : "ImPlotAxisFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "ImPlotAxisFlags_None"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "y_flags",
+        "qualType" : "ImPlotAxisFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "ImPlotAxisFlags_None"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "y2_flags",
+        "qualType" : "ImPlotAxisFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "ImPlotAxisFlags_NoGridLines"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "y3_flags",
+        "qualType" : "ImPlotAxisFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "ImPlotAxisFlags_NoGridLines"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "y2_label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "="
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "y3_label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1656,71 +1767,6 @@
             "text" : " - See ImPlotFlags and ImPlotAxisFlags for more available options."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "title_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "x_label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "="
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "="
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
-        "defaultValue" : "ImVec2(-1,0)"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "ImPlotFlags_None"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "x_flags",
-        "qualType" : "ImPlotAxisFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "ImPlotAxisFlags_None"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_flags",
-        "qualType" : "ImPlotAxisFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "ImPlotAxisFlags_None"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y2_flags",
-        "qualType" : "ImPlotAxisFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "ImPlotAxisFlags_NoGridLines"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y3_flags",
-        "qualType" : "ImPlotAxisFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "ImPlotAxisFlags_NoGridLines"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y2_label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "="
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y3_label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1744,6 +1790,44 @@
       "name" : "BeginSubplots",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "title_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "rows",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "cols",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "size",
+        "qualType" : "const int &",
+        "desugaredQualType" : "const int &"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "ImPlotSubplotFlags",
+        "desugaredQualType" : "int",
+        "defaultValue" : "ImPlotSubplotFlags_None"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "row_ratios",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *",
+        "defaultValue" : "="
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "col_ratios",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -1887,44 +1971,6 @@
             "text" : "   #size value you pass to _BeginSubplots_ and #row/#col_ratios if provided."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "title_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "rows",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "cols",
-        "qualType" : "int",
-        "desugaredQualType" : "int"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotSubplotFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "ImPlotSubplotFlags_None"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "row_ratios",
-        "qualType" : "float *",
-        "desugaredQualType" : "float *",
-        "defaultValue" : "="
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "col_ratios",
-        "qualType" : "float *",
-        "desugaredQualType" : "float *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2143,15 +2189,6 @@
       "name" : "PlotImage",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down)."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label_id",
         "qualType" : "const char *",
@@ -2189,21 +2226,21 @@
         "qualType" : "const int &",
         "desugaredQualType" : "const int &",
         "defaultValue" : "ImVec4(1,1,1,1)"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down)."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PlotText",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...)."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "text",
         "qualType" : "const char *",
@@ -2230,12 +2267,26 @@
         "qualType" : "const int &",
         "desugaredQualType" : "const int &",
         "defaultValue" : "ImVec2(0,0)"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...)."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PlotDummy",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2244,26 +2295,12 @@
             "text" : " Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextPlotLimits",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the axes range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the axes limits will be locked."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "xmin",
         "qualType" : "double",
@@ -2289,21 +2326,21 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "="
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the axes range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the axes limits will be locked."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextPlotLimitsX",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the X axis range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the X axis limits will be locked."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "xmin",
         "qualType" : "double",
@@ -2319,21 +2356,21 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "="
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the X axis range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the X axis limits will be locked."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextPlotLimitsY",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the Y axis range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the Y axis limits will be locked."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "ymin",
         "qualType" : "double",
@@ -2355,21 +2392,21 @@
         "qualType" : "ImPlotYAxis",
         "desugaredQualType" : "int",
         "defaultValue" : "ImPlotYAxis_1"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the Y axis range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the Y axis limits will be locked."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "LinkNextPlotLimits",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Links the next plot limits to external values. Set to NULL for no linkage. The pointer data must remain valid until the matching call to EndPlot."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "xmin",
         "qualType" : "double *",
@@ -2413,21 +2450,21 @@
         "qualType" : "double *",
         "desugaredQualType" : "double *",
         "defaultValue" : "="
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Links the next plot limits to external values. Set to NULL for no linkage. The pointer data must remain valid until the matching call to EndPlot."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "FitNextPlotAxes",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Fits the next plot axes to all plotted data if they are unlocked (equivalent to double-clicks)."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "x",
         "qualType" : "bool",
@@ -2451,21 +2488,21 @@
         "qualType" : "bool",
         "desugaredQualType" : "bool",
         "defaultValue" : "true"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Fits the next plot axes to all plotted data if they are unlocked (equivalent to double-clicks)."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextPlotTicksX",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the X axis ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "values",
         "qualType" : "const double *",
@@ -2487,6 +2524,15 @@
         "qualType" : "bool",
         "desugaredQualType" : "bool",
         "defaultValue" : "false"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the X axis ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2525,15 +2571,6 @@
       "name" : "SetNextPlotTicksY",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the Y axis ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "values",
         "qualType" : "const double *",
@@ -2561,6 +2598,15 @@
         "qualType" : "ImPlotYAxis",
         "desugaredQualType" : "int",
         "defaultValue" : "ImPlotYAxis_1"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the Y axis ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2605,6 +2651,11 @@
       "name" : "SetNextPlotFormatX",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "fmt",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2613,26 +2664,12 @@
             "text" : " Set the format for numeric X axis labels (default=\"%g\"). Formated values will be doubles (i.e. don't supply %d, %i, etc.). Not applicable if ImPlotAxisFlags_Time enabled."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "fmt",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextPlotFormatY",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the format for numeric Y axis labels (default=\"%g\"). Formated values will be doubles (i.e. don't supply %d, %i, etc.)."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "fmt",
         "qualType" : "const char *",
@@ -2643,12 +2680,26 @@
         "qualType" : "ImPlotYAxis",
         "desugaredQualType" : "int",
         "defaultValue" : "ImPlotYAxis_1"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the format for numeric Y axis labels (default=\"%g\"). Formated values will be doubles (i.e. don't supply %d, %i, etc.)."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetPlotYAxis",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "y_axis",
+        "qualType" : "ImPlotYAxis",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2657,26 +2708,12 @@
             "text" : " Select which Y axis will be used for subsequent plot elements. The default is ImPlotYAxis_1, or the first (left) Y axis. Enable 2nd and 3rd axes with ImPlotFlags_YAxisX."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_axis",
-        "qualType" : "ImPlotYAxis",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "HideNextItem",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Hides or shows the next plot item (i.e. as if it were toggled from the legend). Use ImGuiCond_Always if you need to forcefully set this every frame."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "hidden",
         "qualType" : "bool",
@@ -2688,21 +2725,21 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "="
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Hides or shows the next plot item (i.e. as if it were toggled from the legend). Use ImGuiCond_Always if you need to forcefully set this every frame."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PixelsToPlot",
       "resultType" : "ImPlotPoint",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Convert pixels to a position in the current plot's coordinate system. A negative y_axis uses the current value of SetPlotYAxis (ImPlotYAxis_1 initially)."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "pix",
         "qualType" : "const int &",
@@ -2713,6 +2750,15 @@
         "qualType" : "ImPlotYAxis",
         "desugaredQualType" : "int",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Convert pixels to a position in the current plot's coordinate system. A negative y_axis uses the current value of SetPlotYAxis (ImPlotYAxis_1 initially)."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2740,15 +2786,6 @@
       "name" : "PlotToPixels",
       "resultType" : "int",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Convert a position in the current plot's coordinate system to pixels. A negative y_axis uses the current value of SetPlotYAxis (ImPlotYAxis_1 initially)."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "plt",
         "qualType" : "const ImPlotPoint &",
@@ -2759,6 +2796,15 @@
         "qualType" : "ImPlotYAxis",
         "desugaredQualType" : "int",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Convert a position in the current plot's coordinate system to pixels. A negative y_axis uses the current value of SetPlotYAxis (ImPlotYAxis_1 initially)."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2842,6 +2888,12 @@
       "name" : "IsPlotYAxisHovered",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "y_axis",
+        "qualType" : "ImPlotYAxis",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2850,18 +2902,18 @@
             "text" : " Returns true if the YAxis[n] plot area in the current plot is hovered."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_axis",
-        "qualType" : "ImPlotYAxis",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetPlotMousePos",
       "resultType" : "ImPlotPoint",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "y_axis",
+        "qualType" : "ImPlotYAxis",
+        "desugaredQualType" : "int",
+        "defaultValue" : "IMPLOT_AUTO"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2870,18 +2922,18 @@
             "text" : " Returns the mouse position in x,y coordinates of the current plot. A negative y_axis uses the current value of SetPlotYAxis (ImPlotYAxis_1 initially)."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_axis",
-        "qualType" : "ImPlotYAxis",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_AUTO"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetPlotLimits",
       "resultType" : "ImPlotLimits",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "y_axis",
+        "qualType" : "ImPlotYAxis",
+        "desugaredQualType" : "int",
+        "defaultValue" : "IMPLOT_AUTO"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2890,12 +2942,6 @@
             "text" : " Returns the current plot axis range. A negative y_axis uses the current value of SetPlotYAxis (ImPlotYAxis_1 initially)."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_axis",
-        "qualType" : "ImPlotYAxis",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_AUTO"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2916,6 +2962,12 @@
       "name" : "GetPlotSelection",
       "resultType" : "ImPlotLimits",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "y_axis",
+        "qualType" : "ImPlotYAxis",
+        "desugaredQualType" : "int",
+        "defaultValue" : "IMPLOT_AUTO"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2924,12 +2976,6 @@
             "text" : " Returns the current plot box selection bounds."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_axis",
-        "qualType" : "ImPlotYAxis",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_AUTO"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -2950,6 +2996,12 @@
       "name" : "GetPlotQuery",
       "resultType" : "ImPlotLimits",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "y_axis",
+        "qualType" : "ImPlotYAxis",
+        "desugaredQualType" : "int",
+        "defaultValue" : "IMPLOT_AUTO"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -2958,27 +3010,12 @@
             "text" : " Returns the current plot query bounds. Query must be enabled with ImPlotFlags_Query."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_axis",
-        "qualType" : "ImPlotYAxis",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_AUTO"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetPlotQuery",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the current plot query bounds. Query must be enabled with ImPlotFlags_Query."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "query",
         "qualType" : "const ImPlotLimits &",
@@ -2989,6 +3026,15 @@
         "qualType" : "ImPlotYAxis",
         "desugaredQualType" : "int",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the current plot query bounds. Query must be enabled with ImPlotFlags_Query."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3009,15 +3055,6 @@
       "name" : "BeginAlignedPlots",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Align axis padding over multiple plots in a single row or column. If this function returns true, EndAlignedPlots() must be called. #group_id must be unique."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "group_id",
         "qualType" : "const char *",
@@ -3028,6 +3065,15 @@
         "qualType" : "ImPlotOrientation",
         "desugaredQualType" : "int",
         "defaultValue" : "ImPlotOrientation_Vertical"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Align axis padding over multiple plots in a single row or column. If this function returns true, EndAlignedPlots() must be called. #group_id must be unique."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3048,15 +3094,6 @@
       "name" : "DragLineX",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
         "qualType" : "const char *",
@@ -3084,21 +3121,21 @@
         "qualType" : "float",
         "desugaredQualType" : "float",
         "defaultValue" : "1"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DragLineY",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
         "qualType" : "const char *",
@@ -3126,21 +3163,21 @@
         "qualType" : "float",
         "desugaredQualType" : "float",
         "defaultValue" : "1"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "DragPoint",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Shows a draggable point at x,y. #col defaults to ImGuiCol_Text."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "id",
         "qualType" : "const char *",
@@ -3173,21 +3210,21 @@
         "qualType" : "float",
         "desugaredQualType" : "float",
         "defaultValue" : "4"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Shows a draggable point at x,y. #col defaults to ImGuiCol_Text."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetLegendLocation",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the location of the current plot's (or subplot's) legend."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "location",
         "qualType" : "ImPlotLocation",
@@ -3204,12 +3241,26 @@
         "qualType" : "bool",
         "desugaredQualType" : "bool",
         "defaultValue" : "false"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the location of the current plot's (or subplot's) legend."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetMousePosLocation",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "location",
+        "qualType" : "ImPlotLocation",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3218,17 +3269,17 @@
             "text" : " Set the location of the current plot's mouse position text (default = South|East)."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "location",
-        "qualType" : "ImPlotLocation",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "IsLegendEntryHovered",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3237,26 +3288,12 @@
             "text" : " Returns true if a plot item legend entry is hovered."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginLegendPopup",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Begin a popup for a legend entry."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label_id",
         "qualType" : "const char *",
@@ -3267,6 +3304,15 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "1"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Begin a popup for a legend entry."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3315,6 +3361,12 @@
       "name" : "BeginDragDropTargetY",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "axis",
+        "qualType" : "ImPlotYAxis",
+        "desugaredQualType" : "int",
+        "defaultValue" : "ImPlotYAxis_1"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3323,12 +3375,6 @@
             "text" : " Turns the current plot's Y-Axis into a drag and drop target. Don't forget to call EndDragDropTarget!"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "axis",
-        "qualType" : "ImPlotYAxis",
-        "desugaredQualType" : "int",
-        "defaultValue" : "ImPlotYAxis_1"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3363,6 +3409,18 @@
       "name" : "BeginDragDropSource",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "key_mods",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "="
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "flags",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3371,7 +3429,12 @@
             "text" : " Turns the current plot's plotting area into a drag and drop source. Don't forget to call EndDragDropSource!"
           } ]
         } ]
-      }, {
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "BeginDragDropSourceX",
+      "resultType" : "bool",
+      "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "key_mods",
         "qualType" : "int",
@@ -3383,12 +3446,7 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "BeginDragDropSourceX",
-      "resultType" : "bool",
-      "decls" : [ {
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3397,33 +3455,12 @@
             "text" : " Turns the current plot's X-axis into a drag and drop source. Don't forget to call EndDragDropSource!"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "key_mods",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "="
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginDragDropSourceY",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Turns the current plot's Y-axis into a drag and drop source. Don't forget to call EndDragDropSource!"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "axis",
         "qualType" : "ImPlotYAxis",
@@ -3441,21 +3478,21 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Turns the current plot's Y-axis into a drag and drop source. Don't forget to call EndDragDropSource!"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginDragDropSourceItem",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Turns an item in the current plot's legend into drag and drop source. Don't forget to call EndDragDropSource!"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label_id",
         "qualType" : "const char *",
@@ -3466,6 +3503,15 @@
         "qualType" : "int",
         "desugaredQualType" : "int",
         "defaultValue" : "0"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Turns an item in the current plot's legend into drag and drop source. Don't forget to call EndDragDropSource!"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3500,6 +3546,12 @@
       "name" : "StyleColorsAuto",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImPlotStyle *",
+        "desugaredQualType" : "ImPlotStyle *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3508,18 +3560,18 @@
             "text" : " Style plot colors for current ImGui style (default)."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "dst",
-        "qualType" : "ImPlotStyle *",
-        "desugaredQualType" : "ImPlotStyle *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "StyleColorsClassic",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImPlotStyle *",
+        "desugaredQualType" : "ImPlotStyle *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3528,18 +3580,18 @@
             "text" : " Style plot colors for ImGui \"Classic\"."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "dst",
-        "qualType" : "ImPlotStyle *",
-        "desugaredQualType" : "ImPlotStyle *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "StyleColorsDark",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImPlotStyle *",
+        "desugaredQualType" : "ImPlotStyle *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3548,18 +3600,18 @@
             "text" : " Style plot colors for ImGui \"Dark\"."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "dst",
-        "qualType" : "ImPlotStyle *",
-        "desugaredQualType" : "ImPlotStyle *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "StyleColorsLight",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dst",
+        "qualType" : "ImPlotStyle *",
+        "desugaredQualType" : "ImPlotStyle *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3568,27 +3620,12 @@
             "text" : " Style plot colors for ImGui \"Light\"."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "dst",
-        "qualType" : "ImPlotStyle *",
-        "desugaredQualType" : "ImPlotStyle *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushStyleColor",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Temporarily modify a style color. Don't forget to call PopStyleColor!"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "idx",
         "qualType" : "ImPlotCol",
@@ -3598,6 +3635,15 @@
         "name" : "col",
         "qualType" : "int",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Temporarily modify a style color. Don't forget to call PopStyleColor!"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3619,6 +3665,12 @@
       "name" : "PopStyleColor",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "1"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3627,27 +3679,12 @@
             "text" : " Undo temporary style color modification(s). Undo multiple pushes at once by increasing count."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "count",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "1"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushStyleVar",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Temporarily modify a style variable of float type. Don't forget to call PopStyleVar!"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "idx",
         "qualType" : "ImPlotStyleVar",
@@ -3657,21 +3694,21 @@
         "name" : "val",
         "qualType" : "float",
         "desugaredQualType" : "float"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Temporarily modify a style variable of float type. Don't forget to call PopStyleVar!"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushStyleVar",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Temporarily modify a style variable of int type. Don't forget to call PopStyleVar!"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "idx",
         "qualType" : "ImPlotStyleVar",
@@ -3681,21 +3718,21 @@
         "name" : "val",
         "qualType" : "int",
         "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Temporarily modify a style variable of int type. Don't forget to call PopStyleVar!"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushStyleVar",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Temporarily modify a style variable of ImVec2 type. Don't forget to call PopStyleVar!"
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "idx",
         "qualType" : "ImPlotStyleVar",
@@ -3705,12 +3742,27 @@
         "name" : "val",
         "qualType" : "const int &",
         "desugaredQualType" : "const int &"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Temporarily modify a style variable of ImVec2 type. Don't forget to call PopStyleVar!"
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PopStyleVar",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "1"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3719,27 +3771,12 @@
             "text" : " Undo temporary style variable modification(s). Undo multiple pushes at once by increasing count."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "count",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "1"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextLineStyle",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the line color and weight for the next item only."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
         "qualType" : "const int &",
@@ -3751,21 +3788,21 @@
         "qualType" : "float",
         "desugaredQualType" : "float",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the line color and weight for the next item only."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextFillStyle",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the fill color for the next item only."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
         "qualType" : "const int &",
@@ -3777,21 +3814,21 @@
         "qualType" : "float",
         "desugaredQualType" : "float",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the fill color for the next item only."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextMarkerStyle",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the marker style for the next item only."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "marker",
         "qualType" : "ImPlotMarker",
@@ -3821,21 +3858,21 @@
         "qualType" : "const int &",
         "desugaredQualType" : "const int &",
         "defaultValue" : "IMPLOT_AUTO_COL"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the marker style for the next item only."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetNextErrorBarStyle",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the error bar style for the next item only."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "col",
         "qualType" : "const int &",
@@ -3853,6 +3890,15 @@
         "qualType" : "float",
         "desugaredQualType" : "float",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set the error bar style for the next item only."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3873,6 +3919,11 @@
       "name" : "GetStyleColorName",
       "resultType" : "const char *",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImPlotCol",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3881,17 +3932,17 @@
             "text" : " Returns the null terminated string name for an ImPlotCol."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "idx",
-        "qualType" : "ImPlotCol",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetMarkerName",
       "resultType" : "const char *",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "idx",
+        "qualType" : "ImPlotMarker",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -3900,38 +3951,12 @@
             "text" : " Returns the null terminated string name for an ImPlotMarker."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "idx",
-        "qualType" : "ImPlotMarker",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "AddColormap",
       "resultType" : "ImPlotColormap",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Add a new colormap. The color data will be copied. The colormap can be used by pushing either the returned index or the"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " string name with PushColormap. The colormap name must be unique and the size must be greater than 1. You will receive"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " an assert otherwise! By default colormaps are considered to be qualitative (i.e. discrete). If you want to create a"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " continuous colormap, set #qual=false. This will treat the colors you provide as keys, and ImPlot will build a linearly"
-          }, {
-            "@type" : "AstTextComment",
-            "text" : " interpolated lookup table. The memory footprint of this table will be exactly ((size-1)*255+1)*4 bytes."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "name",
         "qualType" : "const char *",
@@ -3952,6 +3977,27 @@
         "qualType" : "bool",
         "desugaredQualType" : "bool",
         "defaultValue" : "true"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Add a new colormap. The color data will be copied. The colormap can be used by pushing either the returned index or the"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " string name with PushColormap. The colormap name must be unique and the size must be greater than 1. You will receive"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " an assert otherwise! By default colormaps are considered to be qualitative (i.e. discrete). If you want to create a"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " continuous colormap, set #qual=false. This will treat the colors you provide as keys, and ImPlot will build a linearly"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " interpolated lookup table. The memory footprint of this table will be exactly ((size-1)*255+1)*4 bytes."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3998,6 +4044,11 @@
       "name" : "GetColormapName",
       "resultType" : "const char *",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "cmap",
+        "qualType" : "ImPlotColormap",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4006,17 +4057,17 @@
             "text" : " Returns a null terminated string name for a colormap given an index. Returns NULL if index is invalid."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "cmap",
-        "qualType" : "ImPlotColormap",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetColormapIndex",
       "resultType" : "ImPlotColormap",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4025,17 +4076,17 @@
             "text" : " Returns an index number for a colormap given a valid string name. Returns -1 if name is invalid."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "name",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushColormap",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "cmap",
+        "qualType" : "ImPlotColormap",
+        "desugaredQualType" : "int"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4044,17 +4095,17 @@
             "text" : " Temporarily switch to one of the built-in (i.e. ImPlotColormap_XXX) or user-added colormaps (i.e. a return value of AddColormap). Don't forget to call PopColormap!"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "cmap",
-        "qualType" : "ImPlotColormap",
-        "desugaredQualType" : "int"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PushColormap",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "name",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4063,17 +4114,18 @@
             "text" : " Push a colormap by string name. Use built-in names such as \"Default\", \"Deep\", \"Jet\", etc. or a string you provided to AddColormap. Don't forget to call PopColormap!"
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "name",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "PopColormap",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "count",
+        "qualType" : "int",
+        "desugaredQualType" : "int",
+        "defaultValue" : "1"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4082,12 +4134,6 @@
             "text" : " Undo temporary colormap modification(s). Undo multiple pushes at once by increasing count."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "count",
-        "qualType" : "int",
-        "desugaredQualType" : "int",
-        "defaultValue" : "1"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4111,6 +4157,12 @@
       "name" : "GetColormapSize",
       "resultType" : "int",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "cmap",
+        "qualType" : "ImPlotColormap",
+        "desugaredQualType" : "int",
+        "defaultValue" : "IMPLOT_AUTO"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4119,27 +4171,12 @@
             "text" : " Returns the size of a colormap."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "cmap",
-        "qualType" : "ImPlotColormap",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_AUTO"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetColormapColor",
       "resultType" : "int",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Returns a color from a colormap given an index >= 0 (modulo will be performed)."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "idx",
         "qualType" : "int",
@@ -4150,21 +4187,21 @@
         "qualType" : "ImPlotColormap",
         "desugaredQualType" : "int",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Returns a color from a colormap given an index >= 0 (modulo will be performed)."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SampleColormap",
       "resultType" : "int",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Sample a color from the current colormap given t between 0 and 1."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "t",
         "qualType" : "float",
@@ -4175,21 +4212,21 @@
         "qualType" : "ImPlotColormap",
         "desugaredQualType" : "int",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Sample a color from the current colormap given t between 0 and 1."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ColormapScale",
       "resultType" : "void",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Shows a vertical color scale with linear spaced ticks using the specified color map. Use double hashes to hide label (e.g. \"##NoLabel\")."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -4222,21 +4259,21 @@
         "qualType" : "const char *",
         "desugaredQualType" : "const char *",
         "defaultValue" : "\"%g\""
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Shows a vertical color scale with linear spaced ticks using the specified color map. Use double hashes to hide label (e.g. \"##NoLabel\")."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ColormapSlider",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Shows a horizontal slider with a colormap gradient background. Optionally returns the color sampled at t in [0 1]."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -4264,21 +4301,21 @@
         "qualType" : "ImPlotColormap",
         "desugaredQualType" : "int",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Shows a horizontal slider with a colormap gradient background. Optionally returns the color sampled at t in [0 1]."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ColormapButton",
       "resultType" : "bool",
       "decls" : [ {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Shows a button with a colormap gradient brackground."
-          } ]
-        } ]
-      }, {
         "@type" : "AstParmVarDecl",
         "name" : "label",
         "qualType" : "const char *",
@@ -4295,12 +4332,27 @@
         "qualType" : "ImPlotColormap",
         "desugaredQualType" : "int",
         "defaultValue" : "IMPLOT_AUTO"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Shows a button with a colormap gradient brackground."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BustColorCache",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "plot_title_id",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4327,18 +4379,17 @@
             "text" : " need this function, but it is available for applications that require runtime colormap swaps (e.g. Heatmaps demo)."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "plot_title_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ItemIcon",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "col",
+        "qualType" : "const int &",
+        "desugaredQualType" : "const int &"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4347,11 +4398,6 @@
             "text" : " Render icons similar to those that appear in legends (nifty for data lists)."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "col",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4392,6 +4438,12 @@
       "name" : "PushPlotClipRect",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "expand",
+        "qualType" : "float",
+        "desugaredQualType" : "float",
+        "defaultValue" : "0"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4400,12 +4452,6 @@
             "text" : " Push clip rect for rendering to current plot area. The rect can be expanded or contracted by #expand pixels. Call between Begin/EndPlot."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "expand",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "0"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4426,6 +4472,11 @@
       "name" : "ShowStyleSelector",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4434,17 +4485,17 @@
             "text" : " Shows ImPlot style selector dropdown menu."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ShowColormapSelector",
       "resultType" : "bool",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "label",
+        "qualType" : "const char *",
+        "desugaredQualType" : "const char *"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4453,17 +4504,18 @@
             "text" : " Shows ImPlot colormap selector dropdown menu."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ShowStyleEditor",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "ref",
+        "qualType" : "ImPlotStyle *",
+        "desugaredQualType" : "ImPlotStyle *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4472,12 +4524,6 @@
             "text" : " Shows ImPlot style editor block (not a window)."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "ref",
-        "qualType" : "ImPlotStyle *",
-        "desugaredQualType" : "ImPlotStyle *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -4498,6 +4544,12 @@
       "name" : "ShowMetricsWindow",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_popen",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4506,18 +4558,18 @@
             "text" : " Shows ImPlot metrics/debug information window."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "p_popen",
-        "qualType" : "bool *",
-        "desugaredQualType" : "bool *",
-        "defaultValue" : "="
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ShowDemoWindow",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "p_open",
+        "qualType" : "bool *",
+        "desugaredQualType" : "bool *",
+        "defaultValue" : "="
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
@@ -4526,12 +4578,6 @@
             "text" : " Shows the ImPlot demo window."
           } ]
         } ]
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "p_open",
-        "qualType" : "bool *",
-        "desugaredQualType" : "bool *",
-        "defaultValue" : "="
       } ]
     } ]
   } ]

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeFlags.java
@@ -158,19 +158,25 @@ public final class ImGuiDockNodeFlags {
      */
     public static final int SharedFlagsInheritMask_ = -1;
 
-    public static final int NoResizeFlagsMask_ = 15;
+    /**
+     * Definition: {@code ImGuiDockNodeFlags_NoResize | ImGuiDockNodeFlags_NoResizeX | ImGuiDockNodeFlags_NoResizeY}
+     */
+    public static final int NoResizeFlagsMask_ = 12582944;
 
-    public static final int LocalFlagsMask_ = 16;
+    /**
+     * Definition: {@code ImGuiDockNodeFlags_NoSplit | ImGuiDockNodeFlags_NoResizeFlagsMask_ | ImGuiDockNodeFlags_AutoHideTabBar | ImGuiDockNodeFlags_DockSpace | ImGuiDockNodeFlags_CentralNode | ImGuiDockNodeFlags_NoTabBar | ImGuiDockNodeFlags_HiddenTabBar | ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_NoCloseButton | ImGuiDockNodeFlags_NoDocking}
+     */
+    public static final int LocalFlagsMask_ = 12713072;
 
     /**
      * When splitting those flags are moved to the inheriting child, never duplicated
      *
      * <p>Definition: {@code ImGuiDockNodeFlags_LocalFlagsMask_ {@code &} ~ImGuiDockNodeFlags_DockSpace}
      */
-    public static final int LocalFlagsTransferMask_ = 1;
+    public static final int LocalFlagsTransferMask_ = 12712048;
 
     /**
      * Definition: {@code ImGuiDockNodeFlags_NoResizeFlagsMask_ | ImGuiDockNodeFlags_DockSpace | ImGuiDockNodeFlags_CentralNode | ImGuiDockNodeFlags_NoTabBar | ImGuiDockNodeFlags_HiddenTabBar | ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_NoCloseButton | ImGuiDockNodeFlags_NoDocking}
      */
-    public static final int SavedFlagsMask_ = 130048;
+    public static final int SavedFlagsMask_ = 12712992;
 }


### PR DESCRIPTION
# Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->

Found the problem, that `ImGuiDockNodeFlags` had invalid flags values.
The reason for that was that it referenced to the value, which was defined in `imgui.h` header.

## Type of change

<!-- 
Please check options that are relevant.
-->

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
