### PR TITLE
Add missing ImGui.TableGetSortSpecs API (and related objects)

### DIFF
--- a/imgui-binding/src/generated/java/imgui/ImGui.java
+++ b/imgui-binding/src/generated/java/imgui/ImGui.java
@@ -8351,6 +8351,17 @@ public class ImGui {
         return _result;
     */
 
+    public static boolean treeNodeEx(final String label, final int imGuiTreeNodeFlags) {
+        return nTreeNodeEx(label, imGuiTreeNodeFlags);
+    }
+
+    private static native boolean nTreeNodeEx(String obj_label, int imGuiTreeNodeFlags); /*MANUAL
+        auto label = obj_label == NULL ? NULL : (char*)env->GetStringUTFChars(obj_label, JNI_FALSE);
+        auto _result = ImGui::TreeNodeEx(label, imGuiTreeNodeFlags);
+        if (label != NULL) env->ReleaseStringUTFChars(obj_label, label);
+        return _result;
+    */
+
     public static boolean treeNodeEx(final String strId, final int imGuiTreeNodeFlags, final String label) {
         return nTreeNodeEx(strId, imGuiTreeNodeFlags, label);
     }
@@ -10110,7 +10121,13 @@ public class ImGui {
     //   wastefully sort your data every frame!
     // - Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable().
 
-    // TODO: TableGetSortSpecs()
+    public static ImGuiTableSortSpecs tableGetSortSpecs() {
+        return new ImGuiTableSortSpecs(nTableGetSortSpecs());
+    }
+
+    private static native long nTableGetSortSpecs(); /*
+        return (intptr_t)ImGui::TableGetSortSpecs();
+    */
 
     // Tables: Miscellaneous functions
     // - Functions args 'int column_n' treat the default value of -1 as the same as passing the current column index.

--- a/imgui-binding/src/generated/java/imgui/ImGuiTableColumnSortSpecs.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTableColumnSortSpecs.java
@@ -1,0 +1,66 @@
+package imgui;
+
+import imgui.binding.ImGuiStruct;
+
+/**
+ * Sorting specification for one column of a table.
+ */
+public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
+
+    public ImGuiTableColumnSortSpecs(final long ptr) {
+        super(ptr);
+    }
+
+    /*JNI
+        #include "_common.h"
+        #define THIS ((ImGuiTableColumnSortSpecs*)STRUCT_PTR)
+     */
+
+    /**
+     * User id of the column (if specified by a TableSetupColumn() call)
+     */
+    public int getColumnUserID() {
+        return nGetColumnUserID();
+    }
+
+    private native int nGetColumnUserID(); /*
+        return THIS->ColumnUserID;
+    */
+
+    /**
+     * Index of the column
+     */
+    public int getColumnIndex() {
+        return nGetColumnIndex();
+    }
+
+    private native int nGetColumnIndex(); /*
+        return THIS->ColumnIndex;
+    */
+
+    /**
+     * Index within parent ImGuiTableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
+     */
+    public int getSortOrder() {
+        return nGetSortOrder();
+    }
+
+    private native int nGetSortOrder(); /*
+        return THIS->SortOrder;
+    */
+
+    /**
+     * ImGuiSortDirection_Ascending or ImGuiSortDirection_Descending (you can use this or SortSign, whichever is more convenient for your sort function)
+     */
+    public int getSortDirection() {
+        return nGetSortDirection();
+    }
+
+    private native int nGetSortDirection(); /*
+        return THIS->SortDirection;
+    */
+
+    /*JNI
+        #undef THIS
+     */
+}

--- a/imgui-binding/src/generated/java/imgui/ImGuiTableSortSpecs.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTableSortSpecs.java
@@ -1,0 +1,83 @@
+package imgui;
+
+import imgui.binding.ImGuiStruct;
+
+/**
+ * Sorting specifications for a table (often handling sort specs for a single column, occasionally more)
+ * Obtained by calling TableGetSortSpecs().
+ * When 'SpecsDirty == true' you can sort your data. It will be true with sorting specs have changed since last call, or the first time.
+ * Make sure to set 'SpecsDirty = false' after sorting, else you may wastefully sort your data every frame!
+ */
+public final class ImGuiTableSortSpecs extends ImGuiStruct {
+
+    public ImGuiTableSortSpecs(final long ptr) {
+        super(ptr);
+    }
+
+    /*JNI
+        #include "_common.h"
+        #define THIS ((ImGuiTableSortSpecs*)STRUCT_PTR)
+     */
+
+    /**
+     * Pointer to sort spec array.
+     */
+    public ImGuiTableColumnSortSpecs[] getSpecs() {
+        long[] specsPointers = nGetSpecs();
+        ImGuiTableColumnSortSpecs[] specs = new ImGuiTableColumnSortSpecs[specsPointers.length];
+        for (int i = 0; i < specsPointers.length; i++) {
+            specs[i] = new ImGuiTableColumnSortSpecs(specsPointers[i]);
+        }
+        return specs;
+    }
+
+    private native long[] nGetSpecs(); /*
+        const ImGuiTableColumnSortSpecs* specs = THIS->Specs;
+        int specsCount = THIS->SpecsCount;
+        jlong jBuf[specsCount];
+        for (int i = 0; i < specsCount; i++) {
+            jBuf[i] = (intptr_t)specs;
+            specs++;
+        }
+        jlongArray result = env->NewLongArray(specsCount);
+        env->SetLongArrayRegion(result, 0, specsCount, jBuf);
+        return result;
+    */
+
+    /**
+     * Sort spec count. Most often 1. May be > 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
+     */
+    public int getSpecsCount() {
+        return nGetSpecsCount();
+    }
+
+    private native int nGetSpecsCount(); /*
+        return THIS->SpecsCount;
+    */
+
+    /**
+     * Set to true when specs have changed since last time! Use this to sort again, then clear the flag.
+     */
+    public boolean getSpecsDirty() {
+        return nGetSpecsDirty();
+    }
+
+    /**
+     * Set to true when specs have changed since last time! Use this to sort again, then clear the flag.
+     */
+    public void setSpecsDirty(final boolean value) {
+        nSetSpecsDirty(value);
+    }
+
+    private native boolean nGetSpecsDirty(); /*
+        return THIS->SpecsDirty;
+    */
+
+    private native void nSetSpecsDirty(boolean value); /*
+        THIS->SpecsDirty = value;
+    */
+
+    /*JNI
+        #undef THIS
+     */
+}

--- a/imgui-binding/src/generated/java/imgui/ImGuiTableSortSpecs.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTableSortSpecs.java
@@ -45,7 +45,7 @@ public final class ImGuiTableSortSpecs extends ImGuiStruct {
     */
 
     /**
-     * Sort spec count. Most often 1. May be > 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
+     * Sort spec count. Most often 1. May be {@code > } 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
      */
     public int getSpecsCount() {
         return nGetSpecsCount();

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -1931,7 +1931,8 @@ public class ImGui {
     //   wastefully sort your data every frame!
     // - Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable().
 
-    // TODO: TableGetSortSpecs()
+    @BindingMethod
+    public static native ImGuiTableSortSpecs TableGetSortSpecs();
 
     // Tables: Miscellaneous functions
     // - Functions args 'int column_n' treat the default value of -1 as the same as passing the current column index.

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -1563,6 +1563,9 @@ public class ImGui {
     public static native boolean TreeNode(@ArgValue(callPrefix = "(void*)") long ptrId, String label, Void NULL);
 
     @BindingMethod
+    public static native boolean TreeNodeEx(String label, int imGuiTreeNodeFlags);
+
+    @BindingMethod
     public static native boolean TreeNodeEx(String strId, int imGuiTreeNodeFlags, String label, Void NULL);
 
     @BindingMethod

--- a/imgui-binding/src/main/java/imgui/ImGuiTableColumnSortSpecs.java
+++ b/imgui-binding/src/main/java/imgui/ImGuiTableColumnSortSpecs.java
@@ -1,0 +1,50 @@
+package imgui;
+
+import imgui.binding.ImGuiStruct;
+import imgui.binding.annotation.BindingField;
+import imgui.binding.annotation.BindingField.Accessor;
+import imgui.binding.annotation.BindingSource;
+
+/**
+ * Sorting specification for one column of a table.
+ */
+@BindingSource
+public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
+
+    public ImGuiTableColumnSortSpecs(final long ptr) {
+        super(ptr);
+    }
+
+    /*JNI
+        #include "_common.h"
+        #define THIS ((ImGuiTableColumnSortSpecs*)STRUCT_PTR)
+     */
+
+    /**
+     * User id of the column (if specified by a TableSetupColumn() call)
+     */
+    @BindingField(accessors = { Accessor.GETTER })
+    public int ColumnUserID;
+
+    /**
+     * Index of the column
+     */
+    @BindingField(accessors = { Accessor.GETTER })
+    public int ColumnIndex;
+
+    /**
+     * Index within parent ImGuiTableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
+     */
+    @BindingField(accessors = { Accessor.GETTER })
+    public int SortOrder;
+
+    /**
+     * ImGuiSortDirection_Ascending or ImGuiSortDirection_Descending (you can use this or SortSign, whichever is more convenient for your sort function)
+     */
+    @BindingField(accessors = { Accessor.GETTER })
+    public int SortDirection;
+
+    /*JNI
+        #undef THIS
+     */
+}

--- a/imgui-binding/src/main/java/imgui/ImGuiTableSortSpecs.java
+++ b/imgui-binding/src/main/java/imgui/ImGuiTableSortSpecs.java
@@ -1,0 +1,66 @@
+package imgui;
+
+import imgui.binding.ImGuiStruct;
+import imgui.binding.annotation.BindingField;
+import imgui.binding.annotation.BindingField.Accessor;
+import imgui.binding.annotation.BindingSource;
+
+/**
+ * Sorting specifications for a table (often handling sort specs for a single column, occasionally more)
+ * Obtained by calling TableGetSortSpecs().
+ * When 'SpecsDirty == true' you can sort your data. It will be true with sorting specs have changed since last call, or the first time.
+ * Make sure to set 'SpecsDirty = false' after sorting, else you may wastefully sort your data every frame!
+ */
+@BindingSource
+public final class ImGuiTableSortSpecs extends ImGuiStruct {
+
+    public ImGuiTableSortSpecs(final long ptr) {
+        super(ptr);
+    }
+
+    /*JNI
+        #include "_common.h"
+        #define THIS ((ImGuiTableSortSpecs*)STRUCT_PTR)
+     */
+
+    /**
+     * Pointer to sort spec array.
+     */
+    public ImGuiTableColumnSortSpecs[] getSpecs() {
+        long[] specsPointers = nGetSpecs();
+        ImGuiTableColumnSortSpecs[] specs = new ImGuiTableColumnSortSpecs[specsPointers.length];
+        for (int i = 0; i < specsPointers.length; i++) {
+            specs[i] = new ImGuiTableColumnSortSpecs(specsPointers[i]);
+        }
+        return specs;
+    }
+
+    private native long[] nGetSpecs(); /*
+        const ImGuiTableColumnSortSpecs* specs = THIS->Specs;
+        int specsCount = THIS->SpecsCount;
+        jlong jBuf[specsCount];
+        for (int i = 0; i < specsCount; i++) {
+            jBuf[i] = (intptr_t)specs;
+            specs++;
+        }
+        jlongArray result = env->NewLongArray(specsCount);
+        env->SetLongArrayRegion(result, 0, specsCount, jBuf);
+        return result;
+    */
+
+    /**
+     * Sort spec count. Most often 1. May be > 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
+     */
+    @BindingField(accessors = { Accessor.GETTER })
+    public int SpecsCount;
+
+    /**
+     * Set to true when specs have changed since last time! Use this to sort again, then clear the flag.
+     */
+    @BindingField
+    public boolean SpecsDirty;
+
+    /*JNI
+        #undef THIS
+     */
+}

--- a/imgui-binding/src/main/java/imgui/ImGuiTableSortSpecs.java
+++ b/imgui-binding/src/main/java/imgui/ImGuiTableSortSpecs.java
@@ -49,7 +49,7 @@ public final class ImGuiTableSortSpecs extends ImGuiStruct {
     */
 
     /**
-     * Sort spec count. Most often 1. May be > 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
+     * Sort spec count. Most often 1. May be {@code > } 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
      */
     @BindingField(accessors = { Accessor.GETTER })
     public int SpecsCount;


### PR DESCRIPTION
# Description

This PR adds the missing binding for the `ImGui::TableGetSortSpecs` API, which includes structs to describe table and column sorting with `ImGuiTableSortSpecs` and `ImGuiTableColumnSortSpecs` respectively.

I had a workaround for the missing binding for a prior version which I posted about in #114, but with the recent release and seeing the binding generator being merged to main, I thought I'd try to understand the generator work and complete the API properly.  I still had to write some custom JNI code for `ImGuiTableSortSpecs.Specs` which holds a `ImGuiTableColumnSortSpecs` array as I couldn't find anything yet built to handle object arrays that weren't the `ImVec` types.  (Happy to be proven wrong on that point though!)

I also added a commit to add a binding for an `ImGui::TreeNodeEx` overload which seems to have gone missing with the generator work (maybe? 🤷‍♂️) and that I happen to be using in a project that I used to test these changes.

## Type of change

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
