### PR TITLE
ArgVariant annotation and plot methods with count parameter

### DIFF
--- a/buildSrc/src/main/kotlin/tool/generator/api/BindingSourceProcessor.kt
+++ b/buildSrc/src/main/kotlin/tool/generator/api/BindingSourceProcessor.kt
@@ -5,6 +5,7 @@ import spoon.reflect.declaration.CtElement
 import spoon.reflect.declaration.CtField
 import spoon.reflect.declaration.CtMethod
 import spoon.reflect.declaration.CtType
+import kotlin.math.max
 
 class BindingSourceProcessor(
     private val type: CtType<*>
@@ -101,7 +102,53 @@ class BindingSourceProcessor(
             contentToReplace[ReplacePos(it.position.sourceStart, it.position.sourceEnd + 6)] = ""
         }
 
-        val content = jvmMethodContent(method) + jniMethodContent(method)
+        val content = mutableListOf<String>()
+
+        // Handle argument variants
+        if (method.parameters.find { it.hasAnnotation(A_NAME_ARG_VARIANT) } != null) {
+            data class ArgVar(val idx: Int, val type: String, val name: String)
+
+            val variants = mutableListOf<ArgVar>()
+
+            method.parameters.forEachIndexed { idx, p ->
+                if (p.hasAnnotation(A_NAME_ARG_VARIANT)) {
+                    val a = p.getAnnotation(A_NAME_ARG_VARIANT)!!
+                    val types = (a.getValueAsObject(A_VALUE_TYPE) as Array<*>).map { it.toString() }
+                    val names = (a.getValueAsObject(A_VALUE_NAME) as Array<*>).map { it.toString() }
+
+                    if (types.isNotEmpty() && names.isNotEmpty() && types.size != names.size) {
+                        error("Types size should be the as names! Current: types=${types.size}, names=${names.size}")
+                    }
+
+                    for (i in 0 until max(types.size, names.size)) {
+                        variants += ArgVar(
+                            idx,
+                            types.getOrNull(i) ?: p.type.simpleName,
+                            names.getOrNull(i) ?: p.simpleName,
+                        )
+                    }
+                }
+            }
+
+            val variantsMap = variants.groupBy { it.idx }
+            val variantsCount = variantsMap.values.first().size
+
+            for (i in 0 until variantsCount) {
+                val m = method.clone()
+                m.setParent<Nothing>(method.parent)
+                variantsMap.values.forEach { vList ->
+                    val v = vList[i]
+                    val p = m.parameters[v.idx]
+                    p.setAnnotations<Nothing>(p.annotations.filterNot { it.name == A_NAME_ARG_VARIANT })
+                    p.setType<Nothing>(m.factory.createTypeParameterReference(v.type))
+                    p.setSimpleName<Nothing>(v.name)
+                }
+                content += jvmMethodContent(m) + jniMethodContent(m)
+            }
+        } else {
+            content += jvmMethodContent(method) + jniMethodContent(method)
+        }
+
         contentToReplace[method.findReplacePos()] = content.joinWithIndention()
         return contentToReplace
     }

