### PR TITLE
Fix incorrect ImDrawData method return type

### DIFF
--- a/imgui-binding/src/generated/java/imgui/ImDrawData.java
+++ b/imgui-binding/src/generated/java/imgui/ImDrawData.java
@@ -63,7 +63,7 @@ public final class ImDrawData extends ImGuiStruct {
      * User-provided texture ID. Set by user in ImfontAtlas::SetTexID() for fonts or passed to Image*() functions.
      * Ignore if never using images or multiple fonts atlas.
      */
-    public native int getCmdListCmdBufferTextureId(int cmdListIdx, int cmdBufferIdx); /*
+    public native long getCmdListCmdBufferTextureId(int cmdListIdx, int cmdBufferIdx); /*
         return (uintptr_t)THIS->CmdLists[cmdListIdx]->CmdBuffer[cmdBufferIdx].GetTexID();
     */
 

--- a/imgui-binding/src/main/java/imgui/ImDrawData.java
+++ b/imgui-binding/src/main/java/imgui/ImDrawData.java
@@ -67,7 +67,7 @@ public final class ImDrawData extends ImGuiStruct {
      * User-provided texture ID. Set by user in ImfontAtlas::SetTexID() for fonts or passed to Image*() functions.
      * Ignore if never using images or multiple fonts atlas.
      */
-    public native int getCmdListCmdBufferTextureId(int cmdListIdx, int cmdBufferIdx); /*
+    public native long getCmdListCmdBufferTextureId(int cmdListIdx, int cmdBufferIdx); /*
         return (uintptr_t)THIS->CmdLists[cmdListIdx]->CmdBuffer[cmdBufferIdx].GetTexID();
     */
 

--- a/imgui-lwjgl3/src/main/java/imgui/gl3/ImGuiImplGl3.java
+++ b/imgui-lwjgl3/src/main/java/imgui/gl3/ImGuiImplGl3.java
@@ -474,14 +474,14 @@ public class ImGuiImplGl3 {
                 glScissor((int) clipMinX, (int) (fbHeight - clipMaxY), (int) (clipMaxX - clipMinX), (int) (clipMaxY - clipMinY));
 
                 // Bind texture, Draw
-                final int textureId = drawData.getCmdListCmdBufferTextureId(n, cmdIdx);
+                final long textureId = drawData.getCmdListCmdBufferTextureId(n, cmdIdx);
                 final int elemCount = drawData.getCmdListCmdBufferElemCount(n, cmdIdx);
                 final int idxOffset = drawData.getCmdListCmdBufferIdxOffset(n, cmdIdx);
                 final int vtxOffset = drawData.getCmdListCmdBufferVtxOffset(n, cmdIdx);
                 final long indices = idxOffset * (long) ImDrawData.sizeOfImDrawIdx();
                 final int type = ImDrawData.sizeOfImDrawIdx() == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT;
 
-                glBindTexture(GL_TEXTURE_2D, textureId);
+                glBindTexture(GL_TEXTURE_2D, (int) textureId);
 
                 if (data.glVersion >= 320) {
                     glDrawElementsBaseVertex(GL_TRIANGLES, elemCount, type, indices, vtxOffset);


### PR DESCRIPTION
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->

Method `getCmdListCmdBufferTextureId` must return long to be consistent with API in general.

fixes #271 

## Type of change

<!-- 
Please check options that are relevant.
-->

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