--- a/buildSrc/src/main/kotlin/tool/generator/api/jni_content.kt
+++ b/buildSrc/src/main/kotlin/tool/generator/api/jni_content.kt
@@ -110,7 +110,7 @@ private fun convertParams2jni(f: Factory, params: List<CtParameter<*>>, defaults
             result += f.createParameter<Nothing>().apply {
                 val type = if (p.type.isPtrClass()) {
                     f.createTypeParam("long")
-                } else if (p.type.isClass) {
+                } else {
                     when (p.type.simpleName) {
                         "ImBoolean" -> f.createTypeParam("boolean[]")
                         "ImShort" -> f.createTypeParam("short[]")
@@ -120,8 +120,6 @@ private fun convertParams2jni(f: Factory, params: List<CtParameter<*>>, defaults
                         "ImDouble" -> f.createTypeParam("double[]")
                         else -> p.type
                     }
-                } else {
-                    p.type
                 }
 
                 setType<Nothing>(type)
@@ -138,7 +136,7 @@ private fun joinInBodyParams(params: List<CtParameter<*>>, defaults: IntArray): 
             "reinterpret_cast<${p.type.simpleName}*>(${p.simpleName})"
         } else if (p.isPrimitivePtrType()) {
             "&${p.simpleName}[0]"
-        } else if (p.type.isClass) {
+        } else {
             when (p.type.simpleName) {
                 "ImBoolean", "ImShort", "ImInt", "ImFloat", "ImLong", "ImDouble" -> {
                     "(${p.simpleName} != NULL ? &${p.simpleName}[0] : NULL)"
@@ -166,8 +164,6 @@ private fun joinInBodyParams(params: List<CtParameter<*>>, defaults: IntArray): 
 
                 else -> p.simpleName
             }
-        } else {
-            p.simpleName
         }
     }
 

--- a/buildSrc/src/main/kotlin/tool/generator/api/jvm_content.kt
+++ b/buildSrc/src/main/kotlin/tool/generator/api/jvm_content.kt
@@ -20,7 +20,7 @@ private fun joinInBodyParams(params: List<CtParameter<*>>, defaults: IntArray): 
     fun param2str(p: CtParameter<*>): String {
         return if (p.type.isPtrClass()) {
             "${p.simpleName}.$PTR_JVM_FIELD"
-        } else if (p.type.isClass) {
+        } else {
             when (p.type.simpleName) {
                 "ImBoolean", "ImShort", "ImInt", "ImFloat", "ImLong", "ImDouble" -> {
                     "${p.simpleName} != null ? ${p.simpleName}.getData() : null"
@@ -42,8 +42,6 @@ private fun joinInBodyParams(params: List<CtParameter<*>>, defaults: IntArray): 
 
                 else -> p.simpleName
             }
-        } else {
-            p.simpleName
         }
     }
 
@@ -147,7 +145,7 @@ private fun createMethod(origM: CtMethod<*>, params: List<CtParameter<*>>, defau
                 append(createBodyStaticStructReturn(origM, params, defaults))
             } else if (DST_RETURN_TYPE_SET.contains(origM.type.simpleName)) {
                 append(createBodyDstReturn(origM, params, defaults))
-            } else if (origM.type.isClass && !origM.type.isPrimitive && !origM.isType("void") && !origM.isType("String") && !origM.isPrimitivePtrType()) {
+            } else if (origM.type.isPtrClass()) {
                 append(createBodyStructReturn(origM, params, defaults))
             } else {
                 if (!origM.isType("void")) {

--- a/buildSrc/src/main/kotlin/tool/generator/api/util.kt
+++ b/buildSrc/src/main/kotlin/tool/generator/api/util.kt
@@ -19,6 +19,7 @@ const val A_NAME_OPT_ARG = "OptArg"
 const val A_NAME_EXCLUDED_SOURCE = "ExcludedSource"
 const val A_NAME_RETURN_VALUE = "ReturnValue"
 const val A_NAME_ARG_VALUE = "ArgValue"
+const val A_NAME_ARG_VARIANT = "ArgVariant"
 const val A_NAME_TYPE_ARRAY = "TypeArray"
 const val A_NAME_TYPE_STD_STRING = "TypeStdString"
 
@@ -56,6 +57,7 @@ val CLEANUP_ANNOTATIONS_LIST = listOf(
     A_NAME_RETURN_VALUE,
     A_NAME_OPT_ARG,
     A_NAME_ARG_VALUE,
+    A_NAME_ARG_VARIANT,
     A_NAME_TYPE_ARRAY,
     A_NAME_TYPE_STD_STRING,
     A_NAME_BINDING_AST_ENUM,

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
@@ -1503,28 +1503,11 @@ public final class ImPlot {
         nPlotLine(labelId, xs, ys);
     }
 
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final short[] xs, final short[] ys, final int offset) {
-        nPlotLine(labelId, xs, ys, offset);
-    }
-
     private static native void nPlotLine(String labelId, short[] xs, short[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, short[] xs, short[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1537,28 +1520,11 @@ public final class ImPlot {
         nPlotLine(labelId, xs, ys);
     }
 
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final int[] xs, final int[] ys, final int offset) {
-        nPlotLine(labelId, xs, ys, offset);
-    }
-
     private static native void nPlotLine(String labelId, int[] xs, int[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, int[] xs, int[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1571,28 +1537,11 @@ public final class ImPlot {
         nPlotLine(labelId, xs, ys);
     }
 
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final long[] xs, final long[] ys, final int offset) {
-        nPlotLine(labelId, xs, ys, offset);
-    }
-
     private static native void nPlotLine(String labelId, long[] xs, long[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, long[] xs, long[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1605,28 +1554,11 @@ public final class ImPlot {
         nPlotLine(labelId, xs, ys);
     }
 
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final float[] xs, final float[] ys, final int offset) {
-        nPlotLine(labelId, xs, ys, offset);
-    }
-
     private static native void nPlotLine(String labelId, float[] xs, float[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, float[] xs, float[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1639,13 +1571,6 @@ public final class ImPlot {
         nPlotLine(labelId, xs, ys);
     }
 
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final double[] xs, final double[] ys, final int offset) {
-        nPlotLine(labelId, xs, ys, offset);
-    }
-
     private static native void nPlotLine(String labelId, double[] xs, double[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
@@ -1656,15 +1581,12 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, double[] xs, double[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final short[] xs, final short[] ys, final int count) {
+        nPlotLine(labelId, xs, ys, count);
+    }
 
     /**
      * Plots a standard 2D line plot.
@@ -1672,6 +1594,16 @@ public final class ImPlot {
     public static void plotLine(final String labelId, final short[] xs, final short[] ys, final int count, final int offset) {
         nPlotLine(labelId, xs, ys, count, offset);
     }
+
+    private static native void nPlotLine(String labelId, short[] xs, short[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
 
     private static native void nPlotLine(String labelId, short[] xs, short[] ys, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
@@ -1686,9 +1618,26 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
+    public static void plotLine(final String labelId, final int[] xs, final int[] ys, final int count) {
+        nPlotLine(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
     public static void plotLine(final String labelId, final int[] xs, final int[] ys, final int count, final int offset) {
         nPlotLine(labelId, xs, ys, count, offset);
     }
+
+    private static native void nPlotLine(String labelId, int[] xs, int[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
 
     private static native void nPlotLine(String labelId, int[] xs, int[] ys, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
@@ -1703,9 +1652,26 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
+    public static void plotLine(final String labelId, final long[] xs, final long[] ys, final int count) {
+        nPlotLine(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
     public static void plotLine(final String labelId, final long[] xs, final long[] ys, final int count, final int offset) {
         nPlotLine(labelId, xs, ys, count, offset);
     }
+
+    private static native void nPlotLine(String labelId, long[] xs, long[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
 
     private static native void nPlotLine(String labelId, long[] xs, long[] ys, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
@@ -1720,9 +1686,26 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
+    public static void plotLine(final String labelId, final float[] xs, final float[] ys, final int count) {
+        nPlotLine(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
     public static void plotLine(final String labelId, final float[] xs, final float[] ys, final int count, final int offset) {
         nPlotLine(labelId, xs, ys, count, offset);
     }
+
+    private static native void nPlotLine(String labelId, float[] xs, float[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
 
     private static native void nPlotLine(String labelId, float[] xs, float[] ys, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
@@ -1737,9 +1720,26 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
+    public static void plotLine(final String labelId, final double[] xs, final double[] ys, final int count) {
+        nPlotLine(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
     public static void plotLine(final String labelId, final double[] xs, final double[] ys, final int count, final int offset) {
         nPlotLine(labelId, xs, ys, count, offset);
     }
+
+    private static native void nPlotLine(String labelId, double[] xs, double[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
 
     private static native void nPlotLine(String labelId, double[] xs, double[] ys, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
@@ -2053,6 +2053,306 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final short[] values, final int count) {
+        nPlotScatter(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final short[] values, final int count, final double xscale) {
+        nPlotScatter(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final short[] values, final int count, final double xscale, final double x0) {
+        nPlotScatter(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final short[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotScatter(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, short[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, short[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, short[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, short[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final int[] values, final int count) {
+        nPlotScatter(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final int[] values, final int count, final double xscale) {
+        nPlotScatter(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final int[] values, final int count, final double xscale, final double x0) {
+        nPlotScatter(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final int[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotScatter(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, int[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, int[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, int[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, int[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final long[] values, final int count) {
+        nPlotScatter(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final long[] values, final int count, final double xscale) {
+        nPlotScatter(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final long[] values, final int count, final double xscale, final double x0) {
+        nPlotScatter(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final long[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotScatter(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, long[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, long[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, long[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, long[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final float[] values, final int count) {
+        nPlotScatter(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final float[] values, final int count, final double xscale) {
+        nPlotScatter(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final float[] values, final int count, final double xscale, final double x0) {
+        nPlotScatter(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final float[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotScatter(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, float[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, float[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, float[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, float[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final double[] values, final int count) {
+        nPlotScatter(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final double[] values, final int count, final double xscale) {
+        nPlotScatter(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final double[] values, final int count, final double xscale, final double x0) {
+        nPlotScatter(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final double[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotScatter(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, double[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, double[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, double[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, double[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
     // xs,ys
 
     /**
@@ -2060,13 +2360,6 @@ public final class ImPlot {
      */
     public static void plotScatter(final String labelId, final short[] xs, final short[] ys) {
         nPlotScatter(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final short[] xs, final short[] ys, final int offset) {
-        nPlotScatter(labelId, xs, ys, offset);
     }
 
     private static native void nPlotScatter(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -2079,28 +2372,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, short[] xs, short[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final int[] xs, final int[] ys) {
         nPlotScatter(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final int[] xs, final int[] ys, final int offset) {
-        nPlotScatter(labelId, xs, ys, offset);
     }
 
     private static native void nPlotScatter(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -2113,28 +2389,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, int[] xs, int[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final long[] xs, final long[] ys) {
         nPlotScatter(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final long[] xs, final long[] ys, final int offset) {
-        nPlotScatter(labelId, xs, ys, offset);
     }
 
     private static native void nPlotScatter(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -2147,28 +2406,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, long[] xs, long[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final float[] xs, final float[] ys) {
         nPlotScatter(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final float[] xs, final float[] ys, final int offset) {
-        nPlotScatter(labelId, xs, ys, offset);
     }
 
     private static native void nPlotScatter(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -2181,28 +2423,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, float[] xs, float[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final double[] xs, final double[] ys) {
         nPlotScatter(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final double[] xs, final double[] ys, final int offset) {
-        nPlotScatter(labelId, xs, ys, offset);
     }
 
     private static native void nPlotScatter(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -2215,11 +2440,171 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, double[] xs, double[] ys, int offset); /*MANUAL
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final short[] xs, final short[] ys, final int count) {
+        nPlotScatter(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final short[] xs, final short[] ys, final int count, final int offset) {
+        nPlotScatter(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, short[] xs, short[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, short[] xs, short[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final int[] xs, final int[] ys, final int count) {
+        nPlotScatter(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final int[] xs, final int[] ys, final int count, final int offset) {
+        nPlotScatter(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, int[] xs, int[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, int[] xs, int[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final long[] xs, final long[] ys, final int count) {
+        nPlotScatter(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final long[] xs, final long[] ys, final int count, final int offset) {
+        nPlotScatter(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, long[] xs, long[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, long[] xs, long[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final float[] xs, final float[] ys, final int count) {
+        nPlotScatter(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final float[] xs, final float[] ys, final int count, final int offset) {
+        nPlotScatter(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, float[] xs, float[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, float[] xs, float[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final double[] xs, final double[] ys, final int count) {
+        nPlotScatter(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+     */
+    public static void plotScatter(final String labelId, final double[] xs, final double[] ys, final int count, final int offset) {
+        nPlotScatter(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotScatter(String labelId, double[] xs, double[] ys, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), offset);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotScatter(String labelId, double[] xs, double[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -2527,6 +2912,306 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final short[] values, final int count) {
+        nPlotStairs(labelId, values, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final short[] values, final int count, final double xscale) {
+        nPlotStairs(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final short[] values, final int count, final double xscale, final double x0) {
+        nPlotStairs(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final short[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotStairs(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, short[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, short[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, short[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, short[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final int[] values, final int count) {
+        nPlotStairs(labelId, values, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final int[] values, final int count, final double xscale) {
+        nPlotStairs(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final int[] values, final int count, final double xscale, final double x0) {
+        nPlotStairs(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final int[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotStairs(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, int[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, int[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, int[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, int[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final long[] values, final int count) {
+        nPlotStairs(labelId, values, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final long[] values, final int count, final double xscale) {
+        nPlotStairs(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final long[] values, final int count, final double xscale, final double x0) {
+        nPlotStairs(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final long[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotStairs(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, long[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, long[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, long[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, long[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final float[] values, final int count) {
+        nPlotStairs(labelId, values, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final float[] values, final int count, final double xscale) {
+        nPlotStairs(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final float[] values, final int count, final double xscale, final double x0) {
+        nPlotStairs(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final float[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotStairs(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, float[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, float[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, float[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, float[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final double[] values, final int count) {
+        nPlotStairs(labelId, values, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final double[] values, final int count, final double xscale) {
+        nPlotStairs(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final double[] values, final int count, final double xscale, final double x0) {
+        nPlotStairs(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final double[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotStairs(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, double[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, double[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, double[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, double[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
     // xs,ys
 
     /**
@@ -2534,13 +3219,6 @@ public final class ImPlot {
      */
     public static void plotStairs(final String labelId, final short[] xs, final short[] ys) {
         nPlotStairs(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final short[] xs, final short[] ys, final int offset) {
-        nPlotStairs(labelId, xs, ys, offset);
     }
 
     private static native void nPlotStairs(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -2553,28 +3231,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, short[] xs, short[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final int[] xs, final int[] ys) {
         nPlotStairs(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final int[] xs, final int[] ys, final int offset) {
-        nPlotStairs(labelId, xs, ys, offset);
     }
 
     private static native void nPlotStairs(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -2587,28 +3248,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, int[] xs, int[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final long[] xs, final long[] ys) {
         nPlotStairs(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final long[] xs, final long[] ys, final int offset) {
-        nPlotStairs(labelId, xs, ys, offset);
     }
 
     private static native void nPlotStairs(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -2621,28 +3265,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, long[] xs, long[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final float[] xs, final float[] ys) {
         nPlotStairs(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final float[] xs, final float[] ys, final int offset) {
-        nPlotStairs(labelId, xs, ys, offset);
     }
 
     private static native void nPlotStairs(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -2655,28 +3282,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, float[] xs, float[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final double[] xs, final double[] ys) {
         nPlotStairs(labelId, xs, ys);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final double[] xs, final double[] ys, final int offset) {
-        nPlotStairs(labelId, xs, ys, offset);
     }
 
     private static native void nPlotStairs(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -2689,11 +3299,171 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, double[] xs, double[] ys, int offset); /*MANUAL
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final short[] xs, final short[] ys, final int count) {
+        nPlotStairs(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final short[] xs, final short[] ys, final int count, final int offset) {
+        nPlotStairs(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, short[] xs, short[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, short[] xs, short[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final int[] xs, final int[] ys, final int count) {
+        nPlotStairs(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final int[] xs, final int[] ys, final int count, final int offset) {
+        nPlotStairs(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, int[] xs, int[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, int[] xs, int[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final long[] xs, final long[] ys, final int count) {
+        nPlotStairs(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final long[] xs, final long[] ys, final int count, final int offset) {
+        nPlotStairs(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, long[] xs, long[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, long[] xs, long[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final float[] xs, final float[] ys, final int count) {
+        nPlotStairs(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final float[] xs, final float[] ys, final int count, final int offset) {
+        nPlotStairs(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, float[] xs, float[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, float[] xs, float[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final double[] xs, final double[] ys, final int count) {
+        nPlotStairs(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
+     */
+    public static void plotStairs(final String labelId, final double[] xs, final double[] ys, final int count, final int offset) {
+        nPlotStairs(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotStairs(String labelId, double[] xs, double[] ys, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), offset);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStairs(String labelId, double[] xs, double[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -3076,6 +3846,381 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] values, final int count) {
+        nPlotShaded(labelId, values, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] values, final int count, final double yRef) {
+        nPlotShaded(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] values, final int count, final double yRef, final double xscale) {
+        nPlotShaded(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, short[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, short[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, short[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, short[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, short[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] values, final int count) {
+        nPlotShaded(labelId, values, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] values, final int count, final double yRef) {
+        nPlotShaded(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] values, final int count, final double yRef, final double xscale) {
+        nPlotShaded(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, int[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, int[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, int[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, int[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, int[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] values, final int count) {
+        nPlotShaded(labelId, values, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] values, final int count, final double yRef) {
+        nPlotShaded(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] values, final int count, final double yRef, final double xscale) {
+        nPlotShaded(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, long[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, long[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, long[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, long[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, long[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] values, final int count) {
+        nPlotShaded(labelId, values, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] values, final int count, final double yRef) {
+        nPlotShaded(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] values, final int count, final double yRef, final double xscale) {
+        nPlotShaded(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, float[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, float[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, float[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, float[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, float[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] values, final int count) {
+        nPlotShaded(labelId, values, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] values, final int count, final double yRef) {
+        nPlotShaded(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] values, final int count, final double yRef, final double xscale) {
+        nPlotShaded(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotShaded(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, double[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, double[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, double[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, double[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, double[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
     // xs,ys
 
     /**
@@ -3333,6 +4478,261 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] xs, final short[] ys, final int count) {
+        nPlotShaded(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef) {
+        nPlotShaded(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef, final int offset) {
+        nPlotShaded(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, short[] xs, short[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, short[] xs, short[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, short[] xs, short[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] xs, final int[] ys, final int count) {
+        nPlotShaded(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef) {
+        nPlotShaded(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef, final int offset) {
+        nPlotShaded(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, int[] xs, int[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, int[] xs, int[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, int[] xs, int[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] xs, final long[] ys, final int count) {
+        nPlotShaded(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef) {
+        nPlotShaded(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef, final int offset) {
+        nPlotShaded(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, long[] xs, long[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, long[] xs, long[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, long[] xs, long[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] xs, final float[] ys, final int count) {
+        nPlotShaded(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef) {
+        nPlotShaded(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef, final int offset) {
+        nPlotShaded(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, float[] xs, float[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, float[] xs, float[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, float[] xs, float[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] xs, final double[] ys, final int count) {
+        nPlotShaded(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef) {
+        nPlotShaded(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef, final int offset) {
+        nPlotShaded(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, double[] xs, double[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, double[] xs, double[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, double[] xs, double[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
     // xs,ys1,ys2
 
     /**
@@ -3340,13 +4740,6 @@ public final class ImPlot {
      */
     public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2) {
         nPlotShaded(labelId, xs, ys1, ys2);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int offset) {
-        nPlotShaded(labelId, xs, ys1, ys2, offset);
     }
 
     private static native void nPlotShaded(String labelId, short[] xs, short[] ys1, short[] ys2); /*MANUAL
@@ -3361,30 +4754,11 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, short[] xs, short[] ys1, short[] ys2, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final int[] xs, final int[] ys1, final int[] ys2) {
         nPlotShaded(labelId, xs, ys1, ys2);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final int[] xs, final int[] ys1, final int[] ys2, final int offset) {
-        nPlotShaded(labelId, xs, ys1, ys2, offset);
     }
 
     private static native void nPlotShaded(String labelId, int[] xs, int[] ys1, int[] ys2); /*MANUAL
@@ -3399,30 +4773,11 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, int[] xs, int[] ys1, int[] ys2, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final long[] xs, final long[] ys1, final long[] ys2) {
         nPlotShaded(labelId, xs, ys1, ys2);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final long[] xs, final long[] ys1, final long[] ys2, final int offset) {
-        nPlotShaded(labelId, xs, ys1, ys2, offset);
     }
 
     private static native void nPlotShaded(String labelId, long[] xs, long[] ys1, long[] ys2); /*MANUAL
@@ -3437,30 +4792,11 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, long[] xs, long[] ys1, long[] ys2, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final float[] xs, final float[] ys1, final float[] ys2) {
         nPlotShaded(labelId, xs, ys1, ys2);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final float[] xs, final float[] ys1, final float[] ys2, final int offset) {
-        nPlotShaded(labelId, xs, ys1, ys2, offset);
     }
 
     private static native void nPlotShaded(String labelId, float[] xs, float[] ys1, float[] ys2); /*MANUAL
@@ -3475,30 +4811,11 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, float[] xs, float[] ys1, float[] ys2, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final double[] xs, final double[] ys1, final double[] ys2) {
         nPlotShaded(labelId, xs, ys1, ys2);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final double[] xs, final double[] ys1, final double[] ys2, final int offset) {
-        nPlotShaded(labelId, xs, ys1, ys2, offset);
     }
 
     private static native void nPlotShaded(String labelId, double[] xs, double[] ys1, double[] ys2); /*MANUAL
@@ -3513,12 +4830,190 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, double[] xs, double[] ys1, double[] ys2, int offset); /*MANUAL
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int count) {
+        nPlotShaded(labelId, xs, ys1, ys2, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int count, final int offset) {
+        nPlotShaded(labelId, xs, ys1, ys2, count, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, short[] xs, short[] ys1, short[] ys2, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, short[] xs, short[] ys1, short[] ys2, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] xs, final int[] ys1, final int[] ys2, final int count) {
+        nPlotShaded(labelId, xs, ys1, ys2, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final int[] xs, final int[] ys1, final int[] ys2, final int count, final int offset) {
+        nPlotShaded(labelId, xs, ys1, ys2, count, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, int[] xs, int[] ys1, int[] ys2, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, int[] xs, int[] ys1, int[] ys2, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] xs, final long[] ys1, final long[] ys2, final int count) {
+        nPlotShaded(labelId, xs, ys1, ys2, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final long[] xs, final long[] ys1, final long[] ys2, final int count, final int offset) {
+        nPlotShaded(labelId, xs, ys1, ys2, count, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, long[] xs, long[] ys1, long[] ys2, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, long[] xs, long[] ys1, long[] ys2, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] xs, final float[] ys1, final float[] ys2, final int count) {
+        nPlotShaded(labelId, xs, ys1, ys2, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final float[] xs, final float[] ys1, final float[] ys2, final int count, final int offset) {
+        nPlotShaded(labelId, xs, ys1, ys2, count, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, float[] xs, float[] ys1, float[] ys2, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, float[] xs, float[] ys1, float[] ys2, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] xs, final double[] ys1, final double[] ys2, final int count) {
+        nPlotShaded(labelId, xs, ys1, ys2, count);
+    }
+
+    /**
+     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
+     */
+    public static void plotShaded(final String labelId, final double[] xs, final double[] ys1, final double[] ys2, final int count, final int offset) {
+        nPlotShaded(labelId, xs, ys1, ys2, count, offset);
+    }
+
+    private static native void nPlotShaded(String labelId, double[] xs, double[] ys1, double[] ys2, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
+        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
+    */
+
+    private static native void nPlotShaded(String labelId, double[] xs, double[] ys1, double[] ys2, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys1 = obj_ys1 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
+        auto ys2 = obj_ys2 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -3827,6 +5322,306 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final short[] values, final int count) {
+        nPlotBars(labelId, values, count);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final short[] values, final int count, final double width) {
+        nPlotBars(labelId, values, count, width);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final short[] values, final int count, final double width, final double shift) {
+        nPlotBars(labelId, values, count, width, shift);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final short[] values, final int count, final double width, final double shift, final int offset) {
+        nPlotBars(labelId, values, count, width, shift, offset);
+    }
+
+    private static native void nPlotBars(String labelId, short[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, short[] values, int count, double width); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, short[] values, int count, double width, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, short[] values, int count, double width, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final int[] values, final int count) {
+        nPlotBars(labelId, values, count);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final int[] values, final int count, final double width) {
+        nPlotBars(labelId, values, count, width);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final int[] values, final int count, final double width, final double shift) {
+        nPlotBars(labelId, values, count, width, shift);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final int[] values, final int count, final double width, final double shift, final int offset) {
+        nPlotBars(labelId, values, count, width, shift, offset);
+    }
+
+    private static native void nPlotBars(String labelId, int[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, int[] values, int count, double width); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, int[] values, int count, double width, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, int[] values, int count, double width, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final long[] values, final int count) {
+        nPlotBars(labelId, values, count);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final long[] values, final int count, final double width) {
+        nPlotBars(labelId, values, count, width);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final long[] values, final int count, final double width, final double shift) {
+        nPlotBars(labelId, values, count, width, shift);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final long[] values, final int count, final double width, final double shift, final int offset) {
+        nPlotBars(labelId, values, count, width, shift, offset);
+    }
+
+    private static native void nPlotBars(String labelId, long[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, long[] values, int count, double width); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, long[] values, int count, double width, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, long[] values, int count, double width, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final float[] values, final int count) {
+        nPlotBars(labelId, values, count);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final float[] values, final int count, final double width) {
+        nPlotBars(labelId, values, count, width);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final float[] values, final int count, final double width, final double shift) {
+        nPlotBars(labelId, values, count, width, shift);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final float[] values, final int count, final double width, final double shift, final int offset) {
+        nPlotBars(labelId, values, count, width, shift, offset);
+    }
+
+    private static native void nPlotBars(String labelId, float[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, float[] values, int count, double width); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, float[] values, int count, double width, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, float[] values, int count, double width, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final double[] values, final int count) {
+        nPlotBars(labelId, values, count);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final double[] values, final int count, final double width) {
+        nPlotBars(labelId, values, count, width);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final double[] values, final int count, final double width, final double shift) {
+        nPlotBars(labelId, values, count, width, shift);
+    }
+
+    /**
+     * Plots a vertical bar graph. #width and #shift are in X units.
+     */
+    public static void plotBars(final String labelId, final double[] values, final int count, final double width, final double shift, final int offset) {
+        nPlotBars(labelId, values, count, width, shift, offset);
+    }
+
+    private static native void nPlotBars(String labelId, double[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, double[] values, int count, double width); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, double[] values, int count, double width, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBars(String labelId, double[] values, int count, double width, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &values[0], count, width, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
     // xs,ys
 
     /**
@@ -3834,13 +5629,6 @@ public final class ImPlot {
      */
     public static void plotBars(final String labelId, final short[] xs, final short[] ys, final double width) {
         nPlotBars(labelId, xs, ys, width);
-    }
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    public static void plotBars(final String labelId, final short[] xs, final short[] ys, final double width, final int offset) {
-        nPlotBars(labelId, xs, ys, width, offset);
     }
 
     private static native void nPlotBars(String labelId, short[] xs, short[] ys, double width); /*MANUAL
@@ -3853,28 +5641,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, short[] xs, short[] ys, double width, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), width, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
     public static void plotBars(final String labelId, final int[] xs, final int[] ys, final double width) {
         nPlotBars(labelId, xs, ys, width);
-    }
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    public static void plotBars(final String labelId, final int[] xs, final int[] ys, final double width, final int offset) {
-        nPlotBars(labelId, xs, ys, width, offset);
     }
 
     private static native void nPlotBars(String labelId, int[] xs, int[] ys, double width); /*MANUAL
@@ -3887,28 +5658,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, int[] xs, int[] ys, double width, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), width, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
     public static void plotBars(final String labelId, final long[] xs, final long[] ys, final double width) {
         nPlotBars(labelId, xs, ys, width);
-    }
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    public static void plotBars(final String labelId, final long[] xs, final long[] ys, final double width, final int offset) {
-        nPlotBars(labelId, xs, ys, width, offset);
     }
 
     private static native void nPlotBars(String labelId, long[] xs, long[] ys, double width); /*MANUAL
@@ -3921,28 +5675,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, long[] xs, long[] ys, double width, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), width, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
     public static void plotBars(final String labelId, final float[] xs, final float[] ys, final double width) {
         nPlotBars(labelId, xs, ys, width);
-    }
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    public static void plotBars(final String labelId, final float[] xs, final float[] ys, final double width, final int offset) {
-        nPlotBars(labelId, xs, ys, width, offset);
     }
 
     private static native void nPlotBars(String labelId, float[] xs, float[] ys, double width); /*MANUAL
@@ -3955,28 +5692,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, float[] xs, float[] ys, double width, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), width, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
     public static void plotBars(final String labelId, final double[] xs, final double[] ys, final double width) {
         nPlotBars(labelId, xs, ys, width);
-    }
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    public static void plotBars(final String labelId, final double[] xs, final double[] ys, final double width, final int offset) {
-        nPlotBars(labelId, xs, ys, width, offset);
     }
 
     private static native void nPlotBars(String labelId, double[] xs, double[] ys, double width); /*MANUAL
@@ -3989,45 +5709,35 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, double[] xs, double[] ys, double width, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), width, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final short[] xs, final short[] ys) {
-        nPlotBars(labelId, xs, ys);
+    public static void plotBars(final String labelId, final short[] xs, final short[] ys, final int count, final double width) {
+        nPlotBars(labelId, xs, ys, count, width);
     }
 
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final short[] xs, final short[] ys, final int offset) {
-        nPlotBars(labelId, xs, ys, offset);
+    public static void plotBars(final String labelId, final short[] xs, final short[] ys, final int count, final double width, final int offset) {
+        nPlotBars(labelId, xs, ys, count, width, offset);
     }
 
-    private static native void nPlotBars(String labelId, short[] xs, short[] ys); /*MANUAL
+    private static native void nPlotBars(String labelId, short[] xs, short[] ys, int count, double width); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, short[] xs, short[] ys, int offset); /*MANUAL
+    private static native void nPlotBars(String labelId, short[] xs, short[] ys, int count, double width, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4036,32 +5746,32 @@ public final class ImPlot {
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final int[] xs, final int[] ys) {
-        nPlotBars(labelId, xs, ys);
+    public static void plotBars(final String labelId, final int[] xs, final int[] ys, final int count, final double width) {
+        nPlotBars(labelId, xs, ys, count, width);
     }
 
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final int[] xs, final int[] ys, final int offset) {
-        nPlotBars(labelId, xs, ys, offset);
+    public static void plotBars(final String labelId, final int[] xs, final int[] ys, final int count, final double width, final int offset) {
+        nPlotBars(labelId, xs, ys, count, width, offset);
     }
 
-    private static native void nPlotBars(String labelId, int[] xs, int[] ys); /*MANUAL
+    private static native void nPlotBars(String labelId, int[] xs, int[] ys, int count, double width); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, int[] xs, int[] ys, int offset); /*MANUAL
+    private static native void nPlotBars(String labelId, int[] xs, int[] ys, int count, double width, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4070,32 +5780,32 @@ public final class ImPlot {
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final long[] xs, final long[] ys) {
-        nPlotBars(labelId, xs, ys);
+    public static void plotBars(final String labelId, final long[] xs, final long[] ys, final int count, final double width) {
+        nPlotBars(labelId, xs, ys, count, width);
     }
 
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final long[] xs, final long[] ys, final int offset) {
-        nPlotBars(labelId, xs, ys, offset);
+    public static void plotBars(final String labelId, final long[] xs, final long[] ys, final int count, final double width, final int offset) {
+        nPlotBars(labelId, xs, ys, count, width, offset);
     }
 
-    private static native void nPlotBars(String labelId, long[] xs, long[] ys); /*MANUAL
+    private static native void nPlotBars(String labelId, long[] xs, long[] ys, int count, double width); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, long[] xs, long[] ys, int offset); /*MANUAL
+    private static native void nPlotBars(String labelId, long[] xs, long[] ys, int count, double width, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4104,32 +5814,32 @@ public final class ImPlot {
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final float[] xs, final float[] ys) {
-        nPlotBars(labelId, xs, ys);
+    public static void plotBars(final String labelId, final float[] xs, final float[] ys, final int count, final double width) {
+        nPlotBars(labelId, xs, ys, count, width);
     }
 
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final float[] xs, final float[] ys, final int offset) {
-        nPlotBars(labelId, xs, ys, offset);
+    public static void plotBars(final String labelId, final float[] xs, final float[] ys, final int count, final double width, final int offset) {
+        nPlotBars(labelId, xs, ys, count, width, offset);
     }
 
-    private static native void nPlotBars(String labelId, float[] xs, float[] ys); /*MANUAL
+    private static native void nPlotBars(String labelId, float[] xs, float[] ys, int count, double width); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, float[] xs, float[] ys, int offset); /*MANUAL
+    private static native void nPlotBars(String labelId, float[] xs, float[] ys, int count, double width, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4138,32 +5848,32 @@ public final class ImPlot {
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final double[] xs, final double[] ys) {
-        nPlotBars(labelId, xs, ys);
+    public static void plotBars(final String labelId, final double[] xs, final double[] ys, final int count, final double width) {
+        nPlotBars(labelId, xs, ys, count, width);
     }
 
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final double[] xs, final double[] ys, final int offset) {
-        nPlotBars(labelId, xs, ys, offset);
+    public static void plotBars(final String labelId, final double[] xs, final double[] ys, final int count, final double width, final int offset) {
+        nPlotBars(labelId, xs, ys, count, width, offset);
     }
 
-    private static native void nPlotBars(String labelId, double[] xs, double[] ys); /*MANUAL
+    private static native void nPlotBars(String labelId, double[] xs, double[] ys, int count, double width); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, double[] xs, double[] ys, int offset); /*MANUAL
+    private static native void nPlotBars(String labelId, double[] xs, double[] ys, int count, double width, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, width, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4471,6 +6181,306 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final short[] values, final int count) {
+        nPlotBarsH(labelId, values, count);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final short[] values, final int count, final double height) {
+        nPlotBarsH(labelId, values, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final short[] values, final int count, final double height, final double shift) {
+        nPlotBarsH(labelId, values, count, height, shift);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final short[] values, final int count, final double height, final double shift, final int offset) {
+        nPlotBarsH(labelId, values, count, height, shift, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, short[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, short[] values, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, short[] values, int count, double height, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, short[] values, int count, double height, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final int[] values, final int count) {
+        nPlotBarsH(labelId, values, count);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final int[] values, final int count, final double height) {
+        nPlotBarsH(labelId, values, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final int[] values, final int count, final double height, final double shift) {
+        nPlotBarsH(labelId, values, count, height, shift);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final int[] values, final int count, final double height, final double shift, final int offset) {
+        nPlotBarsH(labelId, values, count, height, shift, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, int[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, int[] values, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, int[] values, int count, double height, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, int[] values, int count, double height, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final long[] values, final int count) {
+        nPlotBarsH(labelId, values, count);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final long[] values, final int count, final double height) {
+        nPlotBarsH(labelId, values, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final long[] values, final int count, final double height, final double shift) {
+        nPlotBarsH(labelId, values, count, height, shift);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final long[] values, final int count, final double height, final double shift, final int offset) {
+        nPlotBarsH(labelId, values, count, height, shift, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, long[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, long[] values, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, long[] values, int count, double height, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, long[] values, int count, double height, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final float[] values, final int count) {
+        nPlotBarsH(labelId, values, count);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final float[] values, final int count, final double height) {
+        nPlotBarsH(labelId, values, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final float[] values, final int count, final double height, final double shift) {
+        nPlotBarsH(labelId, values, count, height, shift);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final float[] values, final int count, final double height, final double shift, final int offset) {
+        nPlotBarsH(labelId, values, count, height, shift, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, float[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, float[] values, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, float[] values, int count, double height, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, float[] values, int count, double height, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final double[] values, final int count) {
+        nPlotBarsH(labelId, values, count);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final double[] values, final int count, final double height) {
+        nPlotBarsH(labelId, values, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final double[] values, final int count, final double height, final double shift) {
+        nPlotBarsH(labelId, values, count, height, shift);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final double[] values, final int count, final double height, final double shift, final int offset) {
+        nPlotBarsH(labelId, values, count, height, shift, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, double[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, double[] values, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, double[] values, int count, double height, double shift); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, double[] values, int count, double height, double shift, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &values[0], count, height, shift, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
     // xs,ys
 
     /**
@@ -4478,13 +6488,6 @@ public final class ImPlot {
      */
     public static void plotBarsH(final String labelId, final short[] xs, final short[] ys, final double height) {
         nPlotBarsH(labelId, xs, ys, height);
-    }
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    public static void plotBarsH(final String labelId, final short[] xs, final short[] ys, final double height, final int offset) {
-        nPlotBarsH(labelId, xs, ys, height, offset);
     }
 
     private static native void nPlotBarsH(String labelId, short[] xs, short[] ys, double height); /*MANUAL
@@ -4497,28 +6500,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsH(String labelId, short[] xs, short[] ys, double height, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], LEN(xs), height, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     public static void plotBarsH(final String labelId, final int[] xs, final int[] ys, final double height) {
         nPlotBarsH(labelId, xs, ys, height);
-    }
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    public static void plotBarsH(final String labelId, final int[] xs, final int[] ys, final double height, final int offset) {
-        nPlotBarsH(labelId, xs, ys, height, offset);
     }
 
     private static native void nPlotBarsH(String labelId, int[] xs, int[] ys, double height); /*MANUAL
@@ -4531,28 +6517,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsH(String labelId, int[] xs, int[] ys, double height, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], LEN(xs), height, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     public static void plotBarsH(final String labelId, final long[] xs, final long[] ys, final double height) {
         nPlotBarsH(labelId, xs, ys, height);
-    }
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    public static void plotBarsH(final String labelId, final long[] xs, final long[] ys, final double height, final int offset) {
-        nPlotBarsH(labelId, xs, ys, height, offset);
     }
 
     private static native void nPlotBarsH(String labelId, long[] xs, long[] ys, double height); /*MANUAL
@@ -4565,28 +6534,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsH(String labelId, long[] xs, long[] ys, double height, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], LEN(xs), height, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     public static void plotBarsH(final String labelId, final float[] xs, final float[] ys, final double height) {
         nPlotBarsH(labelId, xs, ys, height);
-    }
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    public static void plotBarsH(final String labelId, final float[] xs, final float[] ys, final double height, final int offset) {
-        nPlotBarsH(labelId, xs, ys, height, offset);
     }
 
     private static native void nPlotBarsH(String labelId, float[] xs, float[] ys, double height); /*MANUAL
@@ -4599,28 +6551,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsH(String labelId, float[] xs, float[] ys, double height, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], LEN(xs), height, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     public static void plotBarsH(final String labelId, final double[] xs, final double[] ys, final double height) {
         nPlotBarsH(labelId, xs, ys, height);
-    }
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    public static void plotBarsH(final String labelId, final double[] xs, final double[] ys, final double height, final int offset) {
-        nPlotBarsH(labelId, xs, ys, height, offset);
     }
 
     private static native void nPlotBarsH(String labelId, double[] xs, double[] ys, double height); /*MANUAL
@@ -4633,11 +6568,171 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsH(String labelId, double[] xs, double[] ys, double height, int offset); /*MANUAL
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final short[] xs, final short[] ys, final int count, final double height) {
+        nPlotBarsH(labelId, xs, ys, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final short[] xs, final short[] ys, final int count, final double height, final int offset) {
+        nPlotBarsH(labelId, xs, ys, count, height, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, short[] xs, short[] ys, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, short[] xs, short[] ys, int count, double height, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final int[] xs, final int[] ys, final int count, final double height) {
+        nPlotBarsH(labelId, xs, ys, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final int[] xs, final int[] ys, final int count, final double height, final int offset) {
+        nPlotBarsH(labelId, xs, ys, count, height, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, int[] xs, int[] ys, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, int[] xs, int[] ys, int count, double height, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final long[] xs, final long[] ys, final int count, final double height) {
+        nPlotBarsH(labelId, xs, ys, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final long[] xs, final long[] ys, final int count, final double height, final int offset) {
+        nPlotBarsH(labelId, xs, ys, count, height, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, long[] xs, long[] ys, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, long[] xs, long[] ys, int count, double height, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final float[] xs, final float[] ys, final int count, final double height) {
+        nPlotBarsH(labelId, xs, ys, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final float[] xs, final float[] ys, final int count, final double height, final int offset) {
+        nPlotBarsH(labelId, xs, ys, count, height, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, float[] xs, float[] ys, int count, double height); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, float[] xs, float[] ys, int count, double height, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final double[] xs, final double[] ys, final int count, final double height) {
+        nPlotBarsH(labelId, xs, ys, count, height);
+    }
+
+    /**
+     * Plots a horizontal bar graph. #height and #shift are in Y units.
+     */
+    public static void plotBarsH(final String labelId, final double[] xs, final double[] ys, final int count, final double height, final int offset) {
+        nPlotBarsH(labelId, xs, ys, count, height, offset);
+    }
+
+    private static native void nPlotBarsH(String labelId, double[] xs, double[] ys, int count, double height); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], LEN(xs), height, offset);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsH(String labelId, double[] xs, double[] ys, int count, double height, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBarsH(labelId, &xs[0], &ys[0], count, height, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4820,13 +6915,6 @@ public final class ImPlot {
         nPlotErrorBars(labelId, xs, ys, err);
     }
 
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, offset);
-    }
-
     private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] err); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
@@ -4839,30 +6927,11 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] err, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] err) {
         nPlotErrorBars(labelId, xs, ys, err);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] err, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] err); /*MANUAL
@@ -4877,30 +6946,11 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] err, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] err) {
         nPlotErrorBars(labelId, xs, ys, err);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] err, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] err); /*MANUAL
@@ -4915,30 +6965,11 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] err, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] err) {
         nPlotErrorBars(labelId, xs, ys, err);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] err, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] err); /*MANUAL
@@ -4953,30 +6984,11 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] err, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] err) {
         nPlotErrorBars(labelId, xs, ys, err);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] err, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] err); /*MANUAL
@@ -4991,12 +7003,190 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] err, int offset); /*MANUAL
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count) {
+        nPlotErrorBars(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] err, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] err, final int count) {
+        nPlotErrorBars(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] err, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] err, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] err, final int count) {
+        nPlotErrorBars(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] err, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] err, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] err, final int count) {
+        nPlotErrorBars(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] err, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] err, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] err, final int count) {
+        nPlotErrorBars(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] err, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] err, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5008,13 +7198,6 @@ public final class ImPlot {
      */
     public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos) {
         nPlotErrorBars(labelId, xs, ys, neg, pos);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos); /*MANUAL
@@ -5031,32 +7214,11 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos) {
         nPlotErrorBars(labelId, xs, ys, neg, pos);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos); /*MANUAL
@@ -5073,32 +7235,11 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos) {
         nPlotErrorBars(labelId, xs, ys, neg, pos);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos); /*MANUAL
@@ -5115,32 +7256,11 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos) {
         nPlotErrorBars(labelId, xs, ys, neg, pos);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos); /*MANUAL
@@ -5157,32 +7277,11 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos) {
         nPlotErrorBars(labelId, xs, ys, neg, pos);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, offset);
     }
 
     private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos); /*MANUAL
@@ -5199,13 +7298,209 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int offset); /*MANUAL
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int count) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int count) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int count) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int count) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count);
+    }
+
+    /**
+     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int count, final int offset) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, count, offset);
+    }
+
+    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
+        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto neg = obj_neg == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
+        auto pos = obj_pos == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5220,13 +7515,6 @@ public final class ImPlot {
         nPlotErrorBarsH(labelId, xs, ys, err);
     }
 
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] err, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, err, offset);
-    }
-
     private static native void nPlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] err); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
@@ -5239,30 +7527,11 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] err, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsH(final String labelId, final int[] xs, final int[] ys, final int[] err) {
         nPlotErrorBarsH(labelId, xs, ys, err);
-    }
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsH(final String labelId, final int[] xs, final int[] ys, final int[] err, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, err, offset);
     }
 
     private static native void nPlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] err); /*MANUAL
@@ -5277,30 +7546,11 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] err, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsH(final String labelId, final long[] xs, final long[] ys, final long[] err) {
         nPlotErrorBarsH(labelId, xs, ys, err);
-    }
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsH(final String labelId, final long[] xs, final long[] ys, final long[] err, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, err, offset);
     }
 
     private static native void nPlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] err); /*MANUAL
@@ -5315,30 +7565,11 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] err, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsH(final String labelId, final float[] xs, final float[] ys, final float[] err) {
         nPlotErrorBarsH(labelId, xs, ys, err);
-    }
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsH(final String labelId, final float[] xs, final float[] ys, final float[] err, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, err, offset);
     }
 
     private static native void nPlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] err); /*MANUAL
@@ -5353,30 +7584,11 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] err, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsH(final String labelId, final double[] xs, final double[] ys, final double[] err) {
         nPlotErrorBarsH(labelId, xs, ys, err);
-    }
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsH(final String labelId, final double[] xs, final double[] ys, final double[] err, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, err, offset);
     }
 
     private static native void nPlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] err); /*MANUAL
@@ -5391,12 +7603,38 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] err, int offset); /*MANUAL
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] err, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], LEN(xs), offset);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5406,24 +7644,176 @@ public final class ImPlot {
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos);
+    public static void plotErrorBarsH(final String labelId, final int[] xs, final int[] ys, final int[] err, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count);
     }
 
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos, offset);
+    public static void plotErrorBarsH(final String labelId, final int[] xs, final int[] ys, final int[] err, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count, offset);
     }
 
-    private static native void nPlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] neg, short[] pos); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] err, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final long[] xs, final long[] ys, final long[] err, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final long[] xs, final long[] ys, final long[] err, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] err, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final float[] xs, final float[] ys, final float[] err, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final float[] xs, final float[] ys, final float[] err, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] err, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final double[] xs, final double[] ys, final double[] err, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count);
+    }
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final double[] xs, final double[] ys, final double[] err, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, err, count, offset);
+    }
+
+    private static native void nPlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] err, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    private static native void nPlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] err, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &err[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
+    */
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count);
+    }
+
+    /**
+     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
+     */
+    public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count, offset);
+    }
+
+    private static native void nPlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs));
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5431,13 +7821,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int offset); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5448,24 +7838,24 @@ public final class ImPlot {
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos);
+    public static void plotErrorBarsH(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count);
     }
 
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos, offset);
+    public static void plotErrorBarsH(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count, offset);
     }
 
-    private static native void nPlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] neg, int[] pos); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs));
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5473,13 +7863,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int offset); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5490,24 +7880,24 @@ public final class ImPlot {
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos);
+    public static void plotErrorBarsH(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count);
     }
 
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos, offset);
+    public static void plotErrorBarsH(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count, offset);
     }
 
-    private static native void nPlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] neg, long[] pos); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs));
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5515,13 +7905,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int offset); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5532,24 +7922,24 @@ public final class ImPlot {
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos);
+    public static void plotErrorBarsH(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count);
     }
 
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos, offset);
+    public static void plotErrorBarsH(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count, offset);
     }
 
-    private static native void nPlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] neg, float[] pos); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs));
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5557,13 +7947,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int offset); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5574,24 +7964,24 @@ public final class ImPlot {
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos);
+    public static void plotErrorBarsH(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int count) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count);
     }
 
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsH(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int offset) {
-        nPlotErrorBarsH(labelId, xs, ys, neg, pos, offset);
+    public static void plotErrorBarsH(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int count, final int offset) {
+        nPlotErrorBarsH(labelId, xs, ys, neg, pos, count, offset);
     }
 
-    private static native void nPlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] neg, double[] pos); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs));
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5599,13 +7989,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int offset); /*MANUAL
+    private static native void nPlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int count, int offset); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), offset);
+        ImPlot::PlotErrorBarsH(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5990,6 +8380,381 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final short[] values, final int count) {
+        nPlotStems(labelId, values, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final short[] values, final int count, final double yRef) {
+        nPlotStems(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final short[] values, final int count, final double yRef, final double xscale) {
+        nPlotStems(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final short[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final short[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotStems(String labelId, short[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, short[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, short[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, short[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, short[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final int[] values, final int count) {
+        nPlotStems(labelId, values, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final int[] values, final int count, final double yRef) {
+        nPlotStems(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final int[] values, final int count, final double yRef, final double xscale) {
+        nPlotStems(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final int[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final int[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotStems(String labelId, int[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, int[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, int[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, int[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, int[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final long[] values, final int count) {
+        nPlotStems(labelId, values, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final long[] values, final int count, final double yRef) {
+        nPlotStems(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final long[] values, final int count, final double yRef, final double xscale) {
+        nPlotStems(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final long[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final long[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotStems(String labelId, long[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, long[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, long[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, long[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, long[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final float[] values, final int count) {
+        nPlotStems(labelId, values, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final float[] values, final int count, final double yRef) {
+        nPlotStems(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final float[] values, final int count, final double yRef, final double xscale) {
+        nPlotStems(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final float[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final float[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotStems(String labelId, float[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, float[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, float[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, float[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, float[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final double[] values, final int count) {
+        nPlotStems(labelId, values, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final double[] values, final int count, final double yRef) {
+        nPlotStems(labelId, values, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final double[] values, final int count, final double yRef, final double xscale) {
+        nPlotStems(labelId, values, count, yRef, xscale);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final double[] values, final int count, final double yRef, final double xscale, final double x0) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final double[] values, final int count, final double yRef, final double xscale, final double x0, final int offset) {
+        nPlotStems(labelId, values, count, yRef, xscale, x0, offset);
+    }
+
+    private static native void nPlotStems(String labelId, double[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, double[] values, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, double[] values, int count, double yRef, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, double[] values, int count, double yRef, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, double[] values, int count, double yRef, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &values[0], count, yRef, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
     // xs,ys
 
     /**
@@ -6248,31 +9013,271 @@ public final class ImPlot {
     */
 
     /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final short[] xs, final short[] ys, final int count) {
+        nPlotStems(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef) {
+        nPlotStems(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef, final int offset) {
+        nPlotStems(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotStems(String labelId, short[] xs, short[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, short[] xs, short[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, short[] xs, short[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final int[] xs, final int[] ys, final int count) {
+        nPlotStems(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef) {
+        nPlotStems(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef, final int offset) {
+        nPlotStems(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotStems(String labelId, int[] xs, int[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, int[] xs, int[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, int[] xs, int[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final long[] xs, final long[] ys, final int count) {
+        nPlotStems(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef) {
+        nPlotStems(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef, final int offset) {
+        nPlotStems(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotStems(String labelId, long[] xs, long[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, long[] xs, long[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, long[] xs, long[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final float[] xs, final float[] ys, final int count) {
+        nPlotStems(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef) {
+        nPlotStems(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef, final int offset) {
+        nPlotStems(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotStems(String labelId, float[] xs, float[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, float[] xs, float[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, float[] xs, float[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final double[] xs, final double[] ys, final int count) {
+        nPlotStems(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef) {
+        nPlotStems(labelId, xs, ys, count, yRef);
+    }
+
+    /**
+     * Plots vertical stems.
+     */
+    public static void plotStems(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef, final int offset) {
+        nPlotStems(labelId, xs, ys, count, yRef, offset);
+    }
+
+    private static native void nPlotStems(String labelId, double[] xs, double[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, double[] xs, double[] ys, int count, double yRef); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotStems(String labelId, double[] xs, double[] ys, int count, double yRef, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     public static void plotVLines(final String labelId, final short[] xs) {
         nPlotVLines(labelId, xs);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotVLines(final String labelId, final short[] xs, final int offset) {
-        nPlotVLines(labelId, xs, offset);
-    }
-
     private static native void nPlotVLines(String labelId, short[] xs); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         ImPlot::PlotVLines(labelId, &xs[0], LEN(xs));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-    */
-
-    private static native void nPlotVLines(String labelId, short[] xs, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        ImPlot::PlotVLines(labelId, &xs[0], LEN(xs), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
     */
@@ -6284,25 +9289,10 @@ public final class ImPlot {
         nPlotVLines(labelId, xs);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotVLines(final String labelId, final int[] xs, final int offset) {
-        nPlotVLines(labelId, xs, offset);
-    }
-
     private static native void nPlotVLines(String labelId, int[] xs); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         ImPlot::PlotVLines(labelId, &xs[0], LEN(xs));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-    */
-
-    private static native void nPlotVLines(String labelId, int[] xs, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        ImPlot::PlotVLines(labelId, &xs[0], LEN(xs), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
     */
@@ -6314,25 +9304,10 @@ public final class ImPlot {
         nPlotVLines(labelId, xs);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotVLines(final String labelId, final long[] xs, final int offset) {
-        nPlotVLines(labelId, xs, offset);
-    }
-
     private static native void nPlotVLines(String labelId, long[] xs); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         ImPlot::PlotVLines(labelId, &xs[0], LEN(xs));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-    */
-
-    private static native void nPlotVLines(String labelId, long[] xs, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        ImPlot::PlotVLines(labelId, &xs[0], LEN(xs), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
     */
@@ -6344,25 +9319,10 @@ public final class ImPlot {
         nPlotVLines(labelId, xs);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotVLines(final String labelId, final float[] xs, final int offset) {
-        nPlotVLines(labelId, xs, offset);
-    }
-
     private static native void nPlotVLines(String labelId, float[] xs); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         ImPlot::PlotVLines(labelId, &xs[0], LEN(xs));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-    */
-
-    private static native void nPlotVLines(String labelId, float[] xs, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        ImPlot::PlotVLines(labelId, &xs[0], LEN(xs), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
     */
@@ -6374,13 +9334,6 @@ public final class ImPlot {
         nPlotVLines(labelId, xs);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotVLines(final String labelId, final double[] xs, final int offset) {
-        nPlotVLines(labelId, xs, offset);
-    }
-
     private static native void nPlotVLines(String labelId, double[] xs); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
@@ -6389,10 +9342,152 @@ public final class ImPlot {
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
     */
 
-    private static native void nPlotVLines(String labelId, double[] xs, int offset); /*MANUAL
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final short[] xs, final int count) {
+        nPlotVLines(labelId, xs, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final short[] xs, final int count, final int offset) {
+        nPlotVLines(labelId, xs, count, offset);
+    }
+
+    private static native void nPlotVLines(String labelId, short[] xs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    private static native void nPlotVLines(String labelId, short[] xs, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final int[] xs, final int count) {
+        nPlotVLines(labelId, xs, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final int[] xs, final int count, final int offset) {
+        nPlotVLines(labelId, xs, count, offset);
+    }
+
+    private static native void nPlotVLines(String labelId, int[] xs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    private static native void nPlotVLines(String labelId, int[] xs, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final long[] xs, final int count) {
+        nPlotVLines(labelId, xs, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final long[] xs, final int count, final int offset) {
+        nPlotVLines(labelId, xs, count, offset);
+    }
+
+    private static native void nPlotVLines(String labelId, long[] xs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    private static native void nPlotVLines(String labelId, long[] xs, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final float[] xs, final int count) {
+        nPlotVLines(labelId, xs, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final float[] xs, final int count, final int offset) {
+        nPlotVLines(labelId, xs, count, offset);
+    }
+
+    private static native void nPlotVLines(String labelId, float[] xs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    private static native void nPlotVLines(String labelId, float[] xs, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final double[] xs, final int count) {
+        nPlotVLines(labelId, xs, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotVLines(final String labelId, final double[] xs, final int count, final int offset) {
+        nPlotVLines(labelId, xs, count, offset);
+    }
+
+    private static native void nPlotVLines(String labelId, double[] xs, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        ImPlot::PlotVLines(labelId, &xs[0], LEN(xs), offset);
+        ImPlot::PlotVLines(labelId, &xs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+    */
+
+    private static native void nPlotVLines(String labelId, double[] xs, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        ImPlot::PlotVLines(labelId, &xs[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
     */
@@ -6404,25 +9499,10 @@ public final class ImPlot {
         nPlotHLines(labelId, ys);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotHLines(final String labelId, final short[] ys, final int offset) {
-        nPlotHLines(labelId, ys, offset);
-    }
-
     private static native void nPlotHLines(String labelId, short[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotHLines(labelId, &ys[0], LEN(ys));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotHLines(String labelId, short[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotHLines(labelId, &ys[0], LEN(ys), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
@@ -6434,25 +9514,10 @@ public final class ImPlot {
         nPlotHLines(labelId, ys);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotHLines(final String labelId, final int[] ys, final int offset) {
-        nPlotHLines(labelId, ys, offset);
-    }
-
     private static native void nPlotHLines(String labelId, int[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotHLines(labelId, &ys[0], LEN(ys));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotHLines(String labelId, int[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotHLines(labelId, &ys[0], LEN(ys), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
@@ -6464,25 +9529,10 @@ public final class ImPlot {
         nPlotHLines(labelId, ys);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotHLines(final String labelId, final long[] ys, final int offset) {
-        nPlotHLines(labelId, ys, offset);
-    }
-
     private static native void nPlotHLines(String labelId, long[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotHLines(labelId, &ys[0], LEN(ys));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotHLines(String labelId, long[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotHLines(labelId, &ys[0], LEN(ys), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
@@ -6494,25 +9544,10 @@ public final class ImPlot {
         nPlotHLines(labelId, ys);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotHLines(final String labelId, final float[] ys, final int offset) {
-        nPlotHLines(labelId, ys, offset);
-    }
-
     private static native void nPlotHLines(String labelId, float[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotHLines(labelId, &ys[0], LEN(ys));
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotHLines(String labelId, float[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotHLines(labelId, &ys[0], LEN(ys), offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
@@ -6524,13 +9559,6 @@ public final class ImPlot {
         nPlotHLines(labelId, ys);
     }
 
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotHLines(final String labelId, final double[] ys, final int offset) {
-        nPlotHLines(labelId, ys, offset);
-    }
-
     private static native void nPlotHLines(String labelId, double[] ys); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
@@ -6539,10 +9567,152 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotHLines(String labelId, double[] ys, int offset); /*MANUAL
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final short[] ys, final int count) {
+        nPlotHLines(labelId, ys, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final short[] ys, final int count, final int offset) {
+        nPlotHLines(labelId, ys, count, offset);
+    }
+
+    private static native void nPlotHLines(String labelId, short[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotHLines(String labelId, short[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final int[] ys, final int count) {
+        nPlotHLines(labelId, ys, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final int[] ys, final int count, final int offset) {
+        nPlotHLines(labelId, ys, count, offset);
+    }
+
+    private static native void nPlotHLines(String labelId, int[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotHLines(String labelId, int[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final long[] ys, final int count) {
+        nPlotHLines(labelId, ys, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final long[] ys, final int count, final int offset) {
+        nPlotHLines(labelId, ys, count, offset);
+    }
+
+    private static native void nPlotHLines(String labelId, long[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotHLines(String labelId, long[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final float[] ys, final int count) {
+        nPlotHLines(labelId, ys, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final float[] ys, final int count, final int offset) {
+        nPlotHLines(labelId, ys, count, offset);
+    }
+
+    private static native void nPlotHLines(String labelId, float[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotHLines(String labelId, float[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final double[] ys, final int count) {
+        nPlotHLines(labelId, ys, count);
+    }
+
+    /**
+     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+     */
+    public static void plotHLines(final String labelId, final double[] ys, final int count, final int offset) {
+        nPlotHLines(labelId, ys, count, offset);
+    }
+
+    private static native void nPlotHLines(String labelId, double[] ys, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotHLines(labelId, &ys[0], LEN(ys), offset);
+        ImPlot::PlotHLines(labelId, &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotHLines(String labelId, double[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotHLines(labelId, &ys[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
@@ -7375,6 +10545,841 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, normalize, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final boolean normalize) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, angle0);
+    }
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, boolean normalize); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, boolean normalize, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final boolean normalize) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, angle0);
+    }
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, boolean normalize); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, boolean normalize, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final boolean normalize) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, angle0);
+    }
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, boolean normalize); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, boolean normalize, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final boolean normalize) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, angle0);
+    }
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, boolean normalize); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, boolean normalize, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final boolean normalize) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, angle0);
+    }
+
+    /**
+     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+     */
+    public static void plotPieChart(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final boolean normalize, final double angle0) {
+        nPlotPieChart(labelIds, labelIds.length, values, count, x, y, radius, normalize, angle0);
+    }
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, boolean normalize); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, boolean normalize, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, String labelFmt, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, labelFmt, angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, false, "%.1f", angle0);
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            env->ReleaseStringUTFChars(str, labelIds[i]);
+        };
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, boolean normalize, double angle0); /*MANUAL
+        const char* labelIds[labelIdsCount];
+        for (int i = 0; i < labelIdsCount; i++) {
+            const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
+            auto rawStr = (char*)env->GetStringUTFChars(str, JNI_FALSE);
+            labelIds[i] = rawStr;
+        };
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, normalize, "%.1f", angle0);
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -9258,6 +13263,996 @@ public final class ImPlot {
     */
 
     /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins) {
+        return nPlotHistogram(labelId, values, count, bins);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final short[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, barScale);
+    }
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins, boolean cumulative); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins, boolean cumulative, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins, boolean cumulative, boolean density, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins, boolean cumulative, boolean density, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins) {
+        return nPlotHistogram(labelId, values, count, bins);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final int[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, barScale);
+    }
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins, boolean cumulative); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins, boolean cumulative, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins, boolean cumulative, boolean density, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins, boolean cumulative, boolean density, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins) {
+        return nPlotHistogram(labelId, values, count, bins);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final long[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, barScale);
+    }
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins, boolean cumulative); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins, boolean cumulative, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins, boolean cumulative, boolean density, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins, boolean cumulative, boolean density, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins) {
+        return nPlotHistogram(labelId, values, count, bins);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final float[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, barScale);
+    }
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins, boolean cumulative); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins, boolean cumulative, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins, boolean cumulative, boolean density, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins, boolean cumulative, boolean density, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins) {
+        return nPlotHistogram(labelId, values, count, bins);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final boolean outliers, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, outliers, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final ImPlotRange range, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, range.min, range.max, barScale);
+    }
+
+    /**
+     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
+     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
+     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram(final String labelId, final double[] values, final int count, final int bins, final boolean cumulative, final boolean density, final double rangeMin, final double rangeMax, final double barScale) {
+        return nPlotHistogram(labelId, values, count, bins, cumulative, density, rangeMin, rangeMax, barScale);
+    }
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins, boolean cumulative); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins, boolean cumulative, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins, boolean cumulative, boolean density, boolean outliers, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), outliers, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins, boolean cumulative, boolean density, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int count, int bins, boolean cumulative, boolean density, double rangeMin, double rangeMax, double barScale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, cumulative, density, ImPlotRange(rangeMin, rangeMax), true, barScale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        return _result;
+    */
+
+    /**
      * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
@@ -10193,17 +15188,745 @@ public final class ImPlot {
     */
 
     /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static void plotDigital(final String labelId, final short[] xs, final short[] ys) {
-        nPlotDigital(labelId, xs, ys);
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins);
     }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final boolean density) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final boolean density, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, outliers);
+    }
+
+    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, false, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, boolean density, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final boolean density) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final boolean density, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, outliers);
+    }
+
+    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, false, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, boolean density, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final boolean density) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final boolean density, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, outliers);
+    }
+
+    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, false, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, boolean density, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final boolean density) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final boolean density, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, outliers);
+    }
+
+    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, false, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, boolean density, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final boolean density) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final boolean density, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final boolean density, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, outliers);
+    }
+
+    /**
+     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
+     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
+     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
+     */
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final boolean density, final boolean outliers) {
+        return nPlotHistogram2D(labelId, xs, ys, count, xBins, yBins, density, outliers);
+    }
+
+    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, boolean density); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, boolean density, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, false, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
+
+    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, boolean density, boolean outliers); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, density, ImPlotRect(), outliers);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        return _result;
+    */
 
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigital(final String labelId, final short[] xs, final short[] ys, final int offset) {
-        nPlotDigital(labelId, xs, ys, offset);
+    public static void plotDigital(final String labelId, final short[] xs, final short[] ys) {
+        nPlotDigital(labelId, xs, ys);
     }
 
     private static native void nPlotDigital(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -10216,28 +15939,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, short[] xs, short[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     public static void plotDigital(final String labelId, final int[] xs, final int[] ys) {
         nPlotDigital(labelId, xs, ys);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final int[] xs, final int[] ys, final int offset) {
-        nPlotDigital(labelId, xs, ys, offset);
     }
 
     private static native void nPlotDigital(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -10250,28 +15956,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, int[] xs, int[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     public static void plotDigital(final String labelId, final long[] xs, final long[] ys) {
         nPlotDigital(labelId, xs, ys);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final long[] xs, final long[] ys, final int offset) {
-        nPlotDigital(labelId, xs, ys, offset);
     }
 
     private static native void nPlotDigital(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -10284,28 +15973,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, long[] xs, long[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     public static void plotDigital(final String labelId, final float[] xs, final float[] ys) {
         nPlotDigital(labelId, xs, ys);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final float[] xs, final float[] ys, final int offset) {
-        nPlotDigital(labelId, xs, ys, offset);
     }
 
     private static native void nPlotDigital(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -10318,28 +15990,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, float[] xs, float[] ys, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     public static void plotDigital(final String labelId, final double[] xs, final double[] ys) {
         nPlotDigital(labelId, xs, ys);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final double[] xs, final double[] ys, final int offset) {
-        nPlotDigital(labelId, xs, ys, offset);
     }
 
     private static native void nPlotDigital(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -10352,11 +16007,171 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, double[] xs, double[] ys, int offset); /*MANUAL
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final short[] xs, final short[] ys, final int count) {
+        nPlotDigital(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final short[] xs, final short[] ys, final int count, final int offset) {
+        nPlotDigital(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotDigital(String labelId, short[] xs, short[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotDigital(String labelId, short[] xs, short[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final int[] xs, final int[] ys, final int count) {
+        nPlotDigital(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final int[] xs, final int[] ys, final int count, final int offset) {
+        nPlotDigital(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotDigital(String labelId, int[] xs, int[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotDigital(String labelId, int[] xs, int[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final long[] xs, final long[] ys, final int count) {
+        nPlotDigital(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final long[] xs, final long[] ys, final int count, final int offset) {
+        nPlotDigital(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotDigital(String labelId, long[] xs, long[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotDigital(String labelId, long[] xs, long[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final float[] xs, final float[] ys, final int count) {
+        nPlotDigital(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final float[] xs, final float[] ys, final int count, final int offset) {
+        nPlotDigital(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotDigital(String labelId, float[] xs, float[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotDigital(String labelId, float[] xs, float[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final double[] xs, final double[] ys, final int count) {
+        nPlotDigital(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+     */
+    public static void plotDigital(final String labelId, final double[] xs, final double[] ys, final int count, final int offset) {
+        nPlotDigital(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotDigital(String labelId, double[] xs, double[] ys, int count); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotDigital(String labelId, double[] xs, double[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
@@ -1194,6 +1194,306 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final short[] values, final int count) {
+        nPlotLine(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final short[] values, final int count, final double xscale) {
+        nPlotLine(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final short[] values, final int count, final double xscale, final double x0) {
+        nPlotLine(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final short[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotLine(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotLine(String labelId, short[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, short[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, short[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, short[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final int[] values, final int count) {
+        nPlotLine(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final int[] values, final int count, final double xscale) {
+        nPlotLine(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final int[] values, final int count, final double xscale, final double x0) {
+        nPlotLine(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final int[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotLine(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotLine(String labelId, int[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, int[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, int[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, int[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final long[] values, final int count) {
+        nPlotLine(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final long[] values, final int count, final double xscale) {
+        nPlotLine(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final long[] values, final int count, final double xscale, final double x0) {
+        nPlotLine(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final long[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotLine(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotLine(String labelId, long[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, long[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, long[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, long[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final float[] values, final int count) {
+        nPlotLine(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final float[] values, final int count, final double xscale) {
+        nPlotLine(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final float[] values, final int count, final double xscale, final double x0) {
+        nPlotLine(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final float[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotLine(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotLine(String labelId, float[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, float[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, float[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, float[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final double[] values, final int count) {
+        nPlotLine(labelId, values, count);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final double[] values, final int count, final double xscale) {
+        nPlotLine(labelId, values, count, xscale);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final double[] values, final int count, final double xscale, final double x0) {
+        nPlotLine(labelId, values, count, xscale, x0);
+    }
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final double[] values, final int count, final double xscale, final double x0, final int offset) {
+        nPlotLine(labelId, values, count, xscale, x0, offset);
+    }
+
+    private static native void nPlotLine(String labelId, double[] values, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, double[] values, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, double[] values, int count, double xscale, double x0); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
+    private static native void nPlotLine(String labelId, double[] values, int count, double xscale, double x0, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, x0, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+    */
+
     // xs,ys
 
     /**
@@ -1361,6 +1661,91 @@ public final class ImPlot {
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final short[] xs, final short[] ys, final int count, final int offset) {
+        nPlotLine(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotLine(String labelId, short[] xs, short[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final int[] xs, final int[] ys, final int count, final int offset) {
+        nPlotLine(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotLine(String labelId, int[] xs, int[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final long[] xs, final long[] ys, final int count, final int offset) {
+        nPlotLine(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotLine(String labelId, long[] xs, long[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final float[] xs, final float[] ys, final int count, final int offset) {
+        nPlotLine(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotLine(String labelId, float[] xs, float[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, offset);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a standard 2D line plot.
+     */
+    public static void plotLine(final String labelId, final double[] xs, final double[] ys, final int count, final int offset) {
+        nPlotLine(labelId, xs, ys, count, offset);
+    }
+
+    private static native void nPlotLine(String labelId, double[] xs, double[] ys, int count, int offset); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, offset);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -2,6 +2,7 @@ package imgui;
 
 import imgui.assertion.ImAssertCallback;
 import imgui.binding.annotation.ArgValue;
+import imgui.binding.annotation.ArgVariant;
 import imgui.binding.annotation.BindingMethod;
 import imgui.binding.annotation.BindingSource;
 import imgui.binding.annotation.OptArg;
@@ -1493,34 +1494,23 @@ public class ImGui {
     public static native boolean InputDouble(String label, ImDouble v, @OptArg double step, @OptArg double stepFast, @OptArg(callValue = "\"%.6f\"") String format, @OptArg int imGuiInputTextFlags);
 
     @BindingMethod
-    public static native boolean InputScalar(String label, Void ImGuiDataType_S16, ImShort pData, @OptArg @ArgValue(callPrefix = "&") short pStep, @OptArg @ArgValue(callPrefix = "&") short pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
+    public static native boolean InputScalar(String label,
+                                             @ArgVariant(name = {"ImGuiDataType_S16", "ImGuiDataType_S32", "ImGuiDataType_S64", "ImGuiDataType_Float", "ImGuiDataType_Double"}) Void __,
+                                             @ArgVariant(type = {"ImShort", "ImInt", "ImLong", "ImFloat", "ImDouble"}) Void pData,
+                                             @ArgVariant(type = {"short", "int", "long", "float", "double"}) @OptArg @ArgValue(callPrefix = "&") Void pStep,
+                                             @ArgVariant(type = {"short", "int", "long", "float", "double"}) @OptArg @ArgValue(callPrefix = "&") Void pStepFast,
+                                             @OptArg String format,
+                                             @OptArg int imGuiSliderFlags);
 
     @BindingMethod
-    public static native boolean InputScalar(String label, Void ImGuiDataType_S32, ImInt pData, @OptArg @ArgValue(callPrefix = "&") int pStep, @OptArg @ArgValue(callPrefix = "&") int pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
-
-    @BindingMethod
-    public static native boolean InputScalar(String label, Void ImGuiDataType_S64, ImLong pData, @OptArg @ArgValue(callPrefix = "&") long pStep, @OptArg @ArgValue(callPrefix = "&") long pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
-
-    @BindingMethod
-    public static native boolean InputScalar(String label, Void ImGuiDataType_Float, ImFloat pData, @OptArg @ArgValue(callPrefix = "&") float pStep, @OptArg @ArgValue(callPrefix = "&") float pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
-
-    @BindingMethod
-    public static native boolean InputScalar(String label, Void ImGuiDataType_Double, ImDouble pData, @OptArg @ArgValue(callPrefix = "&") double pStep, @OptArg @ArgValue(callPrefix = "&") double pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
-
-    @BindingMethod
-    public static native boolean InputScalarN(String label, Void ImGuiDataType_S16, short[] pData, int components, @OptArg @ArgValue(callPrefix = "&") short pStep, @OptArg @ArgValue(callPrefix = "&") short pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
-
-    @BindingMethod
-    public static native boolean InputScalarN(String label, Void ImGuiDataType_S32, int[] pData, int components, @OptArg @ArgValue(callPrefix = "&") int pStep, @OptArg @ArgValue(callPrefix = "&") int pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
-
-    @BindingMethod
-    public static native boolean InputScalarN(String label, Void ImGuiDataType_S64, long[] pData, int components, @OptArg @ArgValue(callPrefix = "&") long pStep, @OptArg @ArgValue(callPrefix = "&") long pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
-
-    @BindingMethod
-    public static native boolean InputScalarN(String label, Void ImGuiDataType_Float, float[] pData, int components, @OptArg @ArgValue(callPrefix = "&") float pStep, @OptArg @ArgValue(callPrefix = "&") float pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
-
-    @BindingMethod
-    public static native boolean InputScalarN(String label, Void ImGuiDataType_Double, double[] pData, int components, @OptArg @ArgValue(callPrefix = "&") double pStep, @OptArg @ArgValue(callPrefix = "&") double pStepFast, @OptArg String format, @OptArg int imGuiSliderFlags);
+    public static native boolean InputScalarN(String label,
+                                              @ArgVariant(name = {"ImGuiDataType_S16", "ImGuiDataType_S32", "ImGuiDataType_S64", "ImGuiDataType_Float", "ImGuiDataType_Double"}) Void __,
+                                              @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void pData,
+                                              int components,
+                                              @ArgVariant(type = {"short", "int", "long", "float", "double"}) @OptArg @ArgValue(callPrefix = "&") Void pStep,
+                                              @ArgVariant(type = {"short", "int", "long", "float", "double"}) @OptArg @ArgValue(callPrefix = "&") Void pStepFast,
+                                              @OptArg String format,
+                                              @OptArg int imGuiSliderFlags);
 
     // Widgets: Color Editor/Picker (tip: the ColorEdit* functions have a little color square that can be left-clicked to open a picker, and right-clicked to open an option menu.)
     // - Note that in C++ a 'float v[X]' function argument is the _same_ as 'float* v', the array syntax is just a way to document the number of elements that are expected to be accessible.

--- a/imgui-binding/src/main/java/imgui/binding/annotation/ArgVariant.java
+++ b/imgui-binding/src/main/java/imgui/binding/annotation/ArgVariant.java
@@ -1,0 +1,27 @@
+package imgui.binding.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Provides a sort of pre-processing experience, to generate method with additional argument variants.
+ * Can generate methods with different arg type and different arg names.
+ * Intended to be used for methods with template arguments.
+ * {@link #type} and {@link #name()} arrays SHOULD have the same length.
+ */
+@ExcludedSource
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.SOURCE)
+public @interface ArgVariant {
+    /**
+     * Variant for the argument type.
+     */
+    String[] type() default {};
+
+    /**
+     * Variant for the argument name.
+     */
+    String[] name() default {};
+}

--- a/imgui-binding/src/main/java/imgui/extension/implot/ImPlot.java
+++ b/imgui-binding/src/main/java/imgui/extension/implot/ImPlot.java
@@ -4,6 +4,7 @@ import imgui.ImDrawList;
 import imgui.ImVec2;
 import imgui.ImVec4;
 import imgui.binding.annotation.ArgValue;
+import imgui.binding.annotation.ArgVariant;
 import imgui.binding.annotation.BindingMethod;
 import imgui.binding.annotation.BindingSource;
 import imgui.binding.annotation.OptArg;
@@ -374,31 +375,23 @@ public final class ImPlot {
      * Plots a standard 2D line plot.
      */
     @BindingMethod
-    public static native void PlotLine(String labelId, short[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotLine(String labelId,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                       @ArgValue(callValue = "LEN(values)") Void count,
+                                       @OptArg double xscale,
+                                       @OptArg double x0,
+                                       @OptArg int offset);
 
     /**
      * Plots a standard 2D line plot.
      */
     @BindingMethod
-    public static native void PlotLine(String labelId, int[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    @BindingMethod
-    public static native void PlotLine(String labelId, long[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    @BindingMethod
-    public static native void PlotLine(String labelId, float[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    @BindingMethod
-    public static native void PlotLine(String labelId, double[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotLine(String labelId,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                       int count,
+                                       @OptArg double xscale,
+                                       @OptArg double x0,
+                                       @OptArg int offset);
 
     // xs,ys
 
@@ -406,31 +399,21 @@ public final class ImPlot {
      * Plots a standard 2D line plot.
      */
     @BindingMethod
-    public static native void PlotLine(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotLine(String labelId,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                       @ArgValue(callValue = "LEN(xs)") Void count,
+                                       @OptArg int offset);
 
     /**
      * Plots a standard 2D line plot.
      */
     @BindingMethod
-    public static native void PlotLine(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    @BindingMethod
-    public static native void PlotLine(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    @BindingMethod
-    public static native void PlotLine(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    @BindingMethod
-    public static native void PlotLine(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotLine(String labelId,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                       int count,
+                                       int offset);
 
     // values
 

--- a/imgui-binding/src/main/java/imgui/extension/implot/ImPlot.java
+++ b/imgui-binding/src/main/java/imgui/extension/implot/ImPlot.java
@@ -402,8 +402,7 @@ public final class ImPlot {
     public static native void PlotLine(String labelId,
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
-                                       @ArgValue(callValue = "LEN(xs)") Void count,
-                                       @OptArg int offset);
+                                       @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots a standard 2D line plot.
@@ -413,7 +412,7 @@ public final class ImPlot {
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                        int count,
-                                       int offset);
+                                       @OptArg int offset);
 
     // values
 
@@ -421,31 +420,23 @@ public final class ImPlot {
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     @BindingMethod
-    public static native void PlotScatter(String labelId, short[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotScatter(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                          @ArgValue(callValue = "LEN(values)") Void count,
+                                          @OptArg double xscale,
+                                          @OptArg double x0,
+                                          @OptArg int offset);
 
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     @BindingMethod
-    public static native void PlotScatter(String labelId, int[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    @BindingMethod
-    public static native void PlotScatter(String labelId, long[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    @BindingMethod
-    public static native void PlotScatter(String labelId, float[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    @BindingMethod
-    public static native void PlotScatter(String labelId, double[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotScatter(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                          int count,
+                                          @OptArg double xscale,
+                                          @OptArg double x0,
+                                          @OptArg int offset);
 
     // xs,ys
 
@@ -453,31 +444,20 @@ public final class ImPlot {
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     @BindingMethod
-    public static native void PlotScatter(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotScatter(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                          @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     @BindingMethod
-    public static native void PlotScatter(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    @BindingMethod
-    public static native void PlotScatter(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    @BindingMethod
-    public static native void PlotScatter(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    @BindingMethod
-    public static native void PlotScatter(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotScatter(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                          int count,
+                                          @OptArg int offset);
 
     // values
 
@@ -485,31 +465,23 @@ public final class ImPlot {
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     @BindingMethod
-    public static native void PlotStairs(String labelId, short[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotStairs(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                         @ArgValue(callValue = "LEN(values)") Void count,
+                                         @OptArg double xscale,
+                                         @OptArg double x0,
+                                         @OptArg int offset);
 
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     @BindingMethod
-    public static native void PlotStairs(String labelId, int[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    @BindingMethod
-    public static native void PlotStairs(String labelId, long[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    @BindingMethod
-    public static native void PlotStairs(String labelId, float[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    @BindingMethod
-    public static native void PlotStairs(String labelId, double[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotStairs(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                         int count,
+                                         @OptArg double xscale,
+                                         @OptArg double x0,
+                                         @OptArg int offset);
 
     // xs,ys
 
@@ -517,31 +489,20 @@ public final class ImPlot {
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     @BindingMethod
-    public static native void PlotStairs(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotStairs(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                         @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     @BindingMethod
-    public static native void PlotStairs(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    @BindingMethod
-    public static native void PlotStairs(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    @BindingMethod
-    public static native void PlotStairs(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    @BindingMethod
-    public static native void PlotStairs(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotStairs(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                         int count,
+                                         @OptArg int offset);
 
     // values
 
@@ -549,31 +510,25 @@ public final class ImPlot {
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     @BindingMethod
-    public static native void PlotShaded(String labelId, short[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotShaded(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                         @ArgValue(callValue = "LEN(values)") Void count,
+                                         @OptArg double yRef,
+                                         @OptArg double xscale,
+                                         @OptArg double x0,
+                                         @OptArg int offset);
 
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     @BindingMethod
-    public static native void PlotShaded(String labelId, int[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, long[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, float[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, double[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotShaded(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                         int count,
+                                         @OptArg double yRef,
+                                         @OptArg double xscale,
+                                         @OptArg double x0,
+                                         @OptArg int offset);
 
     // xs,ys
 
@@ -581,31 +536,23 @@ public final class ImPlot {
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     @BindingMethod
-    public static native void PlotShaded(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
+    public static native void PlotShaded(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                         @ArgValue(callValue = "LEN(xs)") Void count,
+                                         @OptArg double yRef,
+                                         @OptArg int offset);
 
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     @BindingMethod
-    public static native void PlotShaded(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
+    public static native void PlotShaded(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                         int count,
+                                         @OptArg double yRef,
+                                         @OptArg int offset);
 
     // xs,ys1,ys2
 
@@ -613,31 +560,22 @@ public final class ImPlot {
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     @BindingMethod
-    public static native void PlotShaded(String labelId, short[] xs, short[] ys1, short[] ys2, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotShaded(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys1,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys2,
+                                         @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     @BindingMethod
-    public static native void PlotShaded(String labelId, int[] xs, int[] ys1, int[] ys2, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, long[] xs, long[] ys1, long[] ys2, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, float[] xs, float[] ys1, float[] ys2, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    @BindingMethod
-    public static native void PlotShaded(String labelId, double[] xs, double[] ys1, double[] ys2, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotShaded(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys1,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys2,
+                                         int count,
+                                         @OptArg int offset);
 
     // values
 
@@ -645,31 +583,23 @@ public final class ImPlot {
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
     @BindingMethod
-    public static native void PlotBars(String labelId, short[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double width, @OptArg double shift, @OptArg int offset);
+    public static native void PlotBars(String labelId,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                       @ArgValue(callValue = "LEN(values)") Void count,
+                                       @OptArg double width,
+                                       @OptArg double shift,
+                                       @OptArg int offset);
 
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
     @BindingMethod
-    public static native void PlotBars(String labelId, int[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double width, @OptArg double shift, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, long[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double width, @OptArg double shift, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, float[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double width, @OptArg double shift, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, double[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double width, @OptArg double shift, @OptArg int offset);
+    public static native void PlotBars(String labelId,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                       int count,
+                                       @OptArg double width,
+                                       @OptArg double shift,
+                                       @OptArg int offset);
 
     // xs,ys
 
@@ -677,61 +607,22 @@ public final class ImPlot {
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
     @BindingMethod
-    public static native void PlotBars(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double width, @OptArg int offset);
+    public static native void PlotBars(String labelId,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                       @ArgValue(callValue = "LEN(xs)") Void count,
+                                       double width);
 
     /**
      * Plots a vertical bar graph. #width and #shift are in X units.
      */
     @BindingMethod
-    public static native void PlotBars(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double width, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double width, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double width, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double width, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void width, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void width, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void width, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void width, @OptArg int offset);
-
-    /**
-     * Plots a vertical bar graph. #width and #shift are in X units.
-     */
-    @BindingMethod
-    public static native void PlotBars(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void width, @OptArg int offset);
+    public static native void PlotBars(String labelId,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                       @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                       int count,
+                                       double width,
+                                       @OptArg int offset);
 
     // values
 
@@ -739,31 +630,23 @@ public final class ImPlot {
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     @BindingMethod
-    public static native void PlotBarsH(String labelId, short[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double height, @OptArg double shift, @OptArg int offset);
+    public static native void PlotBarsH(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                        @ArgValue(callValue = "LEN(values)") Void count,
+                                        @OptArg double height,
+                                        @OptArg double shift,
+                                        @OptArg int offset);
 
     /**
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     @BindingMethod
-    public static native void PlotBarsH(String labelId, int[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double height, @OptArg double shift, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, long[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double height, @OptArg double shift, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, float[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double height, @OptArg double shift, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, double[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double height, @OptArg double shift, @OptArg int offset);
+    public static native void PlotBarsH(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                        int count,
+                                        @OptArg double height,
+                                        @OptArg double shift,
+                                        @OptArg int offset);
 
     // xs,ys
 
@@ -771,181 +654,110 @@ public final class ImPlot {
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     @BindingMethod
-    public static native void PlotBarsH(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double height, @OptArg int offset);
+    public static native void PlotBarsH(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                        @ArgValue(callValue = "LEN(xs)") Void count,
+                                        double height);
 
     /**
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     @BindingMethod
-    public static native void PlotBarsH(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double height, @OptArg int offset);
+    public static native void PlotBarsH(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                        int count,
+                                        double height,
+                                        @OptArg int offset);
 
     /**
      * Plots a horizontal bar graph. #height and #shift are in Y units.
      */
     @BindingMethod
-    public static native void PlotBarsH(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double height, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double height, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, double height, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void height, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void height, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void height, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void height, @OptArg int offset);
-
-    /**
-     * Plots a horizontal bar graph. #height and #shift are in Y units.
-     */
-    @BindingMethod
-    public static native void PlotBarsH(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @ArgValue(callValue = "0.67") Void height, @OptArg int offset);
+    public static native void PlotBarsH(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                        @ArgValue(callValue = "LEN(xs)") Void count,
+                                        @ArgValue(callValue = "0.67") Void height,
+                                        @OptArg int offset);
 
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     @BindingMethod
-    public static native void PlotErrorBars(String labelId, short[] xs, short[] ys, short[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotErrorBars(String labelId,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void err,
+                                            @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     @BindingMethod
-    public static native void PlotErrorBars(String labelId, int[] xs, int[] ys, int[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotErrorBars(String labelId,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void err,
+                                            int count,
+                                            @OptArg int offset);
 
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     @BindingMethod
-    public static native void PlotErrorBars(String labelId, long[] xs, long[] ys, long[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotErrorBars(String labelId,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void neg,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void pos,
+                                            @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     @BindingMethod
-    public static native void PlotErrorBars(String labelId, float[] xs, float[] ys, float[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBars(String labelId, double[] xs, double[] ys, double[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotErrorBars(String labelId,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void neg,
+                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void pos,
+                                            int count,
+                                            @OptArg int offset);
 
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotErrorBarsH(String labelId,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void err,
+                                             @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotErrorBarsH(String labelId,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void err,
+                                             int count,
+                                             @OptArg int offset);
 
     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] err, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    @BindingMethod
-    public static native void PlotErrorBarsH(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotErrorBarsH(String labelId,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void neg,
+                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void pos,
+                                             int count,
+                                             @OptArg int offset);
 
     // values
 
@@ -953,31 +765,25 @@ public final class ImPlot {
      * Plots vertical stems.
      */
     @BindingMethod
-    public static native void PlotStems(String labelId, short[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotStems(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                        @ArgValue(callValue = "LEN(values)") Void count,
+                                        @OptArg double yRef,
+                                        @OptArg double xscale,
+                                        @OptArg double x0,
+                                        @OptArg int offset);
 
     /**
      * Plots vertical stems.
      */
     @BindingMethod
-    public static native void PlotStems(String labelId, int[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots vertical stems.
-     */
-    @BindingMethod
-    public static native void PlotStems(String labelId, long[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots vertical stems.
-     */
-    @BindingMethod
-    public static native void PlotStems(String labelId, float[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
-
-    /**
-     * Plots vertical stems.
-     */
-    @BindingMethod
-    public static native void PlotStems(String labelId, double[] values, @ArgValue(callValue = "LEN(values)") Void count, @OptArg double yRef, @OptArg double xscale, @OptArg double x0, @OptArg int offset);
+    public static native void PlotStems(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                        int count,
+                                        @OptArg double yRef,
+                                        @OptArg double xscale,
+                                        @OptArg double x0,
+                                        @OptArg int offset);
 
     // xs,ys
 
@@ -985,98 +791,64 @@ public final class ImPlot {
      * Plots vertical stems.
      */
     @BindingMethod
-    public static native void PlotStems(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
+    public static native void PlotStems(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                        @ArgValue(callValue = "LEN(xs)") Void count,
+                                        @OptArg double yRef,
+                                        @OptArg int offset);
 
     /**
      * Plots vertical stems.
      */
     @BindingMethod
-    public static native void PlotStems(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
-
-    /**
-     * Plots vertical stems.
-     */
-    @BindingMethod
-    public static native void PlotStems(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
-
-    /**
-     * Plots vertical stems.
-     */
-    @BindingMethod
-    public static native void PlotStems(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
-
-    /**
-     * Plots vertical stems.
-     */
-    @BindingMethod
-    public static native void PlotStems(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg double yRef, @OptArg int offset);
+    public static native void PlotStems(String labelId,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                        int count,
+                                        @OptArg double yRef,
+                                        @OptArg int offset);
 
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     @BindingMethod
-    public static native void PlotVLines(String labelId, short[] xs, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotVLines(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                         @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     @BindingMethod
-    public static native void PlotVLines(String labelId, int[] xs, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotVLines(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                         int count,
+                                         @OptArg int offset);
 
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     @BindingMethod
-    public static native void PlotVLines(String labelId, long[] xs, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotHLines(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                         @ArgValue(callValue = "LEN(ys)") Void count);
 
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     @BindingMethod
-    public static native void PlotVLines(String labelId, float[] xs, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    @BindingMethod
-    public static native void PlotVLines(String labelId, double[] xs, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    @BindingMethod
-    public static native void PlotHLines(String labelId, short[] ys, @ArgValue(callValue = "LEN(ys)") Void count, @OptArg int offset);
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    @BindingMethod
-    public static native void PlotHLines(String labelId, int[] ys, @ArgValue(callValue = "LEN(ys)") Void count, @OptArg int offset);
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    @BindingMethod
-    public static native void PlotHLines(String labelId, long[] ys, @ArgValue(callValue = "LEN(ys)") Void count, @OptArg int offset);
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    @BindingMethod
-    public static native void PlotHLines(String labelId, float[] ys, @ArgValue(callValue = "LEN(ys)") Void count, @OptArg int offset);
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    @BindingMethod
-    public static native void PlotHLines(String labelId, double[] ys, @ArgValue(callValue = "LEN(ys)") Void count, @OptArg int offset);
+    public static native void PlotHLines(String labelId,
+                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                         int count,
+                                         @OptArg int offset);
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
     @BindingMethod
     public static native void PlotPieChart(String[] labelIds,
-                                           short[] values,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                            @ArgValue(callValue = "LEN(values)") Void count,
                                            double x,
                                            double y,
@@ -1090,50 +862,8 @@ public final class ImPlot {
      */
     @BindingMethod
     public static native void PlotPieChart(String[] labelIds,
-                                           int[] values,
-                                           @ArgValue(callValue = "LEN(values)") Void count,
-                                           double x,
-                                           double y,
-                                           double radius,
-                                           @OptArg(callValue = "false") boolean normalize,
-                                           @OptArg(callValue = "\"%.1f\"") String labelFmt,
-                                           @OptArg double angle0);
-
-    /**
-     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
-     */
-    @BindingMethod
-    public static native void PlotPieChart(String[] labelIds,
-                                           long[] values,
-                                           @ArgValue(callValue = "LEN(values)") Void count,
-                                           double x,
-                                           double y,
-                                           double radius,
-                                           @OptArg(callValue = "false") boolean normalize,
-                                           @OptArg(callValue = "\"%.1f\"") String labelFmt,
-                                           @OptArg double angle0);
-
-    /**
-     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
-     */
-    @BindingMethod
-    public static native void PlotPieChart(String[] labelIds,
-                                           float[] values,
-                                           @ArgValue(callValue = "LEN(values)") Void count,
-                                           double x,
-                                           double y,
-                                           double radius,
-                                           @OptArg(callValue = "false") boolean normalize,
-                                           @OptArg(callValue = "\"%.1f\"") String labelFmt,
-                                           @OptArg double angle0);
-
-    /**
-     * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
-     */
-    @BindingMethod
-    public static native void PlotPieChart(String[] labelIds,
-                                           double[] values,
-                                           @ArgValue(callValue = "LEN(values)") Void count,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                           int count,
                                            double x,
                                            double y,
                                            double radius,
@@ -1146,63 +876,7 @@ public final class ImPlot {
      */
     @BindingMethod
     public static native void PlotHeatmap(String labelId,
-                                          short[] values,
-                                          int rows,
-                                          int cols,
-                                          @OptArg double scaleMin,
-                                          @OptArg double scaleMax,
-                                          @OptArg(callValue = "\"%.1f\"") String labelFmt,
-                                          @OptArg ImPlotPoint boundsMin,
-                                          @OptArg ImPlotPoint boundsMax);
-
-    /**
-     * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
-     */
-    @BindingMethod
-    public static native void PlotHeatmap(String labelId,
-                                          int[] values,
-                                          int rows,
-                                          int cols,
-                                          @OptArg double scaleMin,
-                                          @OptArg double scaleMax,
-                                          @OptArg(callValue = "\"%.1f\"") String labelFmt,
-                                          @OptArg ImPlotPoint boundsMin,
-                                          @OptArg ImPlotPoint boundsMax);
-
-    /**
-     * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
-     */
-    @BindingMethod
-    public static native void PlotHeatmap(String labelId,
-                                          long[] values,
-                                          int rows,
-                                          int cols,
-                                          @OptArg double scaleMin,
-                                          @OptArg double scaleMax,
-                                          @OptArg(callValue = "\"%.1f\"") String labelFmt,
-                                          @OptArg ImPlotPoint boundsMin,
-                                          @OptArg ImPlotPoint boundsMax);
-
-    /**
-     * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
-     */
-    @BindingMethod
-    public static native void PlotHeatmap(String labelId,
-                                          float[] values,
-                                          int rows,
-                                          int cols,
-                                          @OptArg double scaleMin,
-                                          @OptArg double scaleMax,
-                                          @OptArg(callValue = "\"%.1f\"") String labelFmt,
-                                          @OptArg ImPlotPoint boundsMin,
-                                          @OptArg ImPlotPoint boundsMax);
-
-    /**
-     * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
-     */
-    @BindingMethod
-    public static native void PlotHeatmap(String labelId,
-                                          double[] values,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                           int rows,
                                           int cols,
                                           @OptArg double scaleMin,
@@ -1218,7 +892,7 @@ public final class ImPlot {
      */
     @BindingMethod
     public static native double PlotHistogram(String labelId,
-                                              short[] values,
+                                              @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                               @ArgValue(callValue = "LEN(values)") Void count,
                                               @OptArg(callValue = "ImPlotBin_Sturges") int bins,
                                               @OptArg boolean cumulative,
@@ -1234,57 +908,9 @@ public final class ImPlot {
      */
     @BindingMethod
     public static native double PlotHistogram(String labelId,
-                                              int[] values,
-                                              @ArgValue(callValue = "LEN(values)") Void count,
-                                              @OptArg(callValue = "ImPlotBin_Sturges") int bins,
-                                              @OptArg boolean cumulative,
-                                              @OptArg boolean density,
-                                              @OptArg(callValue = "ImPlotRange()") ImPlotRange range,
-                                              @OptArg(callValue = "true") boolean outliers,
-                                              @OptArg double barScale);
-
-    /**
-     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
-     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
-     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
-     */
-    @BindingMethod
-    public static native double PlotHistogram(String labelId,
-                                              long[] values,
-                                              @ArgValue(callValue = "LEN(values)") Void count,
-                                              @OptArg(callValue = "ImPlotBin_Sturges") int bins,
-                                              @OptArg boolean cumulative,
-                                              @OptArg boolean density,
-                                              @OptArg(callValue = "ImPlotRange()") ImPlotRange range,
-                                              @OptArg(callValue = "true") boolean outliers,
-                                              @OptArg double barScale);
-
-    /**
-     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
-     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
-     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
-     */
-    @BindingMethod
-    public static native double PlotHistogram(String labelId,
-                                              float[] values,
-                                              @ArgValue(callValue = "LEN(values)") Void count,
-                                              @OptArg(callValue = "ImPlotBin_Sturges") int bins,
-                                              @OptArg boolean cumulative,
-                                              @OptArg boolean density,
-                                              @OptArg(callValue = "ImPlotRange()") ImPlotRange range,
-                                              @OptArg(callValue = "true") boolean outliers,
-                                              @OptArg double barScale);
-
-    /**
-     * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
-     * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
-     * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
-     */
-    @BindingMethod
-    public static native double PlotHistogram(String labelId,
-                                              double[] values,
-                                              @ArgValue(callValue = "LEN(values)") Void count,
-                                              @OptArg(callValue = "ImPlotBin_Sturges") int bins,
+                                              @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                              int count,
+                                              int bins,
                                               @OptArg boolean cumulative,
                                               @OptArg boolean density,
                                               @OptArg(callValue = "ImPlotRange()") ImPlotRange range,
@@ -1298,8 +924,8 @@ public final class ImPlot {
      */
     @BindingMethod
     public static native double PlotHistogram2D(String labelId,
-                                                short[] xs,
-                                                short[] ys,
+                                                @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                                @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                                 @ArgValue(callValue = "LEN(xs)") Void count,
                                                 @OptArg int xBins,
                                                 @OptArg int yBins,
@@ -1314,59 +940,11 @@ public final class ImPlot {
      */
     @BindingMethod
     public static native double PlotHistogram2D(String labelId,
-                                                int[] xs,
-                                                int[] ys,
-                                                @ArgValue(callValue = "LEN(xs)") Void count,
-                                                @OptArg int xBins,
-                                                @OptArg int yBins,
-                                                @OptArg(callValue = "false") boolean density,
-                                                @OptArg(callValue = "ImPlotRect()") ImPlotRect range,
-                                                @OptArg boolean outliers);
-
-    /**
-     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
-     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
-     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
-     */
-    @BindingMethod
-    public static native double PlotHistogram2D(String labelId,
-                                                long[] xs,
-                                                long[] ys,
-                                                @ArgValue(callValue = "LEN(xs)") Void count,
-                                                @OptArg int xBins,
-                                                @OptArg int yBins,
-                                                @OptArg(callValue = "false") boolean density,
-                                                @OptArg(callValue = "ImPlotRect()") ImPlotRect range,
-                                                @OptArg boolean outliers);
-
-    /**
-     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
-     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
-     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
-     */
-    @BindingMethod
-    public static native double PlotHistogram2D(String labelId,
-                                                float[] xs,
-                                                float[] ys,
-                                                @ArgValue(callValue = "LEN(xs)") Void count,
-                                                @OptArg int xBins,
-                                                @OptArg int yBins,
-                                                @OptArg(callValue = "false") boolean density,
-                                                @OptArg(callValue = "ImPlotRect()") ImPlotRect range,
-                                                @OptArg boolean outliers);
-
-    /**
-     * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
-     * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
-     * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
-     */
-    @BindingMethod
-    public static native double PlotHistogram2D(String labelId,
-                                                double[] xs,
-                                                double[] ys,
-                                                @ArgValue(callValue = "LEN(xs)") Void count,
-                                                @OptArg int xBins,
-                                                @OptArg int yBins,
+                                                @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                                @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                                int count,
+                                                int xBins,
+                                                int yBins,
                                                 @OptArg(callValue = "false") boolean density,
                                                 @OptArg(callValue = "ImPlotRect()") ImPlotRect range,
                                                 @OptArg boolean outliers);
@@ -1375,43 +953,42 @@ public final class ImPlot {
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     @BindingMethod
-    public static native void PlotDigital(String labelId, short[] xs, short[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotDigital(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                          @ArgValue(callValue = "LEN(xs)") Void count);
 
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     @BindingMethod
-    public static native void PlotDigital(String labelId, int[] xs, int[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    @BindingMethod
-    public static native void PlotDigital(String labelId, long[] xs, long[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    @BindingMethod
-    public static native void PlotDigital(String labelId, float[] xs, float[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    @BindingMethod
-    public static native void PlotDigital(String labelId, double[] xs, double[] ys, @ArgValue(callValue = "LEN(xs)") Void count, @OptArg int offset);
+    public static native void PlotDigital(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                          int count,
+                                          @OptArg int offset);
 
     /**
      * Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
      */
     @BindingMethod
-    public static native void PlotImage(String labelId, @ArgValue(callPrefix = "(ImTextureID)(intptr_t)") int userTextureId, ImPlotPoint boundsMin, ImPlotPoint boundsMax, @OptArg ImVec2 uv0, @OptArg ImVec2 uv1, @OptArg ImVec4 tintCol);
+    public static native void PlotImage(String labelId,
+                                        @ArgValue(callPrefix = "(ImTextureID)(intptr_t)") int userTextureId,
+                                        ImPlotPoint boundsMin,
+                                        ImPlotPoint boundsMax,
+                                        @OptArg ImVec2 uv0,
+                                        @OptArg ImVec2 uv1,
+                                        @OptArg ImVec4 tintCol);
 
     /**
      * Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
      */
     @BindingMethod
-    public static native void PlotText(String text, double x, double y, @OptArg(callValue = "false") boolean vertical, @OptArg ImVec2 pixOffset);
+    public static native void PlotText(String text,
+                                       double x,
+                                       double y,
+                                       @OptArg(callValue = "false") boolean vertical,
+                                       @OptArg ImVec2 pixOffset);
 
     /**
      * Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)


### PR DESCRIPTION
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->


- This PR introduces a new annotation, `@ArgVariant`, which allows for the generation of methods with different type and name variants. This is particularly useful for generating bindings for templated methods.
- Additional `plot*` method variations with a `count` parameter (indicating the size of the passed array) have been added for `ImPlot` extension.

resolves #261 

## Type of change

<!-- 
Please check options that are relevant.
-->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
