### PR TITLE
Update imnodes binding

### DIFF
--- a/imgui-binding/src/generated/java/imgui/ImDrawData.java
+++ b/imgui-binding/src/generated/java/imgui/ImDrawData.java
@@ -2,6 +2,9 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -13,6 +16,7 @@ import java.nio.ByteOrder;
  * BINDING NOTICE: Since it's impossible to do a 1:1 mapping with JNI, current class provides "getCmdList*()" methods.
  * Those are used to get the data needed to do a rendering.
  */
+
 public final class ImDrawData extends ImGuiStruct {
     private static final int RESIZE_FACTOR = 5_000;
     private static ByteBuffer dataBuffer = ByteBuffer.allocateDirect(25_000).order(ByteOrder.nativeOrder());
@@ -144,7 +148,7 @@ public final class ImDrawData extends ImGuiStruct {
 
     ///////// End of Render Methods
 
-    /**
+     /**
      * Only valid after Render() is called and before the next NewFrame() is called.
      */
     public boolean getValid() {
@@ -155,7 +159,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->Valid;
     */
 
-    /**
+     /**
      * Number of ImDrawList* to render
      */
     public int getCmdListsCount() {
@@ -166,7 +170,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->CmdListsCount;
     */
 
-    /**
+     /**
      * For convenience, sum of all ImDrawList's IdxBuffer.Size
      */
     public int getTotalIdxCount() {
@@ -177,7 +181,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->TotalIdxCount;
     */
 
-    /**
+     /**
      * For convenience, sum of all ImDrawList's VtxBuffer.Size
      */
     public int getTotalVtxCount() {
@@ -188,7 +192,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->TotalVtxCount;
     */
 
-    /**
+     /**
      * Upper-left position of the viewport to render (== upper-left of the orthogonal projection matrix to use)
      */
     public ImVec2 getDisplayPos() {
@@ -230,7 +234,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->DisplayPos.y;
     */
 
-    /**
+     /**
      * Size of the viewport to render (== io.DisplaySize for the main viewport)
      * (DisplayPos + DisplaySize == lower-right of the orthogonal projection matrix to use)
      */
@@ -276,7 +280,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->DisplaySize.y;
     */
 
-    /**
+     /**
      * Amount of pixels for each unit of DisplaySize. Based on io.DisplayFramebufferScale. Generally (1,1) on normal display, (2,2) on OSX with Retina display.
      */
     public ImVec2 getFramebufferScale() {
@@ -318,7 +322,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->FramebufferScale.y;
     */
 
-    /**
+     /**
      * Viewport carrying the ImDrawData instance, might be of use to the renderer (generally not).
      */
     public ImGuiViewport getOwnerViewport() {
@@ -331,7 +335,7 @@ public final class ImDrawData extends ImGuiStruct {
 
     // Functions
 
-    /**
+     /**
      * Helper to convert all buffers from indexed to non-indexed, in case you cannot render indexed. Note: this is slow and most likely a waste of resources.
      * Always prefer indexed rendering!
      */
@@ -343,7 +347,7 @@ public final class ImDrawData extends ImGuiStruct {
         THIS->DeIndexAllBuffers();
     */
 
-    /**
+     /**
      * Helper to scale the ClipRect field of each ImDrawCmd. Use if your final output buffer is at a different scale than Dear ImGui expects,
      * or if there is a difference between your window resolution and framebuffer resolution.
      */

--- a/imgui-binding/src/generated/java/imgui/ImDrawList.java
+++ b/imgui-binding/src/generated/java/imgui/ImDrawList.java
@@ -2,6 +2,11 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
+
 /**
  * Draw command list
  * This is the low-level list of polygons that ImGui:: functions are filling. At the end of the frame,
@@ -13,6 +18,7 @@ import imgui.binding.ImGuiStruct;
  * but you are totally free to apply whatever transformation matrix to want to the data (if you apply such transformation you'll want to apply it to ClipRect as well)
  * Important: Primitives are always added to the list and not culled (culling is done at higher-level by ImGui:: functions), if you use this API a lot consider coarse culling your drawn objects.
  */
+
 public final class ImDrawList extends ImGuiStruct {
     public ImDrawList(final long ptr) {
         super(ptr);
@@ -23,7 +29,7 @@ public final class ImDrawList extends ImGuiStruct {
         #define THIS ((ImDrawList*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Flags, you may poke into these to adjust anti-aliasing settings per-primitive.
      */
     public int getFlags() {
@@ -66,7 +72,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->Flags = value;
     */
 
-    /**
+     /**
      * Render-level scissoring.
      * This is passed down to your render function but not used for CPU-side coarse clipping.
      * Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
@@ -770,7 +776,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->AddPolyline(points, numPoint, col, imDrawFlags, thickness);
     */
 
-    /**
+     /**
      * Note: Anti-aliased filling requires points to be in clockwise order.
      */
     public void addConvexPolyFilled(final ImVec2[] points, final int numPoints, final int col) {
@@ -789,7 +795,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->AddConvexPolyFilled(points, numPoints, col);
     */
 
-    /**
+     /**
      * Cubic Bezier (4 control points)
      */
     public void addBezierCubic(final ImVec2 p1, final ImVec2 p2, final ImVec2 p3, final ImVec2 p4, final int col, final float thickness) {
@@ -833,7 +839,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->AddBezierCubic(p1, p2, p3, p4, col, thickness, numSegments);
     */
 
-    /**
+     /**
      * Quadratic Bezier (3 control points)
      */
     public void addBezierQuadratic(final ImVec2 p1, final ImVec2 p2, final ImVec2 p3, final int col, final float thickness) {
@@ -1119,7 +1125,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->PathLineToMergeDuplicate(pos);
     */
 
-    /**
+     /**
      * Note: Anti-aliased filling requires points to be in clockwise order.
      */
     public void pathFillConvex(final int col) {
@@ -1188,7 +1194,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->PathArcTo(center, radius, aMin, aMax, numSegments);
     */
 
-    /**
+     /**
      * Use precomputed angles for a 12 steps circle
      */
     public void pathArcToFast(final ImVec2 center, final float radius, final int aMinOf12, final int aMaxOf12) {
@@ -1207,7 +1213,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->PathArcToFast(center, radius, aMinOf12, aMaxOf12);
     */
 
-    /**
+     /**
      * Cubic Bezier (4 control points)
      */
     public void pathBezierCubicCurveTo(final ImVec2 p2, final ImVec2 p3, final ImVec2 p4) {
@@ -1249,7 +1255,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->PathBezierCubicCurveTo(p2, p3, p4, numSegments);
     */
 
-    /**
+     /**
      * Quadratic Bezier (3 control points)
      */
     public void pathBezierQuadraticCurveTo(final ImVec2 p2, final ImVec2 p3) {

--- a/imgui-binding/src/generated/java/imgui/ImFont.java
+++ b/imgui-binding/src/generated/java/imgui/ImFont.java
@@ -2,10 +2,17 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
+
+
 /**
  * Font runtime data and rendering
  * ImFontAtlas automatically loads a default embedded font for you when you call GetTexDataAsAlpha8() or GetTexDataAsRGBA32().
  */
+
 public final class ImFont extends ImGuiStructDestroyable {
     public ImFont() {
         super();
@@ -31,7 +38,7 @@ public final class ImFont extends ImGuiStructDestroyable {
 
     // TODO IndexAdvanceX
 
-    /**
+     /**
      * = FallbackGlyph.AdvanceX
      */
     public float getFallbackAdvanceX() {
@@ -53,7 +60,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->FallbackAdvanceX = value;
     */
 
-    /**
+     /**
      * Height of characters/line, set during loading (don't change after loading)
      */
     public float getFontSize() {
@@ -77,7 +84,7 @@ public final class ImFont extends ImGuiStructDestroyable {
 
     // TODO IndexLookup, Glyphs
 
-    private static final ImFontGlyph _GETFALLBACKGLYPH_1 = new ImFontGlyph(0);
+     private static final ImFontGlyph _GETFALLBACKGLYPH_1 = new ImFontGlyph(0);
 
     /**
      * = FindGlyph(FontFallbackChar)
@@ -104,7 +111,7 @@ public final class ImFont extends ImGuiStructDestroyable {
 
     // TODO ContainerAtlas, ConfigData
 
-    /**
+     /**
      * Number of ImFontConfig involved in creating this font.
      * Bigger than 1 when merging multiple font sources into one ImFont.
      */
@@ -128,7 +135,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->ConfigDataCount = value;
     */
 
-    /**
+     /**
      * Character used for ellipsis rendering.
      */
     public short getEllipsisChar() {
@@ -150,7 +157,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->EllipsisChar = value;
     */
 
-    /**
+     /**
      * Character used for ellipsis rendering (if a single '...' character isn't found)
      */
     public short getDotChar() {
@@ -188,7 +195,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->DirtyLookupTables = value;
     */
 
-    /**
+     /**
      * Base font scale, multiplied by the per-window font scale which you can adjust with SetWindowFontScale()
      */
     public float getScale() {
@@ -210,7 +217,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->Scale = value;
     */
 
-    /**
+     /**
      * Ascent: distance from top to bottom of e.g. 'A' [0..FontSize]
      */
     public float getAscent() {
@@ -248,7 +255,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->Descent = value;
     */
 
-    /**
+     /**
      * Total surface in pixels to get an idea of the font rasterization/texture cost (not exact, we approximate the cost of padding between glyphs)
      */
     public int getMetricsTotalSurface() {
@@ -312,7 +319,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         return env->NewStringUTF(THIS->GetDebugName());
     */
 
-    /**
+     /**
      * 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable.
      * 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.
      */

--- a/imgui-binding/src/generated/java/imgui/ImFontAtlas.java
+++ b/imgui-binding/src/generated/java/imgui/ImFontAtlas.java
@@ -1,6 +1,11 @@
 package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
+
+
+
+
+
 import imgui.type.ImInt;
 
 import java.nio.ByteBuffer;
@@ -25,6 +30,7 @@ import java.nio.ByteOrder;
  * - Even though many functions are suffixed with "TTF", OTF data is supported just as well.
  * - This is an old API and it is currently awkward for those and and various other reasons! We will address them in the future!
  */
+
 public final class ImFontAtlas extends ImGuiStructDestroyable {
     private ByteBuffer alpha8pixels = null;
     private ByteBuffer rgba32pixels = null;
@@ -132,7 +138,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after destruction of the atlas.
      * Set font_cfg.FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed.
      */
@@ -196,7 +202,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after destruction of the atlas.
      * Set font_cfg.FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed.
      */
@@ -260,7 +266,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * 'compressed_font_data' still owned by caller. Compress with binary_to_compressed_c.cpp.
      */
     public ImFont addFontFromMemoryCompressedTTF(final byte[] compressedFontData, final float sizePixels) {
@@ -320,7 +326,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * 'compressed_font_data' still owned by caller. Compress with binary_to_compressed_c.cpp.
      */
     public ImFont addFontFromMemoryCompressedTTF(final byte[] compressedFontData, final int compressedFontSize, final float sizePixels) {
@@ -380,7 +386,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * 'compressed_font_data_base85' still owned by caller. Compress with binary_to_compressed_c.cpp with -base85 parameter.
      */
     public ImFont addFontFromMemoryCompressedBase85TTF(final String compressedFontDataBase85, final float sizePixels, final ImFontConfig fontConfig) {
@@ -410,7 +416,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * Clear input data (all ImFontConfig structures including sizes, TTF data, glyph ranges, etc.) = all the data used to build the texture and fonts.
      */
     public void clearInputData() {
@@ -421,7 +427,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->ClearInputData();
     */
 
-    /**
+     /**
      * Clear output texture data (CPU side). Saves RAM once the texture has been copied to graphics memory.
      */
     public void clearTexData() {
@@ -432,7 +438,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->ClearTexData();
     */
 
-    /**
+     /**
      * Clear output font data (glyphs storage, UV coordinates).
      */
     public void clearFonts() {
@@ -443,7 +449,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->ClearFonts();
     */
 
-    /**
+     /**
      * Clear all input and output.
      */
     public void clear() {
@@ -486,7 +492,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         #endif
     */
 
-    /**
+     /**
      * Build pixels data. This is called automatically for you by the GetTexData*** functions.
      */
     public boolean build() {
@@ -571,7 +577,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return THIS->IsBuilt();
     */
 
-    /**
+     /**
      * User data to refer to the texture once it has been uploaded to user's graphic systems.
      * It is passed back to you during rendering via the ImDrawCmd structure.
      */
@@ -681,7 +687,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return THIS->AddCustomRectRegular(width, height);
     */
 
-    /**
+     /**
      * Id needs to be {@code <} 0x110000 to register a rectangle to map into a specific font.
      */
     public int addCustomRectFontGlyph(final ImFont imFont, final short id, final int width, final int height, final float advanceX) {
@@ -718,7 +724,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
     // Members
     //-------------------------------------------
 
-    /**
+     /**
      * Build flags (see {@link imgui.flag.ImFontAtlasFlags})
      */
     public int getFlags() {
@@ -763,7 +769,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
 
     // TexID implemented as SetTexID function
 
-    /**
+     /**
      * Texture width desired by user before Build(). Must be a power-of-two.
      * If have many glyphs your graphics API have texture size restrictions you may want to increase texture width to decrease height.
      */
@@ -787,7 +793,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->TexDesiredWidth = value;
     */
 
-    /**
+     /**
      * Padding between glyphs within texture in pixels. Defaults to 1.
      * If your rendering method doesn't rely on bilinear filtering you may set this to 0.
      */
@@ -811,7 +817,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->TexGlyphPadding = value;
     */
 
-    /**
+     /**
      * Marked as Locked by ImGui::NewFrame() so attempt to modify the atlas will assert.
      */
     public boolean getLocked() {

--- a/imgui-binding/src/generated/java/imgui/ImFontConfig.java
+++ b/imgui-binding/src/generated/java/imgui/ImFontConfig.java
@@ -2,6 +2,9 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 public final class ImFontConfig extends ImGuiStructDestroyable {
     public ImFontConfig() {
         super();
@@ -44,7 +47,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontData = &fontData[0];
     */
 
-    /**
+     /**
      * TTF/OTF data size
      */
     public int getFontDataSize() {
@@ -66,7 +69,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontDataSize = value;
     */
 
-    /**
+     /**
      * TTF/OTF data ownership taken by the container ImFontAtlas (will delete memory itself).
      */
     public boolean getFontDataOwnedByAtlas() {
@@ -88,7 +91,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontDataOwnedByAtlas = value;
     */
 
-    /**
+     /**
      * Index of font within TTF/OTF file
      */
     public int getFontNo() {
@@ -110,7 +113,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontNo = value;
     */
 
-    /**
+     /**
      * Size in pixels for rasterizer (more or less maps to the resulting font height).
      */
     public float getSizePixels() {
@@ -132,7 +135,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->SizePixels = value;
     */
 
-    /**
+     /**
      * Rasterize at higher quality for sub-pixel positioning.
      * Note the difference between 2 and 3 is minimal so you can reduce this to 2 to save memory.
      * Read https://github.com/nothings/stb/blob/master/tests/oversample/README.md for details.
@@ -158,7 +161,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->OversampleH = value;
     */
 
-    /**
+     /**
      * Rasterize at higher quality for sub-pixel positioning.
      * This is not really useful as we don't use sub-pixel positions on the Y axis.
      */
@@ -182,7 +185,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->OversampleV = value;
     */
 
-    /**
+     /**
      * Align every glyph to pixel boundary. Useful e.g. if you are merging a non-pixel aligned font with the default font.
      * If enabled, you can set OversampleH/V to 1.
      */
@@ -206,7 +209,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->PixelSnapH = value;
     */
 
-    /**
+     /**
      * Extra spacing (in pixels) between glyphs. Only X axis is supported for now.
      */
     public ImVec2 getGlyphExtraSpacing() {
@@ -267,7 +270,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->GlyphExtraSpacing = value;
     */
 
-    /**
+     /**
      * Offset all glyphs from this font input.
      */
     public ImVec2 getGlyphOffset() {
@@ -351,7 +354,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->GlyphRanges = glyphRanges != NULL ? (ImWchar*)&glyphRanges[0] : NULL;
     */
 
-    /**
+     /**
      * Minimum AdvanceX for glyphs, set Min to align font icons, set both Min/Max to enforce mono-space font
      */
     public float getGlyphMinAdvanceX() {
@@ -373,7 +376,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->GlyphMinAdvanceX = value;
     */
 
-    /**
+     /**
      * Maximum AdvanceX for glyphs
      */
     public float getGlyphMaxAdvanceX() {
@@ -395,7 +398,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->GlyphMaxAdvanceX = value;
     */
 
-    /**
+     /**
      * Merge into previous ImFont, so you can combine multiple inputs font into one ImFont (e.g. ASCII font + icons + Japanese glyphs).
      * You may want to use GlyphOffset.y when merge font of different heights.
      */
@@ -419,7 +422,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->MergeMode = value;
     */
 
-    /**
+     /**
      * Settings for custom font builder. THIS IS BUILDER IMPLEMENTATION DEPENDENT. Leave as zero if unsure.
      */
     public int getFontBuilderFlags() {
@@ -462,7 +465,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontBuilderFlags = value;
     */
 
-    /**
+     /**
      * Brighten ({@code >}1.0f) or darken ({@code <}1.0f) font output. Brightening small fonts may be a good workaround to make them more readable.
      */
     public float getRasterizerMultiply() {
@@ -484,7 +487,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->RasterizerMultiply = value;
     */
 
-    /**
+     /**
      * Explicitly specify unicode codepoint of ellipsis character. When fonts are being merged first specified ellipsis will be used.
      */
     public short getEllipsisChar() {

--- a/imgui-binding/src/generated/java/imgui/ImFontGlyph.java
+++ b/imgui-binding/src/generated/java/imgui/ImFontGlyph.java
@@ -2,10 +2,13 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
 /**
  * Hold rendering data for one glyph.
  * (Note: some language parsers may fail to convert the 31+1 bitfield members, in this case maybe drop store a single u32 or we can rework this)
  */
+
 public final class ImFontGlyph extends ImGuiStructDestroyable {
     public ImFontGlyph() {
         super();
@@ -29,7 +32,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImFontGlyph());
     */
 
-    /**
+     /**
      * Flag to indicate glyph is colored and should generally ignore tinting (make it usable with no shift on little-endian as this is used in loops).
      */
     public int getColored() {
@@ -51,7 +54,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Colored = value;
     */
 
-    /**
+     /**
      * Flag to indicate glyph has no visible pixels (e.g. space). Allow early out when rendering.
      */
     public int getVisible() {
@@ -73,7 +76,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Visible = value;
     */
 
-    /**
+     /**
      * 0x0000..0xFFFF
      */
     public int getCodepoint() {
@@ -95,7 +98,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Codepoint = value;
     */
 
-    /**
+     /**
      * Distance to next character (= data from font + ImFontConfig::GlyphExtraSpacing.x baked in)
      */
     public float getAdvanceX() {
@@ -117,7 +120,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->AdvanceX = value;
     */
 
-    /**
+     /**
      * Glyph corners
      */
     public float getX0() {
@@ -139,7 +142,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->X0 = value;
     */
 
-    /**
+     /**
      * Glyph corners
      */
     public float getY0() {
@@ -161,7 +164,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Y0 = value;
     */
 
-    /**
+     /**
      * Glyph corners
      */
     public float getX1() {
@@ -183,7 +186,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->X1 = value;
     */
 
-    /**
+     /**
      * Glyph corners
      */
     public float getY1() {
@@ -205,7 +208,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Y1 = value;
     */
 
-    /**
+     /**
      * Texture coordinates
      */
     public float getU0() {
@@ -227,7 +230,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->U0 = value;
     */
 
-    /**
+     /**
      * Texture coordinates
      */
     public float getV0() {
@@ -249,7 +252,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->V0 = value;
     */
 
-    /**
+     /**
      * Texture coordinates
      */
     public float getU1() {
@@ -271,7 +274,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->U1 = value;
     */
 
-    /**
+     /**
      * Texture coordinates
      */
     public float getV1() {

--- a/imgui-binding/src/generated/java/imgui/ImGui.java
+++ b/imgui-binding/src/generated/java/imgui/ImGui.java
@@ -1,6 +1,12 @@
 package imgui;
 
 import imgui.assertion.ImAssertCallback;
+
+
+
+
+
+
 import imgui.callback.ImGuiInputTextCallback;
 import imgui.flag.ImGuiDragDropFlags;
 import imgui.flag.ImGuiInputTextFlags;
@@ -24,6 +30,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.Properties;
+
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ImGui {
@@ -215,7 +222,7 @@ public class ImGui {
 
     // Main
 
-    private static final ImGuiIO _GETIO_1 = new ImGuiIO(0);
+     private static final ImGuiIO _GETIO_1 = new ImGuiIO(0);
 
     /**
      * Access the IO structure (mouse/keyboard/gamepad inputs, time, various configuration options/flags).
@@ -229,7 +236,7 @@ public class ImGui {
         return (uintptr_t)&ImGui::GetIO();
     */
 
-    private static final ImGuiStyle _GETSTYLE_1 = new ImGuiStyle(0);
+     private static final ImGuiStyle _GETSTYLE_1 = new ImGuiStyle(0);
 
     /**
      * Access the Style structure (colors, sizes). Always use PushStyleCol(), PushStyleVar() to modify style mid-frame!
@@ -243,7 +250,7 @@ public class ImGui {
         return (uintptr_t)&ImGui::GetStyle();
     */
 
-    /**
+     /**
      * Start a new Dear ImGui frame, you can submit any command from this point until Render()/EndFrame().
      */
     public static void newFrame() {
@@ -254,7 +261,7 @@ public class ImGui {
         ImGui::NewFrame();
     */
 
-    /**
+     /**
      * Ends the Dear ImGui frame. automatically called by Render(). If you don't need to render data (skipping rendering) you may call EndFrame() without
      * Render()... but you'll have wasted CPU already! If you don't need to render, better to not create any windows and not call NewFrame() at all!
      */
@@ -266,7 +273,7 @@ public class ImGui {
         ImGui::EndFrame();
     */
 
-    /**
+     /**
      * Ends the Dear ImGui frame, finalize the draw data. You can then get call GetDrawData().
      */
     public static void render() {
@@ -277,7 +284,7 @@ public class ImGui {
         ImGui::Render();
     */
 
-    private static final ImDrawData _GETDRAWDATA_1 = new ImDrawData(0);
+     private static final ImDrawData _GETDRAWDATA_1 = new ImDrawData(0);
 
     /**
      * Valid after Render() and until the next call to NewFrame(). this is what you have to render.
@@ -293,7 +300,7 @@ public class ImGui {
 
     // Demo, Debug, Information
 
-    /**
+     /**
      * Create Demo window. Demonstrate most ImGui features. Call this to learn about the library!
      */
     public static void showDemoWindow() {
@@ -317,7 +324,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Create Metrics/Debugger window. display Dear ImGui internals: windows, draw commands, various internal state, etc.
      */
     public static void showMetricsWindow() {
@@ -341,7 +348,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Create Stack Tool window. hover items with mouse to query information about the source of their unique ID.
      */
     public static void showStackToolWindow() {
@@ -365,7 +372,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Create About window. display Dear ImGui version, credits and build/system information.
      */
     public static void showAboutWindow() {
@@ -389,7 +396,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Add style editor block (not a window).
      * You can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else it uses the default style)
      */
@@ -413,7 +420,7 @@ public class ImGui {
         ImGui::ShowStyleEditor(reinterpret_cast<ImGuiStyle*>(ref));
     */
 
-    /**
+     /**
      * Add style selector block (not a window), essentially a combo listing the default styles.
      */
     public static boolean showStyleSelector(final String label) {
@@ -427,7 +434,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Add font selector block (not a window), essentially a combo listing the loaded fonts.
      */
     public static void showFontSelector(final String label) {
@@ -440,7 +447,7 @@ public class ImGui {
         if (label != NULL) env->ReleaseStringUTFChars(obj_label, label);
     */
 
-    /**
+     /**
      * Add basic help/info block (not a window): how to manipulate ImGui as a end-user (mouse/keyboard controls).
      */
     public static void showUserGuide() {
@@ -451,7 +458,7 @@ public class ImGui {
         ImGui::ShowUserGuide();
     */
 
-    /**
+     /**
      * Get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
      */
     public static String getVersion() {
@@ -464,7 +471,7 @@ public class ImGui {
 
     // Styles
 
-    /**
+     /**
      * New, recommended style (default)
      */
     public static void styleColorsDark() {
@@ -486,7 +493,7 @@ public class ImGui {
         ImGui::StyleColorsDark(reinterpret_cast<ImGuiStyle*>(style));
     */
 
-    /**
+     /**
      * Best used with borders and a custom, thicker font
      */
     public static void styleColorsLight() {
@@ -508,7 +515,7 @@ public class ImGui {
         ImGui::StyleColorsLight(reinterpret_cast<ImGuiStyle*>(style));
     */
 
-    /**
+     /**
      * Classic imgui style
      */
     public static void styleColorsClassic() {
@@ -813,7 +820,7 @@ public class ImGui {
         return ImGui::IsWindowCollapsed();
     */
 
-    /**
+     /**
      * Is current window focused? or its root/child, depending on flags. see flags for options.
      */
     public static boolean isWindowFocused() {
@@ -835,7 +842,7 @@ public class ImGui {
         return ImGui::IsWindowFocused(imGuiFocusedFlags);
     */
 
-    /**
+     /**
      * Is current window hovered (and typically: not blocked by a popup/modal)? see flags for options.
      * NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app,
      * you should use the 'io.WantCaptureMouse' boolean for that! Please read the FAQ!
@@ -861,7 +868,7 @@ public class ImGui {
         return ImGui::IsWindowHovered(imGuiHoveredFlags);
     */
 
-    /**
+     /**
      * Get draw list associated to the current window, to append your own drawing primitives
      */
     public static ImDrawList getWindowDrawList() {
@@ -872,7 +879,7 @@ public class ImGui {
         return (uintptr_t)ImGui::GetWindowDrawList();
     */
 
-    /**
+     /**
      * Get DPI scale currently associated to the current window's viewport.
      */
     public static float getWindowDpiScale() {
@@ -883,7 +890,7 @@ public class ImGui {
         return ImGui::GetWindowDpiScale();
     */
 
-    /**
+     /**
      * Get current window position in screen space (useful if you want to do your own drawing via the DrawList API)
      */
     public static ImVec2 getWindowPos() {
@@ -925,7 +932,7 @@ public class ImGui {
         return ImGui::GetWindowPos().y;
     */
 
-    /**
+     /**
      * Get current window size
      */
     public static ImVec2 getWindowSize() {
@@ -967,7 +974,7 @@ public class ImGui {
         return ImGui::GetWindowSize().y;
     */
 
-    /**
+     /**
      * Get current window width (shortcut for GetWindowSize().x)
      */
     public static float getWindowWidth() {
@@ -978,7 +985,7 @@ public class ImGui {
         return ImGui::GetWindowWidth();
     */
 
-    /**
+     /**
      * Get current window height (shortcut for GetWindowSize().y)
      */
     public static float getWindowHeight() {
@@ -989,7 +996,7 @@ public class ImGui {
         return ImGui::GetWindowHeight();
     */
 
-    /**
+     /**
      * Get viewport currently associated to the current window.
      */
     public static ImGuiViewport getWindowViewport() {
@@ -1002,7 +1009,7 @@ public class ImGui {
 
     // Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin).
 
-    /**
+     /**
      * Set next window position. call before Begin(). use pivot=(0.5f,0.5f) to center on given point, etc.
      */
     public static void setNextWindowPos(final ImVec2 pos) {
@@ -1080,7 +1087,7 @@ public class ImGui {
         ImGui::SetNextWindowPos(pos, ImGuiCond_None, pivot);
     */
 
-    /**
+     /**
      * Set next window size. set axis to 0.0f to force an auto-fit on this axis. call before Begin()
      */
     public static void setNextWindowSize(final ImVec2 size) {
@@ -1118,7 +1125,7 @@ public class ImGui {
         ImGui::SetNextWindowSize(size, cond);
     */
 
-    /**
+     /**
      * Set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. Sizes will be rounded down.
      */
     public static void setNextWindowSizeConstraints(final ImVec2 sizeMin, final ImVec2 sizeMax) {
@@ -1138,7 +1145,7 @@ public class ImGui {
         ImGui::SetNextWindowSizeConstraints(sizeMin, sizeMax);
     */
 
-    /**
+     /**
      * Set next window content size (~ scrollable client area, which enforce the range of scrollbars).
      * Not including window decorations (title bar, menu bar, etc.) nor WindowPadding. set an axis to 0.0f to leave it automatic. call before Begin()
      */
@@ -1159,7 +1166,7 @@ public class ImGui {
         ImGui::SetNextWindowContentSize(size);
     */
 
-    /**
+     /**
      * Set next window collapsed state. call before Begin()
      */
     public static void setNextWindowCollapsed(final boolean collapsed) {
@@ -1181,7 +1188,7 @@ public class ImGui {
         ImGui::SetNextWindowCollapsed(collapsed, cond);
     */
 
-    /**
+     /**
      * Set next window to be focused / top-most. call before Begin()
      */
     public static void setNextWindowFocus() {
@@ -1192,7 +1199,7 @@ public class ImGui {
         ImGui::SetNextWindowFocus();
     */
 
-    /**
+     /**
      * Set next window background color alpha. helper to easily override the Alpha component of ImGuiCol_WindowBg/ChildBg/PopupBg.
      * You may also use ImGuiWindowFlags_NoBackground.
      */
@@ -1204,7 +1211,7 @@ public class ImGui {
         ImGui::SetNextWindowBgAlpha(alpha);
     */
 
-    /**
+     /**
      * Set next window viewport.
      */
     public static void setNextWindowViewport(final int viewportId) {
@@ -1215,7 +1222,7 @@ public class ImGui {
         ImGui::SetNextWindowViewport(viewportId);
     */
 
-    /**
+     /**
      * (not recommended) set current window position - call within Begin()/End().
      * Prefer using SetNextWindowPos(), as this may incur tearing and side-effects.
      */
@@ -1257,7 +1264,7 @@ public class ImGui {
         ImGui::SetWindowPos(pos, cond);
     */
 
-    /**
+     /**
      * (not recommended) set current window size - call within Begin()/End(). set to ImVec2(0,0) to force an auto-fit.
      * Prefer using SetNextWindowSize(), as this may incur tearing and minor side-effects.
      */
@@ -1299,7 +1306,7 @@ public class ImGui {
         ImGui::SetWindowSize(size, cond);
     */
 
-    /**
+     /**
      * (not recommended) set current window collapsed state. prefer using SetNextWindowCollapsed().
      */
     public static void setWindowCollapsed(final boolean collapsed) {
@@ -1321,7 +1328,7 @@ public class ImGui {
         ImGui::SetWindowCollapsed(collapsed, cond);
     */
 
-    /**
+     /**
      * (not recommended) set current window to be focused / top-most. prefer using SetNextWindowFocus().
      */
     public static void setWindowFocus() {
@@ -1332,7 +1339,7 @@ public class ImGui {
         ImGui::SetWindowFocus();
     */
 
-    /**
+     /**
      * Set font scale. Adjust IO.FontGlobalScale if you want to scale all windows.
      * This is an old API! For correct scaling, prefer to reload font + rebuild ImFontAtlas + call style.ScaleAllSizes().
      */
@@ -1344,7 +1351,7 @@ public class ImGui {
         ImGui::SetWindowFontScale(scale);
     */
 
-    /**
+     /**
      * Set named window position.
      */
     public static void setWindowPos(final String name, final ImVec2 pos) {
@@ -1386,7 +1393,7 @@ public class ImGui {
         if (name != NULL) env->ReleaseStringUTFChars(obj_name, name);
     */
 
-    /**
+     /**
      * Set named window size. set axis to 0.0f to force an auto-fit on this axis.
      */
     public static void setWindowSize(final String name, final ImVec2 size) {
@@ -1428,7 +1435,7 @@ public class ImGui {
         if (name != NULL) env->ReleaseStringUTFChars(obj_name, name);
     */
 
-    /**
+     /**
      * Set named window collapsed state
      */
     public static void setWindowCollapsed(final String name, final boolean collapsed) {
@@ -1454,7 +1461,7 @@ public class ImGui {
         if (name != NULL) env->ReleaseStringUTFChars(obj_name, name);
     */
 
-    /**
+     /**
      * Set named window to be focused / top-most. Use NULL to remove focus.
      */
     public static void setWindowFocus(final String name) {
@@ -1471,7 +1478,7 @@ public class ImGui {
     // - Retrieve available space from a given point. GetContentRegionAvail() is frequently useful.
     // - Those functions are bound to be redesigned (they are confusing, incomplete and the Min/Max return values are in local window coordinates which increases confusion)
 
-    /**
+     /**
      * == GetContentRegionMax() - GetCursorPos()
      */
     public static ImVec2 getContentRegionAvail() {
@@ -1513,7 +1520,7 @@ public class ImGui {
         return ImGui::GetContentRegionAvail().y;
     */
 
-    /**
+     /**
      * Current content boundaries (typically window boundaries including scrolling, or current column boundaries), in windows coordinates
      */
     public static ImVec2 getContentRegionMax() {
@@ -1555,7 +1562,7 @@ public class ImGui {
         return ImGui::GetContentRegionMax().y;
     */
 
-    /**
+     /**
      * Content boundaries min for the full window (roughly (0,0)-Scroll), in window coordinates
      */
     public static ImVec2 getWindowContentRegionMin() {
@@ -1597,7 +1604,7 @@ public class ImGui {
         return ImGui::GetWindowContentRegionMin().y;
     */
 
-    /**
+     /**
      * Content boundaries max for the full window (roughly (0,0)+Size-Scroll) where Size can be override with SetNextWindowContentSize(), in window coordinates
      */
     public static ImVec2 getWindowContentRegionMax() {
@@ -1641,7 +1648,7 @@ public class ImGui {
 
     // Windows Scrolling
 
-    /**
+     /**
      * Get scrolling amount [0 .. GetScrollMaxX()]
      */
     public static float getScrollX() {
@@ -1652,7 +1659,7 @@ public class ImGui {
         return ImGui::GetScrollX();
     */
 
-    /**
+     /**
      * Get scrolling amount [0 .. GetScrollMaxY()]
      */
     public static float getScrollY() {
@@ -1663,7 +1670,7 @@ public class ImGui {
         return ImGui::GetScrollY();
     */
 
-    /**
+     /**
      * Set scrolling amount [0 .. GetScrollMaxX()]
      */
     public static void setScrollX(final float scrollX) {
@@ -1674,7 +1681,7 @@ public class ImGui {
         ImGui::SetScrollX(scrollX);
     */
 
-    /**
+     /**
      * Set scrolling amount [0..GetScrollMaxY()]
      */
     public static void setScrollY(final float scrollY) {
@@ -1685,7 +1692,7 @@ public class ImGui {
         ImGui::SetScrollY(scrollY);
     */
 
-    /**
+     /**
      * Get maximum scrolling amount ~~ ContentSize.x - WindowSize.x - DecorationsSize.x
      */
     public static float getScrollMaxX() {
@@ -1696,7 +1703,7 @@ public class ImGui {
         return ImGui::GetScrollMaxX();
     */
 
-    /**
+     /**
      * Get maximum scrolling amount ~~ ContentSize.y - WindowSize.y - DecorationsSize.y
      */
     public static float getScrollMaxY() {
@@ -1707,7 +1714,7 @@ public class ImGui {
         return ImGui::GetScrollMaxY();
     */
 
-    /**
+     /**
      * Adjust scrolling amount to make current cursor position visible. center_x_ratio=0.0: left, 0.5: center, 1.0: right.
      * When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
      */
@@ -1731,7 +1738,7 @@ public class ImGui {
         ImGui::SetScrollHereX(centerXRatio);
     */
 
-    /**
+     /**
      * Adjust scrolling amount to make current cursor position visible. center_y_ratio=0.0: top, 0.5: center, 1.0: bottom.
      * When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
      */
@@ -1755,7 +1762,7 @@ public class ImGui {
         ImGui::SetScrollHereY(centerYRatio);
     */
 
-    /**
+     /**
      * Adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
      */
     public static void setScrollFromPosX(final float localX) {
@@ -1777,7 +1784,7 @@ public class ImGui {
         ImGui::SetScrollFromPosX(localX, centerXRatio);
     */
 
-    /**
+     /**
      * Adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
      */
     public static void setScrollFromPosY(final float localY) {
@@ -1824,7 +1831,7 @@ public class ImGui {
         ImGui::PushStyleColor(imGuiCol, (ImU32)ImColor((int)r, (int)g, (int)b, (int)a));
     */
 
-    /**
+     /**
      * Modify a style color. always use this if you modify the style after NewFrame().
      */
     public static void pushStyleColor(final int imGuiCol, final ImVec4 col) {
@@ -1843,7 +1850,7 @@ public class ImGui {
         ImGui::PushStyleColor(imGuiCol, col);
     */
 
-    /**
+     /**
      * Modify a style color. always use this if you modify the style after NewFrame().
      */
     public static void pushStyleColor(final int imGuiCol, final int col) {
@@ -1870,7 +1877,7 @@ public class ImGui {
         ImGui::PopStyleColor(count);
     */
 
-    /**
+     /**
      * Modify a style float variable. always use this if you modify the style after NewFrame().
      */
     public static void pushStyleVar(final int imGuiStyleVar, final float val) {
@@ -1881,7 +1888,7 @@ public class ImGui {
         ImGui::PushStyleVar(imGuiStyleVar, val);
     */
 
-    /**
+     /**
      * Modify a style ImVec2 variable. always use this if you modify the style after NewFrame().
      */
     public static void pushStyleVar(final int imGuiStyleVar, final ImVec2 val) {
@@ -1916,7 +1923,7 @@ public class ImGui {
         ImGui::PopStyleVar(count);
     */
 
-    /**
+     /**
      * Allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets
      */
     public static void pushAllowKeyboardFocus(final boolean allowKeyboardFocus) {
@@ -1935,7 +1942,7 @@ public class ImGui {
         ImGui::PopAllowKeyboardFocus();
     */
 
-    /**
+     /**
      * In 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting).
      * Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.
      */
@@ -1957,7 +1964,7 @@ public class ImGui {
 
     // Parameters stacks (current window)
 
-    /**
+     /**
      * Push width of items for common large "item+label" widgets. {@code > 0.0f}: width in pixels,
      * {@code <0.0f} align xx pixels to the right of window (so -1.0f always align width to the right side).
      */
@@ -1977,7 +1984,7 @@ public class ImGui {
         ImGui::PopItemWidth();
     */
 
-    /**
+     /**
      * Set width of the _next_ common large "item+label" widget. {@code > 0.0f}: width in pixels,
      * {@code <0.0f} align xx pixels to the right of window (so -1.0f always align width to the right side)
      */
@@ -1989,7 +1996,7 @@ public class ImGui {
         ImGui::SetNextItemWidth(itemWidth);
     */
 
-    /**
+     /**
      * Width of item given pushed settings and current cursor position. NOT necessarily the width of last item unlike most 'Item' functions.
      */
     public static float calcItemWidth() {
@@ -2000,7 +2007,7 @@ public class ImGui {
         return ImGui::CalcItemWidth();
     */
 
-    /**
+     /**
      * Push Word-wrapping positions for Text*() commands. {@code < 0.0f}: no wrapping; 0.0f: wrap to end of window (or column); {@code > 0.0f}: wrap at
      * 'wrap_posX' position in window local space
      */
@@ -2034,7 +2041,7 @@ public class ImGui {
 
     // Style read access
 
-    private static final ImFont _GETFONT_1 = new ImFont(0);
+     private static final ImFont _GETFONT_1 = new ImFont(0);
 
     /**
      * Get current font.
@@ -2048,7 +2055,7 @@ public class ImGui {
         return (uintptr_t)ImGui::GetFont();
     */
 
-    /**
+     /**
      * Get current font size (= height in pixels) of current font with current scale applied
      */
     public static int getFontSize() {
@@ -2059,7 +2066,7 @@ public class ImGui {
         return ImGui::GetFontSize();
     */
 
-    /**
+     /**
      * Get UV coordinate for a while pixel, useful to draw custom shapes via the ImDrawList API
      */
     public static ImVec2 getFontTexUvWhitePixel() {
@@ -2101,7 +2108,7 @@ public class ImGui {
         return ImGui::GetFontTexUvWhitePixel().y;
     */
 
-    /**
+     /**
      * Retrieve given style color with style alpha applied and optional extra alpha multiplier, packed as a 32-bit value suitable for ImDrawList.
      */
     public static int getColorU32(final int idx) {
@@ -2123,7 +2130,7 @@ public class ImGui {
         return ImGui::GetColorU32(static_cast<ImGuiCol>(idx), alphaMul);
     */
 
-    /**
+     /**
      * Retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList.
      */
     public static int getColorU32(final ImVec4 col) {
@@ -2143,7 +2150,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList.
      */
     public static int getColorU32i(final int col) {
@@ -2154,7 +2161,7 @@ public class ImGui {
         return ImGui::GetColorU32(static_cast<ImU32>(col));
     */
 
-    /**
+     /**
      * Retrieve style color as stored in ImGuiStyle structure. use to feed back into PushStyleColor(),
      * otherwise use GetColorU32() to get style color with style alpha baked in.
      */
@@ -2232,7 +2239,7 @@ public class ImGui {
     //    Window-local coordinates:   SameLine(), GetCursorPos(), SetCursorPos(), GetCursorStartPos(), GetContentRegionMax(), GetWindowContentRegion*(), PushTextWrapPos()
     //    Absolute coordinate:        GetCursorScreenPos(), SetCursorScreenPos(), all ImDrawList:: functions.
 
-    /**
+     /**
      * Separator, generally horizontal. inside a menu bar or in horizontal layout mode, this becomes a vertical separator.
      */
     public static void separator() {
@@ -2243,7 +2250,7 @@ public class ImGui {
         ImGui::Separator();
     */
 
-    /**
+     /**
      * Call between widgets or groups to layout them horizontally. X position given in window coordinates.
      */
     public static void sameLine() {
@@ -2276,7 +2283,7 @@ public class ImGui {
         ImGui::SameLine(offsetFromStartX, spacing);
     */
 
-    /**
+     /**
      * Undo a SameLine() or force a new line when in an horizontal-layout context.
      */
     public static void newLine() {
@@ -2287,7 +2294,7 @@ public class ImGui {
         ImGui::NewLine();
     */
 
-    /**
+     /**
      * Add vertical spacing.
      */
     public static void spacing() {
@@ -2298,7 +2305,7 @@ public class ImGui {
         ImGui::Spacing();
     */
 
-    /**
+     /**
      * Add a dummy item of given size. unlike InvisibleButton(), Dummy() won't take the mouse click or be navigable into.
      */
     public static void dummy(final ImVec2 size) {
@@ -2317,7 +2324,7 @@ public class ImGui {
         ImGui::Dummy(size);
     */
 
-    /**
+     /**
      * Move content position toward the right, by indent_w, or style.IndentSpacing if indent_w {@code <= 0}.
      */
     public static void indent() {
@@ -2339,7 +2346,7 @@ public class ImGui {
         ImGui::Indent(indentW);
     */
 
-    /**
+     /**
      * Move content position back to the left, by indent_w, or style.IndentSpacing if indent_w {@code <= 0}.
      */
     public static void unindent() {
@@ -2361,7 +2368,7 @@ public class ImGui {
         ImGui::Unindent(indentW);
     */
 
-    /**
+     /**
      * Lock horizontal starting position
      */
     public static void beginGroup() {
@@ -2372,7 +2379,7 @@ public class ImGui {
         ImGui::BeginGroup();
     */
 
-    /**
+     /**
      * Unlock horizontal starting position + capture the whole group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
      */
     public static void endGroup() {
@@ -2388,7 +2395,7 @@ public class ImGui {
     //  are using the main, absolute coordinate system.
     //  GetWindowPos() + GetCursorPos() == GetCursorScreenPos() etc.)
 
-    /**
+     /**
      * Cursor position in window coordinates (relative to window position)
      */
     public static ImVec2 getCursorPos() {
@@ -2430,7 +2437,7 @@ public class ImGui {
         return ImGui::GetCursorPos().y;
     */
 
-    /**
+     /**
      * Cursor position in window coordinates (relative to window position)
      */
     public static void setCursorPos(final ImVec2 pos) {
@@ -2449,7 +2456,7 @@ public class ImGui {
         ImGui::SetCursorPos(pos);
     */
 
-    /**
+     /**
      * Cursor position in window coordinates (relative to window position)
      */
     public static void setCursorPosX(final float x) {
@@ -2460,7 +2467,7 @@ public class ImGui {
         ImGui::SetCursorPosX(x);
     */
 
-    /**
+     /**
      * Cursor position in window coordinates (relative to window position)
      */
     public static void setCursorPosY(final float y) {
@@ -2471,7 +2478,7 @@ public class ImGui {
         ImGui::SetCursorPosY(y);
     */
 
-    /**
+     /**
      * Initial cursor position in window coordinates
      */
     public static ImVec2 getCursorStartPos() {
@@ -2513,7 +2520,7 @@ public class ImGui {
         return ImGui::GetCursorStartPos().y;
     */
 
-    /**
+     /**
      * Cursor position in absolute coordinates (useful to work with ImDrawList API).
      * Generally top-left == GetMainViewport().Pos == (0,0) in single viewport mode,
      * and bottom-right == GetMainViewport().Pos+Size == io.DisplaySize in single-viewport mode.
@@ -2563,7 +2570,7 @@ public class ImGui {
         return ImGui::GetCursorScreenPos().y;
     */
 
-    /**
+     /**
      * Cursor position in absolute coordinates.
      */
     public static void setCursorScreenPos(final ImVec2 pos) {
@@ -2582,7 +2589,7 @@ public class ImGui {
         ImGui::SetCursorScreenPos(pos);
     */
 
-    /**
+     /**
      * Vertically align upcoming text baseline to FramePadding.y so that it will align properly to regularly framed items (call if you have text on a line before a framed item)
      */
     public static void alignTextToFramePadding() {
@@ -2593,7 +2600,7 @@ public class ImGui {
         ImGui::AlignTextToFramePadding();
     */
 
-    /**
+     /**
      * ~ FontSize
      */
     public static float getTextLineHeight() {
@@ -2604,7 +2611,7 @@ public class ImGui {
         return ImGui::GetTextLineHeight();
     */
 
-    /**
+     /**
      * ~ FontSize + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of text)
      */
     public static float getTextLineHeightWithSpacing() {
@@ -2615,7 +2622,7 @@ public class ImGui {
         return ImGui::GetTextLineHeightWithSpacing();
     */
 
-    /**
+     /**
      * ~ FontSize + style.FramePadding.y * 2
      */
     public static float getFrameHeight() {
@@ -2626,7 +2633,7 @@ public class ImGui {
         return ImGui::GetFrameHeight();
     */
 
-    /**
+     /**
      * ~ FontSize + style.FramePadding.y * 2 + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of framed widgets)
      */
     public static float getFrameHeightWithSpacing() {
@@ -2645,7 +2652,7 @@ public class ImGui {
     // - In this header file we use the "label"/"name" terminology to denote a string that will be displayed and used as an ID,
     //   whereas "strId" denote a string that is only used as an ID and not normally displayed.
 
-    /**
+     /**
      * Push string into the ID stack (will hash string).
      */
     public static void pushID(final String strId) {
@@ -2658,7 +2665,7 @@ public class ImGui {
         if (strId != NULL) env->ReleaseStringUTFChars(obj_strId, strId);
     */
 
-    /**
+     /**
      * Push string into the ID stack (will hash string).
      */
     public static void pushID(final String strIdBegin, final String strIdEnd) {
@@ -2673,7 +2680,7 @@ public class ImGui {
         if (strIdEnd != NULL) env->ReleaseStringUTFChars(obj_strIdEnd, strIdEnd);
     */
 
-    /**
+     /**
      * Push pointer into the ID stack (will hash pointer).
      */
     public static void pushID(final long ptrId) {
@@ -2684,7 +2691,7 @@ public class ImGui {
         ImGui::PushID((void*)ptrId);
     */
 
-    /**
+     /**
      * Push integer into the ID stack (will hash integer).
      */
     public static void pushID(final int intId) {
@@ -2695,7 +2702,7 @@ public class ImGui {
         ImGui::PushID(intId);
     */
 
-    /**
+     /**
      * Pop from the ID stack.
      */
     public static void popID() {
@@ -2706,7 +2713,7 @@ public class ImGui {
         ImGui::PopID();
     */
 
-    /**
+     /**
      * Calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
      */
     public static int getID(final String strId) {
@@ -2720,7 +2727,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
      */
     public static int getID(final String strIdBegin, final String strIdEnd) {
@@ -2736,7 +2743,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
      */
     public static int getID(final long ptrId) {
@@ -2749,7 +2756,7 @@ public class ImGui {
 
     // Widgets: Text
 
-    /**
+     /**
      * Raw text without formatting. Roughly equivalent to Text("%s", text) but:
      * A) doesn't require null terminated string if 'textEnd' is specified,
      * B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text.
@@ -2781,7 +2788,7 @@ public class ImGui {
         if (textEnd != NULL) env->ReleaseStringUTFChars(obj_textEnd, textEnd);
     */
 
-    /**
+     /**
      * Formatted text
      */
     public static void text(final String text) {
@@ -2794,7 +2801,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
      */
     public static void textColored(final ImVec4 col, final String text) {
@@ -2829,7 +2836,7 @@ public class ImGui {
         ImGui::TextColored(ImColor(col), text, NULL);
     */
 
-    /**
+     /**
      * Shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
      */
     public static void textDisabled(final String text) {
@@ -2842,7 +2849,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();.
      * Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width,
      * yoy may need to set a size using SetNextWindowSize().
@@ -2857,7 +2864,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Display text+label aligned the same way as value+label widgets
      */
     public static void labelText(final String label, final String text) {
@@ -2872,7 +2879,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Shortcut for Bullet()+Text()
      */
     public static void bulletText(final String text) {
@@ -2889,7 +2896,7 @@ public class ImGui {
     // - Most widgets return true when the value has been changed or when pressed/selected
     // - You may also use one of the many IsItemXXX functions (e.g. IsItemActive, IsItemHovered, etc.) to query widget state.
 
-    /**
+     /**
      * Button
      */
     public static boolean button(final String label) {
@@ -2925,7 +2932,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Button with FramePadding=(0,0) to easily embed within text
      */
     public static boolean smallButton(final String label) {
@@ -2939,7 +2946,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
      */
     public static boolean invisibleButton(final String strId, final ImVec2 size) {
@@ -2983,7 +2990,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Square button with an arrow shape
      */
     public static boolean arrowButton(final String strId, final int dir) {
@@ -3072,7 +3079,7 @@ public class ImGui {
         ImGui::Image((ImTextureID)(uintptr_t)userTextureId, size, uv0, uv1, tintCol, borderCol);
     */
 
-    /**
+     /**
      * {@code <0} framePadding uses default frame padding settings. 0 for no padding
      */
     public static boolean imageButton(final long userTextureId, final ImVec2 size) {
@@ -3263,7 +3270,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Use with e.g. if (RadioButton("one", my_value==1)) { my_value = 1; }
      */
     public static boolean radioButton(final String label, final boolean active) {
@@ -3277,7 +3284,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Shortcut to handle the above pattern when value is an integer
      */
     public static boolean radioButton(final String label, final ImInt v, final int vButton) {
@@ -3339,7 +3346,7 @@ public class ImGui {
         if (overlay != NULL) env->ReleaseStringUTFChars(obj_overlay, overlay);
     */
 
-    /**
+     /**
      * Draw a small circle + keep the cursor on the same line. advance cursor x position by GetTreeNodeToLabelSpacing(), same distance that TreeNode() uses
      */
     public static void bullet() {
@@ -3380,7 +3387,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndCombo() if BeginCombo() returns true!
      */
     public static void endCombo() {
@@ -3437,7 +3444,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
      */
     public static boolean combo(final String label, final ImInt currentItem, final String itemsSeparatedByZeros) {
@@ -3486,7 +3493,7 @@ public class ImGui {
     // - Legacy: Pre-1.78 there are DragXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument.
     //   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361
 
-    /**
+     /**
      * If {@code vMin >= vMax} we have no bound
      */
     public static boolean dragFloat(final String label, final float[] v) {
@@ -3987,7 +3994,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * If {@code vMin >= vMax} we have no bound
      */
     public static boolean dragInt(final String label, final int[] v) {
@@ -5330,7 +5337,7 @@ public class ImGui {
     // - Legacy: Pre-1.78 there are SliderXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument.
     //   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361
 
-    /**
+     /**
      * Adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display.
      */
     public static boolean sliderFloat(final String label, final float[] v, final float vMin, final float vMax) {
@@ -8917,7 +8924,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Display a colored square/button, hover for details, return true when pressed.
      */
     public static boolean colorButton(final String descId, final ImVec4 col) {
@@ -9007,7 +9014,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Display a colored square/button, hover for details, return true when pressed.
      *
      * @deprecated use {@link #colorButton(String, ImVec4)} or {@link #colorButton(String, float, float, float, float)} instead
@@ -9105,7 +9112,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Initialize current options (generally on application startup) if you want to select a default format,
      * picker type, etc. User will be able to change many settings, unless you pass the _NoOptions flag to your calls.
      */
@@ -9131,7 +9138,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Helper variation to easily decorelate the id from the displayed string.
      * Read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use Bullet().
      */
@@ -9205,7 +9212,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * ~ Indent()+PushId(). Already called by TreeNode() when returning true, but you can call TreePush/TreePop yourself if desired.
      */
     public static void treePush(final String strId) {
@@ -9218,7 +9225,7 @@ public class ImGui {
         if (strId != NULL) env->ReleaseStringUTFChars(obj_strId, strId);
     */
 
-    /**
+     /**
      * ~ Indent()+PushId(). Already called by TreeNode() when returning true, but you can call TreePush/TreePop yourself if desired.
      */
     public static void treePush() {
@@ -9240,7 +9247,7 @@ public class ImGui {
         ImGui::TreePush((void*)ptrId);
     */
 
-    /**
+     /**
      * ~ Unindent()+PopId()
      */
     public static void treePop() {
@@ -9251,7 +9258,7 @@ public class ImGui {
         ImGui::TreePop();
     */
 
-    /**
+     /**
      * Horizontal distance preceding label when using TreeNode*() or Bullet() == (g.FontSize + style.FramePadding.x*2) for a regular unframed TreeNode
      */
     public static float getTreeNodeToLabelSpacing() {
@@ -9262,7 +9269,7 @@ public class ImGui {
         return ImGui::GetTreeNodeToLabelSpacing();
     */
 
-    /**
+     /**
      * If returning 'true' the header is open. doesn't indent nor push on ID stack. user doesn't have to call TreePop().
      */
     public static boolean collapsingHeader(final String label) {
@@ -9290,7 +9297,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * When 'p_visible != NULL': if '*p_visible==true' display an additional small close button on upper right of the header which will set the bool
      * to false when clicked, if '*p_visible==false' don't display the header.
      */
@@ -9324,7 +9331,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Set next TreeNode/CollapsingHeader open state.
      */
     public static void setNextItemOpen(final boolean isOpen) {
@@ -9516,7 +9523,7 @@ public class ImGui {
     // - Choose frame width:   size.x > 0.0f: custom  /  size.x < 0.0f or -FLT_MIN: right-align   /  size.x = 0.0f (default): use current ItemWidth
     // - Choose frame height:  size.y > 0.0f: custom  /  size.y < 0.0f or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items
 
-    /**
+     /**
      * Open a framed scrolling region.
      */
     public static boolean beginListBox(final String label) {
@@ -9552,7 +9559,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndListBox() if BeginListBox() returned true!
      */
     public static void endListBox() {
@@ -9972,7 +9979,7 @@ public class ImGui {
     // - Use BeginMainMenuBar() to create a menu bar at the top of the screen and append to it.
     // - Use BeginMenu() to create a menu. You can call BeginMenu() multiple time with the same identifier to append more items to it.
 
-    /**
+     /**
      * Append to menu-bar of current window (requires ImGuiWindowFlags_MenuBar flag set on parent window).
      */
     public static boolean beginMenuBar() {
@@ -9983,7 +9990,7 @@ public class ImGui {
         return ImGui::BeginMenuBar();
     */
 
-    /**
+     /**
      * Only call EndMenuBar() if BeginMenuBar() returns true!
      */
     public static void endMenuBar() {
@@ -9994,7 +10001,7 @@ public class ImGui {
         ImGui::EndMenuBar();
     */
 
-    /**
+     /**
      * Create and append to a full screen menu-bar.
      */
     public static boolean beginMainMenuBar() {
@@ -10005,7 +10012,7 @@ public class ImGui {
         return ImGui::BeginMainMenuBar();
     */
 
-    /**
+     /**
      * Only call EndMainMenuBar() if BeginMainMenuBar() returns true!
      */
     public static void endMainMenuBar() {
@@ -10016,7 +10023,7 @@ public class ImGui {
         ImGui::EndMainMenuBar();
     */
 
-    /**
+     /**
      * Create a sub-menu entry. only call EndMenu() if this returns true!
      */
     public static boolean beginMenu(final String label) {
@@ -10044,7 +10051,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndMenu() if BeginMenu() returns true!
      */
     public static void endMenu() {
@@ -10055,7 +10062,7 @@ public class ImGui {
         ImGui::EndMenu();
     */
 
-    /**
+     /**
      * Return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
      */
     public static boolean menuItem(final String label) {
@@ -10097,7 +10104,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
      */
     public static boolean menuItem(final String label, final String shortcut) {
@@ -10145,7 +10152,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Return true when activated + toggle (*pSelected) if pSelected != NULL
      */
     public static boolean menuItem(final String label, final String shortcut, final ImBoolean pSelected) {
@@ -10184,7 +10191,7 @@ public class ImGui {
     // Tooltips
     // - Tooltip are windows following the mouse. They do not take focus away.
 
-    /**
+     /**
      * Begin/append a tooltip window. to create full-featured tooltip (with any kind of items).
      */
     public static void beginTooltip() {
@@ -10203,7 +10210,7 @@ public class ImGui {
         ImGui::EndTooltip();
     */
 
-    /**
+     /**
      * Set a text-only tooltip, typically use with ImGui::IsItemHovered(). override any previous call to SetTooltip().
      */
     public static void setTooltip(final String text) {
@@ -10228,7 +10235,7 @@ public class ImGui {
     //  - BeginPopup(): query popup state, if open start appending into the window. Call EndPopup() afterwards. ImGuiWindowFlags are forwarded to the window.
     //  - BeginPopupModal(): block every interactions behind the window, cannot be closed by user, add a dimming background, has a title bar.
 
-    /**
+     /**
      * Return true if the popup is open, and you can start outputting to it.
      */
     public static boolean beginPopup(final String strId) {
@@ -10256,7 +10263,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Return true if the popup is open, and you can start outputting to it.
      */
     public static boolean beginPopupModal(final String name) {
@@ -10316,7 +10323,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndPopup() if BeginPopupXXX() returns true!
      */
     public static void endPopup() {
@@ -10334,7 +10341,7 @@ public class ImGui {
     //  - CloseCurrentPopup() is called by default by Selectable()/MenuItem() when activated (FIXME: need some options).
     //  - Use ImGuiPopupFlags_NoOpenOverExistingPopup to avoid opening a popup if there's already one at the same level. This is equivalent to e.g. testing for !IsAnyPopupOpen() prior to OpenPopup().
 
-    /**
+     /**
      * Call to mark popup as open (don't call every frame!).
      */
     public static void openPopup(final String strId) {
@@ -10360,7 +10367,7 @@ public class ImGui {
         if (strId != NULL) env->ReleaseStringUTFChars(obj_strId, strId);
     */
 
-    /**
+     /**
      * Id overload to facilitate calling from nested stacks.
      */
     public static void openPopup(final int id) {
@@ -10382,7 +10389,7 @@ public class ImGui {
         ImGui::OpenPopup((ImGuiID)id, imGuiPopupFlags);
     */
 
-    /**
+     /**
      * Helper to open popup when clicked on last item. return true when just opened. (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
      */
     public static void openPopupOnItemClick() {
@@ -10430,7 +10437,7 @@ public class ImGui {
         ImGui::OpenPopupOnItemClick(NULL, imGuiPopupFlags);
     */
 
-    /**
+     /**
      * Manually close the popup we have begin-ed into.
      */
     public static void closeCurrentPopup() {
@@ -10447,7 +10454,7 @@ public class ImGui {
     //  - IMPORTANT: Notice that BeginPopupContextXXX takes ImGuiPopupFlags just like OpenPopup() and unlike BeginPopup(). For full consistency, we may add ImGuiWindowFlags to the BeginPopupContextXXX functions in the future.
     //  - IMPORTANT: we exceptionally default their flags to 1 (== ImGuiPopupFlags_MouseButtonRight) for backward compatibility with older API taking 'int mouse_button = 1' parameter, so if you add other flags remember to re-add the ImGuiPopupFlags_MouseButtonRight.
 
-    /**
+     /**
      * Open+begin popup when clicked on last item. if you can pass a NULL str_id only if the previous item had an id.
      * If you want to use that on a non-interactive item such as Text() you need to pass in an explicit ID here. read comments in .cpp!
      */
@@ -10501,7 +10508,7 @@ public class ImGui {
         return ImGui::BeginPopupContextItem(NULL, imGuiPopupFlags);
     */
 
-    /**
+     /**
      * Open+begin popup when clicked on current window.
      */
     public static boolean beginPopupContextWindow() {
@@ -10551,7 +10558,7 @@ public class ImGui {
         return ImGui::BeginPopupContextWindow(NULL, imGuiPopupFlags);
     */
 
-    /**
+     /**
      * Open+begin popup when clicked in void (where there are no windows).
      */
     public static boolean beginPopupContextVoid() {
@@ -10606,7 +10613,7 @@ public class ImGui {
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId: return true if any popup is open at the current BeginPopup() level of the popup stack.
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId + ImGuiPopupFlags_AnyPopupLevel: return true if any popup is open.
 
-    /**
+     /**
      * Return true if the popup is open.
      */
     public static boolean isPopupOpen(final String strId) {
@@ -10752,7 +10759,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndTable() if BeginTable() returns true!
      */
     public static void endTable() {
@@ -10763,7 +10770,7 @@ public class ImGui {
         ImGui::EndTable();
     */
 
-    /**
+     /**
      * Append into the first cell of a new row.
      */
     public static void tableNextRow() {
@@ -10807,7 +10814,7 @@ public class ImGui {
         ImGui::TableNextRow(0, minRowHeight);
     */
 
-    /**
+     /**
      * Append into the next column (or first column of next row if currently in last column). Return true when column is visible.
      */
     public static boolean tableNextColumn() {
@@ -10818,7 +10825,7 @@ public class ImGui {
         return ImGui::TableNextColumn();
     */
 
-    /**
+     /**
      * Append into the specified column. Return true when column is visible.
      */
     public static boolean tableSetColumnIndex(final int columnN) {
@@ -10898,7 +10905,7 @@ public class ImGui {
         if (label != NULL) env->ReleaseStringUTFChars(obj_label, label);
     */
 
-    /**
+     /**
      * Lock columns/rows so they stay visible when scrolled.
      */
     public static void tableSetupScrollFreeze(final int cols, final int rows) {
@@ -10909,7 +10916,7 @@ public class ImGui {
         ImGui::TableSetupScrollFreeze(cols, rows);
     */
 
-    /**
+     /**
      * Submit all headers cells based on data provided to TableSetupColumn() + submit context menu
      */
     public static void tableHeadersRow() {
@@ -10920,7 +10927,7 @@ public class ImGui {
         ImGui::TableHeadersRow();
     */
 
-    /**
+     /**
      * Submit one header cell manually (rarely used)
      */
     public static void tableHeader(final String label) {
@@ -10951,7 +10958,7 @@ public class ImGui {
     // Tables: Miscellaneous functions
     // - Functions args 'int column_n' treat the default value of -1 as the same as passing the current column index.
 
-    /**
+     /**
      * Return number of columns (value passed to BeginTable).
      */
     public static int tableGetColumnCount() {
@@ -10962,7 +10969,7 @@ public class ImGui {
         return ImGui::TableGetColumnCount();
     */
 
-    /**
+     /**
      * Return current column index.
      */
     public static int tableGetColumnIndex() {
@@ -10973,7 +10980,7 @@ public class ImGui {
         return ImGui::TableGetColumnIndex();
     */
 
-    /**
+     /**
      * Return current row index.
      */
     public static int tableGetRowIndex() {
@@ -10984,7 +10991,7 @@ public class ImGui {
         return ImGui::TableGetRowIndex();
     */
 
-    /**
+     /**
      * Return "" if column didn't have a name declared by TableSetupColumn(). Pass -1 to use current column.
      */
     public static String tableGetColumnName() {
@@ -11006,7 +11013,7 @@ public class ImGui {
         return env->NewStringUTF(ImGui::TableGetColumnName(columnN));
     */
 
-    /**
+     /**
      * Return column flags, so you can query their Enabled/Visible/Sorted/Hovered status flags. Pass -1 to use current column.
      */
     public static int tableGetColumnFlags() {
@@ -11028,7 +11035,7 @@ public class ImGui {
         return ImGui::TableGetColumnFlags(columnN);
     */
 
-    /**
+     /**
      * change user accessible enabled/disabled state of a column. Set to false to hide the column.
      * User can use the context menu to change this themselves (right-click in headers, or right-click in columns body with ImGuiTableFlags_ContextMenuInBody)
      */
@@ -11040,7 +11047,7 @@ public class ImGui {
         ImGui::TableSetColumnEnabled(columnN, value);
     */
 
-    /**
+     /**
      * Change the color of a cell, row, or column. See ImGuiTableBgTarget_ flags for details.
      */
     public static void tableSetBgColor(final int imGuiTableBgTarget, final int color) {
@@ -11128,7 +11135,7 @@ public class ImGui {
         ImGui::Columns(count, NULL, border);
     */
 
-    /**
+     /**
      * Next column, defaults to current row or next row if the current row is finished
      */
     public static void nextColumn() {
@@ -11139,7 +11146,7 @@ public class ImGui {
         ImGui::NextColumn();
     */
 
-    /**
+     /**
      * Get current column index
      */
     public static int getColumnIndex() {
@@ -11150,7 +11157,7 @@ public class ImGui {
         return ImGui::GetColumnIndex();
     */
 
-    /**
+     /**
      * Get column width (in pixels). pass -1 to use current column
      */
     public static float getColumnWidth() {
@@ -11172,7 +11179,7 @@ public class ImGui {
         return ImGui::GetColumnWidth(columnIndex);
     */
 
-    /**
+     /**
      * Set column width (in pixels). pass -1 to use current column
      */
     public static void setColumnWidth(final int columnIndex, final float width) {
@@ -11183,7 +11190,7 @@ public class ImGui {
         ImGui::SetColumnWidth(columnIndex, width);
     */
 
-    /**
+     /**
      * Get position of column line (in pixels, from the left side of the contents region). pass -1 to use current column, otherwise 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
      */
     public static float getColumnOffset() {
@@ -11205,7 +11212,7 @@ public class ImGui {
         return ImGui::GetColumnOffset(columnIndex);
     */
 
-    /**
+     /**
      * Set position of column line (in pixels, from the left side of the contents region). pass -1 to use current column
      */
     public static void setColumnOffset(final int columnIndex, final float offsetX) {
@@ -11227,7 +11234,7 @@ public class ImGui {
     // Tab Bars, Tabs
     // Note: Tabs are automatically created by the docking system. Use this to create tab bars/tabs yourself without docking being involved.
 
-    /**
+     /**
      * Create and append into a TabBar
      */
     public static boolean beginTabBar(final String strId) {
@@ -11255,7 +11262,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndTabBar() if BeginTabBar() returns true!
      */
     public static void endTabBar() {
@@ -11266,7 +11273,7 @@ public class ImGui {
         ImGui::EndTabBar();
     */
 
-    /**
+     /**
      * Create a Tab. Returns true if the Tab is selected.
      */
     public static boolean beginTabItem(final String label) {
@@ -11326,7 +11333,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndTabItem() if BeginTabItem() returns true!
      */
     public static void endTabItem() {
@@ -11337,7 +11344,7 @@ public class ImGui {
         ImGui::EndTabItem();
     */
 
-    /**
+     /**
      * Create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
      */
     public static boolean tabItemButton(final String label) {
@@ -11365,7 +11372,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars).
      * For tab-bar: call after BeginTabBar() and before Tab submissions. Otherwise call with a window name.
      */
@@ -11508,7 +11515,7 @@ public class ImGui {
         return ImGui::DockSpaceOverViewport(reinterpret_cast<ImGuiViewport*>(viewport), 0, reinterpret_cast<ImGuiWindowClass*>(windowClass));
     */
 
-    /**
+     /**
      * Set next window dock id
      */
     public static void setNextWindowDockID(final int dockId) {
@@ -11530,7 +11537,7 @@ public class ImGui {
         ImGui::SetNextWindowDockID(dockId, imGuiCond);
     */
 
-    /**
+     /**
      * set next window class (rare/advanced uses: provide hints to the platform backend via altered viewport flags and parent/child info)
      */
     public static void setNextWindowClass(final ImGuiWindowClass windowClass) {
@@ -11549,7 +11556,7 @@ public class ImGui {
         return ImGui::GetWindowDockID();
     */
 
-    /**
+     /**
      * Is current window docked into another window?
      */
     public static boolean isWindowDocked() {
@@ -11563,7 +11570,7 @@ public class ImGui {
     // Logging/Capture
     // - All text output from the interface can be captured into tty/file/clipboard. By default, tree nodes are automatically opened during logging.
 
-    /**
+     /**
      * Start logging to tty (stdout)
      */
     public static void logToTTY() {
@@ -11585,7 +11592,7 @@ public class ImGui {
         ImGui::LogToTTY(autoOpenDepth);
     */
 
-    /**
+     /**
      * Start logging to file
      */
     public static void logToFile() {
@@ -11633,7 +11640,7 @@ public class ImGui {
         if (filename != NULL) env->ReleaseStringUTFChars(obj_filename, filename);
     */
 
-    /**
+     /**
      * Start logging to OS clipboard
      */
     public static void logToClipboard() {
@@ -11655,7 +11662,7 @@ public class ImGui {
         ImGui::LogToClipboard(autoOpenDepth);
     */
 
-    /**
+     /**
      * Stop logging (close file, etc.)
      */
     public static void logFinish() {
@@ -11666,7 +11673,7 @@ public class ImGui {
         ImGui::LogFinish();
     */
 
-    /**
+     /**
      * Helper to display buttons for logging to tty/file/clipboard
      */
     public static void logButtons() {
@@ -11677,7 +11684,7 @@ public class ImGui {
         ImGui::LogButtons();
     */
 
-    /**
+     /**
      * Pass text data straight to log (without being displayed)
      */
     public static void logText(final String text) {
@@ -11693,7 +11700,7 @@ public class ImGui {
     // Drag and Drop
     // - If you stop calling BeginDragDropSource() the payload is preserved however it won't have a preview tooltip (we currently display a fallback "..." tooltip as replacement)
 
-    /**
+     /**
      * Call when the current item is active. If this return true, you can call SetDragDropPayload() + EndDragDropSource()
      */
     public static boolean beginDragDropSource() {
@@ -11761,7 +11768,7 @@ public class ImGui {
         return ImGui::SetDragDropPayload(dataType, &data[0], sz, imGuiCond);
     */
 
-    /**
+     /**
      * Only call EndDragDropSource() if BeginDragDropSource() returns true!
      */
     public static void endDragDropSource() {
@@ -11772,7 +11779,7 @@ public class ImGui {
         ImGui::EndDragDropSource();
     */
 
-    /**
+     /**
      * Call after submitting an item that may receive a payload. If this returns true, you can call AcceptDragDropPayload() + EndDragDropTarget()
      */
     public static boolean beginDragDropTarget() {
@@ -11838,7 +11845,7 @@ public class ImGui {
         return ImGui::AcceptDragDropPayload(dataType, imGuiDragDropFlags) != NULL;
     */
 
-    /**
+     /**
      * Only call EndDragDropTarget() if BeginDragDropTarget() returns true!
      */
     public static void endDragDropTarget() {
@@ -11894,7 +11901,7 @@ public class ImGui {
         return payload != NULL && payload->IsDataType(dataType);
     */
 
-    /**
+     /**
      * Disable all user interactions and dim items visuals (applying style.DisabledAlpha over current colors)
      * BeginDisabled(false) essentially does nothing useful but is provided to facilitate use of boolean expressions.
      * If you can avoid calling BeginDisabled(False)/EndDisabled() best to avoid it.
@@ -11956,7 +11963,7 @@ public class ImGui {
     // Focus, Activation
     // - Prefer using "SetItemDefaultFocus()" over "if (IsWindowAppearing()) SetScrollHereY()" when applicable to signify "this is the default item"
 
-    /**
+     /**
      * Make last item the default focused item of a window.
      */
     public static void setItemDefaultFocus() {
@@ -11967,7 +11974,7 @@ public class ImGui {
         ImGui::SetItemDefaultFocus();
     */
 
-    /**
+     /**
      * Focus keyboard on the next widget. Use positive 'offset' to access sub components of a multiple component widget. Use -1 to access previous widget.
      */
     public static void setKeyboardFocusHere() {
@@ -11993,7 +12000,7 @@ public class ImGui {
     // - Most of the functions are referring to the last/previous item we submitted.
     // - See Demo Window under "Widgets->Querying Status" for an interactive visualization of most of those functions.
 
-    /**
+     /**
      * Is the last item hovered? (and usable, aka not blocked by a popup, etc.). See ImGuiHoveredFlags for more options.
      */
     public static boolean isItemHovered() {
@@ -12015,7 +12022,7 @@ public class ImGui {
         return ImGui::IsItemHovered(imGuiHoveredFlags);
     */
 
-    /**
+     /**
      * Is the last item active? (e.g. button being held, text field being edited.
      * This will continuously return true while holding mouse button on an item.
      * Items that don't interact will always return false)
@@ -12028,7 +12035,7 @@ public class ImGui {
         return ImGui::IsItemActive();
     */
 
-    /**
+     /**
      * Is the last item focused for keyboard/gamepad navigation?
      */
     public static boolean isItemFocused() {
@@ -12039,7 +12046,7 @@ public class ImGui {
         return ImGui::IsItemFocused();
     */
 
-    /**
+     /**
      * Is the last item clicked? (e.g. button/node just clicked on) == {@code IsMouseClicked(mouseButton) && IsItemHovered()}
      */
     public static boolean isItemClicked() {
@@ -12061,7 +12068,7 @@ public class ImGui {
         return ImGui::IsItemClicked(mouseButton);
     */
 
-    /**
+     /**
      * Is the last item visible? (items may be out of sight because of clipping/scrolling)
      */
     public static boolean isItemVisible() {
@@ -12072,7 +12079,7 @@ public class ImGui {
         return ImGui::IsItemVisible();
     */
 
-    /**
+     /**
      * Did the last item modify its underlying value this frame? or was pressed? This is generally the same as the "bool" return value of many widgets.
      */
     public static boolean isItemEdited() {
@@ -12083,7 +12090,7 @@ public class ImGui {
         return ImGui::IsItemEdited();
     */
 
-    /**
+     /**
      * Was the last item just made active (item was previously inactive).
      */
     public static boolean isItemActivated() {
@@ -12094,7 +12101,7 @@ public class ImGui {
         return ImGui::IsItemActivated();
     */
 
-    /**
+     /**
      * Was the last item just made inactive (item was previously active). Useful for Undo/Redo patterns with widgets that requires continuous editing.
      */
     public static boolean isItemDeactivated() {
@@ -12105,7 +12112,7 @@ public class ImGui {
         return ImGui::IsItemDeactivated();
     */
 
-    /**
+     /**
      * Was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved).
      * Useful for Undo/Redo patterns with widgets that requires continuous editing.
      * Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
@@ -12118,7 +12125,7 @@ public class ImGui {
         return ImGui::IsItemDeactivatedAfterEdit();
     */
 
-    /**
+     /**
      * Was the last item open state toggled? set by TreeNode().
      */
     public static boolean isItemToggledOpen() {
@@ -12129,7 +12136,7 @@ public class ImGui {
         return ImGui::IsItemToggledOpen();
     */
 
-    /**
+     /**
      * Is any item hovered?
      */
     public static boolean isAnyItemHovered() {
@@ -12140,7 +12147,7 @@ public class ImGui {
         return ImGui::IsAnyItemHovered();
     */
 
-    /**
+     /**
      * Is any item active?
      */
     public static boolean isAnyItemActive() {
@@ -12150,7 +12157,7 @@ public class ImGui {
     private static native boolean nIsAnyItemActive(); /*
         return ImGui::IsAnyItemActive();
     */
-    /**
+     /**
      * Is any item focused?
      */
     public static boolean isAnyItemFocused() {
@@ -12161,7 +12168,7 @@ public class ImGui {
         return ImGui::IsAnyItemFocused();
     */
 
-    /**
+     /**
      * Get upper-left bounding rectangle of the last item (screen space)
      */
     public static ImVec2 getItemRectMin() {
@@ -12203,7 +12210,7 @@ public class ImGui {
         return ImGui::GetItemRectMin().y;
     */
 
-    /**
+     /**
      * Get lower-right bounding rectangle of the last item (screen space)
      */
     public static ImVec2 getItemRectMax() {
@@ -12245,7 +12252,7 @@ public class ImGui {
         return ImGui::GetItemRectMax().y;
     */
 
-    /**
+     /**
      * Get size of last item
      */
     public static ImVec2 getItemRectSize() {
@@ -12287,7 +12294,7 @@ public class ImGui {
         return ImGui::GetItemRectSize().y;
     */
 
-    /**
+     /**
      * Allow last item to be overlapped by a subsequent item. sometimes useful with invisible buttons, selectables, etc. to catch unused area.
      */
     public static void setItemAllowOverlap() {
@@ -12303,7 +12310,7 @@ public class ImGui {
     // - In 'docking' branch with multi-viewport enabled, we extend this concept to have multiple active viewports.
     // - In the future we will extend this concept further to also represent Platform Monitor and support a "no main platform window" operation mode.
 
-    private static final ImGuiViewport _GETMAINVIEWPORT_1 = new ImGuiViewport(0);
+     private static final ImGuiViewport _GETMAINVIEWPORT_1 = new ImGuiViewport(0);
 
     /**
      * Return primary/default viewport.
@@ -12319,7 +12326,7 @@ public class ImGui {
 
     // Miscellaneous Utilities
 
-    /**
+     /**
      * Test if rectangle (of given size, starting from cursor position) is visible / not clipped.
      */
     public static boolean isRectVisible(final ImVec2 size) {
@@ -12339,7 +12346,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Test if rectangle (in screen space) is visible / not clipped. to perform coarse clipping on user's side.
      */
     public static boolean isRectVisible(final ImVec2 rectMin, final ImVec2 rectMax) {
@@ -12360,7 +12367,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Get global imgui time. incremented by io.DeltaTime every frame.
      */
     public static double getTime() {
@@ -12371,7 +12378,7 @@ public class ImGui {
         return ImGui::GetTime();
     */
 
-    /**
+     /**
      * Get global imgui frame count. incremented by 1 every frame.
      */
     public static int getFrameCount() {
@@ -12382,7 +12389,7 @@ public class ImGui {
         return ImGui::GetFrameCount();
     */
 
-    /**
+     /**
      * Get background draw list for the viewport associated to the current window.
      * This draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
      */
@@ -12406,7 +12413,7 @@ public class ImGui {
         return (uintptr_t)ImGui::GetBackgroundDrawList(reinterpret_cast<ImGuiViewport*>(viewport));
     */
 
-    /**
+     /**
      * Get foreground draw list for the viewport associated to the current window.
      * This draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
      */
@@ -12432,7 +12439,7 @@ public class ImGui {
 
     // TODO GetDrawListSharedData
 
-    /**
+     /**
      * Get a string corresponding to the enum value (for display, saving, etc.).
      */
     public static String getStyleColorName(final int imGuiColIdx) {
@@ -12443,7 +12450,7 @@ public class ImGui {
         return env->NewStringUTF(ImGui::GetStyleColorName(imGuiColIdx));
     */
 
-    /**
+     /**
      * Replace current window storage with our own (if you want to manipulate it yourself, typically clear subsection of it).
      */
     public static void setStateStorage(final ImGuiStorage storage) {
@@ -12462,7 +12469,7 @@ public class ImGui {
         return (uintptr_t)ImGui::GetStateStorage();
     */
 
-    /**
+     /**
      * Helper to create a child window / scrolling region that looks like a normal widget frame
      */
     public static boolean beginChildFrame(final int id, final ImVec2 size) {
@@ -12502,7 +12509,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Always call EndChildFrame() regardless of BeginChildFrame() return values (which indicates a collapsed/clipped window)
      */
     public static void endChildFrame() {
@@ -12752,7 +12759,7 @@ public class ImGui {
     //   - Any use of 'ImGuiKey' will assert when key < 512 will be passed, previously reserved as native/user keys indices
     //   - GetKeyIndex() is pass-through and therefore deprecated (gone if IMGUI_DISABLE_OBSOLETE_KEYIO is defined)
 
-    /**
+     /**
      * Map ImGuiKey_* values into user's key index. == io.KeyMap[key]
      */
     @Deprecated
@@ -12764,7 +12771,7 @@ public class ImGui {
         return ImGui::GetKeyIndex(static_cast<ImGuiKey>(key));
     */
 
-    /**
+     /**
      * Is key being held. == io.KeysDown[user_key_index].
      */
     public static boolean isKeyDown(final int key) {
@@ -12775,7 +12782,7 @@ public class ImGui {
         return ImGui::IsKeyDown(static_cast<ImGuiKey>(key));
     */
 
-    /**
+     /**
      * Was key pressed (went from !Down to Down)? if repeat=true, uses io.KeyRepeatDelay / KeyRepeatRate
      */
     public static boolean isKeyPressed(final int key) {
@@ -12797,7 +12804,7 @@ public class ImGui {
         return ImGui::IsKeyPressed(static_cast<ImGuiKey>(key), repeat);
     */
 
-    /**
+     /**
      * Was key released (went from Down to !Down)
      */
     public static boolean isKeyReleased(final int key) {
@@ -12808,7 +12815,7 @@ public class ImGui {
         return ImGui::IsKeyReleased(static_cast<ImGuiKey>(key));
     */
 
-    /**
+     /**
      * Uses provided repeat rate/delay.
      * Return a count, most often 0 or 1 but might be {@code >1} if RepeatRate is small enough that {@code DeltaTime > RepeatRate}
      */
@@ -12820,7 +12827,7 @@ public class ImGui {
         return ImGui::GetKeyPressedAmount(static_cast<ImGuiKey>(key), repeatDelay, rate);
     */
 
-    /**
+     /**
      * [DEBUG] returns English name of the key. Those names a provided for debugging purpose and are not meant to be saved persistently not compared.
      */
     public static String getKeyName(final int key) {
@@ -12831,7 +12838,7 @@ public class ImGui {
         return env->NewStringUTF(ImGui::GetKeyName(static_cast<ImGuiKey>(key)));
     */
 
-    /**
+     /**
      * Attention: misleading name! manually override io.WantCaptureKeyboard flag next frame (said flag is entirely left for your application to handle).
      * e.g. force capture keyboard when your widget is being hovered.
      * This is equivalent to setting "io.WantCaptureKeyboard = wantCaptureKeyboardValue"; after the next NewFrame() call.
@@ -12862,7 +12869,7 @@ public class ImGui {
     // - You can also use regular integer: it is forever guaranteed that 0=Left, 1=Right, 2=Middle.
     // - Dragging operations are only reported after mouse has moved a certain distance away from the initial clicking position (see 'lock_threshold' and 'io.MouseDraggingThreshold')
 
-    /**
+     /**
      * Is mouse button held (0=left, 1=right, 2=middle)
      */
     public static boolean isMouseDown(final int button) {
@@ -12873,7 +12880,7 @@ public class ImGui {
         return ImGui::IsMouseDown(button);
     */
 
-    /**
+     /**
      * Did mouse button clicked (went from !Down to Down) (0=left, 1=right, 2=middle)
      */
     public static boolean isMouseClicked(final int button) {
@@ -12895,7 +12902,7 @@ public class ImGui {
         return ImGui::IsMouseClicked(button, repeat);
     */
 
-    /**
+     /**
      * Did mouse button released (went from Down to !Down)
      */
     public static boolean isMouseReleased(final int button) {
@@ -12906,7 +12913,7 @@ public class ImGui {
         return ImGui::IsMouseReleased(button);
     */
 
-    /**
+     /**
      * did mouse button double-clicked? (note that a double-click will also report IsMouseClicked() == true).
      */
     public static boolean isMouseDoubleClicked(final int button) {
@@ -12917,7 +12924,7 @@ public class ImGui {
         return ImGui::IsMouseDoubleClicked(button);
     */
 
-    /**
+     /**
      * Return the number of successive mouse-clicks at the time where a click happen (otherwise 0).
      */
     public static int getMouseClickedCount(final int button) {
@@ -12928,7 +12935,7 @@ public class ImGui {
         return ImGui::GetMouseClickedCount(button);
     */
 
-    /**
+     /**
      * Is mouse hovering given bounding rect (in screen space). clipped by current clipping settings, but disregarding of other consideration of focus/window ordering/popup-block.
      */
     public static boolean isMouseHoveringRect(final ImVec2 rMin, final ImVec2 rMax) {
@@ -12970,7 +12977,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * By convention we use (-FLT_MAX,-FLT_MAX) to denote that there is no mouse
      */
     public static boolean isMousePosValid() {
@@ -13001,7 +13008,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Is any mouse button held
      */
     public static boolean isAnyMouseDown() {
@@ -13012,7 +13019,7 @@ public class ImGui {
         return ImGui::IsAnyMouseDown();
     */
 
-    /**
+     /**
      * Shortcut to ImGui::GetIO().MousePos provided by user, to be consistent with other calls
      */
     public static ImVec2 getMousePos() {
@@ -13054,7 +13061,7 @@ public class ImGui {
         return ImGui::GetMousePos().y;
     */
 
-    /**
+     /**
      * Retrieve backup of mouse position at the time of opening popup we have BeginPopup() into
      */
     public static ImVec2 getMousePosOnOpeningCurrentPopup() {
@@ -13096,7 +13103,7 @@ public class ImGui {
         return ImGui::GetMousePosOnOpeningCurrentPopup().y;
     */
 
-    /**
+     /**
      * Is mouse dragging. if lockThreshold {@code < -1.0f} uses io.MouseDraggingThreshold
      */
     public static boolean isMouseDragging(final int button) {
@@ -13118,7 +13125,7 @@ public class ImGui {
         return ImGui::IsMouseDragging(button, lockThreshold);
     */
 
-    /**
+     /**
      * Return the delta from the initial clicking position while the mouse button is pressed or was just released.
      * This is locked and return 0.0f until the mouse moves past a distance threshold at least once. If lockThreshold {@code < -1.0f} uses io.MouseDraggingThreshold.
      */
@@ -13272,7 +13279,7 @@ public class ImGui {
         ImGui::ResetMouseDragDelta(button);
     */
 
-    /**
+     /**
      * get desired cursor type, reset in ImGui::NewFrame(), this is updated during the frame. valid before Render().
      * If you use software rendering by setting io.MouseDrawCursor ImGui will render those for you
      */
@@ -13284,7 +13291,7 @@ public class ImGui {
         return ImGui::GetMouseCursor();
     */
 
-    /**
+     /**
      * Set desired cursor type
      */
     public static void setMouseCursor(final int type) {
@@ -13295,7 +13302,7 @@ public class ImGui {
         ImGui::SetMouseCursor(type);
     */
 
-    /**
+     /**
      * Attention: misleading name! manually override io.WantCaptureMouse flag next frame (said flag is entirely left for your application to handle).
      * This is equivalent to setting "io.WantCaptureMouse = wantCaptureMouseValue;" after the next NewFrame() call.
      */
@@ -13344,7 +13351,7 @@ public class ImGui {
     // - The disk functions are automatically called if io.IniFilename != NULL (default is "imgui.ini").
     // - Set io.IniFilename to NULL to load/save manually. Read io.WantSaveIniSettings description about handling .ini saving manually.
 
-    /**
+     /**
      * Call after CreateContext() and before the first call to NewFrame(). NewFrame() automatically calls LoadIniSettingsFromDisk(io.IniFilename).
      */
     public static void loadIniSettingsFromDisk(final String iniFilename) {
@@ -13357,7 +13364,7 @@ public class ImGui {
         if (iniFilename != NULL) env->ReleaseStringUTFChars(obj_iniFilename, iniFilename);
     */
 
-    /**
+     /**
      * Call after CreateContext() and before the first call to NewFrame() to provide .ini data from your own data source.
      */
     public static void loadIniSettingsFromMemory(final String iniData) {
@@ -13383,7 +13390,7 @@ public class ImGui {
         if (iniData != NULL) env->ReleaseStringUTFChars(obj_iniData, iniData);
     */
 
-    /**
+     /**
      * This is automatically called (if io.IniFilename is not empty) a few seconds after any modification that should be reflected in the .ini file (and also by DestroyContext).
      */
     public static void saveIniSettingsToDisk(final String iniFilename) {
@@ -13396,7 +13403,7 @@ public class ImGui {
         if (iniFilename != NULL) env->ReleaseStringUTFChars(obj_iniFilename, iniFilename);
     */
 
-    /**
+     /**
      * Return a zero-terminated string with the .ini data which you can save by your own mean.
      * Call when io.WantSaveIniSettings is set, then save data by your own mean and clear io.WantSaveIniSettings.
      */
@@ -13438,7 +13445,7 @@ public class ImGui {
     // Read comments around the ImGuiPlatformIO structure for more details.
     // Note: You may use GetWindowViewport() to get the current viewport of the current window.
 
-    private static final ImGuiPlatformIO _GETPLATFORMIO_1 = new ImGuiPlatformIO(0);
+     private static final ImGuiPlatformIO _GETPLATFORMIO_1 = new ImGuiPlatformIO(0);
 
     /**
      * Platform/renderer functions, for backend to setup + viewports list.
@@ -13452,7 +13459,7 @@ public class ImGui {
         return (uintptr_t)&ImGui::GetPlatformIO();
     */
 
-    /**
+     /**
      * Call in main loop. Will call CreateWindow/ResizeWindow/etc. Platform functions for each secondary viewport, and DestroyWindow for each inactive viewport.
      */
     public static void updatePlatformWindows() {
@@ -13463,7 +13470,7 @@ public class ImGui {
         ImGui::UpdatePlatformWindows();
     */
 
-    /**
+     /**
      * Call in main loop. will call RenderWindow/SwapBuffers platform functions for each secondary viewport which doesn't have the ImGuiViewportFlags_Minimized flag set.
      * May be reimplemented by user for custom rendering needs.
      */
@@ -13475,7 +13482,7 @@ public class ImGui {
         ImGui::RenderPlatformWindowsDefault();
     */
 
-    /**
+     /**
      * Call DestroyWindow platform functions for all viewports.
      * Call from backend Shutdown() if you need to close platform windows before imgui shutdown.
      * Otherwise will be called by DestroyContext().
@@ -13488,7 +13495,7 @@ public class ImGui {
         ImGui::DestroyPlatformWindows();
     */
 
-    /**
+     /**
      * This is a helper for backends.
      */
     public static ImGuiViewport findViewportByID(final int imGuiID) {
@@ -13499,7 +13506,7 @@ public class ImGui {
         return (uintptr_t)ImGui::FindViewportByID(imGuiID);
     */
 
-    /**
+     /**
      * This is a helper for backends. The type platform_handle is decided by the backend (e.g. HWND, MyWindow*, GLFWwindow* etc.)
      */
     public static ImGuiViewport findViewportByPlatformHandle(final long platformHandle) {

--- a/imgui-binding/src/generated/java/imgui/ImGuiIO.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiIO.java
@@ -1,6 +1,13 @@
 package imgui;
 
 import imgui.binding.ImGuiStruct;
+
+
+
+
+
+
+
 import imgui.callback.ImStrConsumer;
 import imgui.callback.ImStrSupplier;
 
@@ -8,6 +15,7 @@ import imgui.callback.ImStrSupplier;
  * Communicate most settings and inputs/outputs to Dear ImGui using this structure.
  * Access via ImGui::GetIO(). Read 'Programmer guide' section in .cpp file for general usage.
  */
+
 public final class ImGuiIO extends ImGuiStruct {
     public ImGuiIO(final long ptr) {
         super(ptr);
@@ -22,7 +30,7 @@ public final class ImGuiIO extends ImGuiStruct {
     // Configuration (fill once)
     //------------------------------------------------------------------
 
-    /**
+     /**
      * See ImGuiConfigFlags enum. Set by user/application. Gamepad/keyboard navigation options, etc.
      */
     public int getConfigFlags() {
@@ -65,7 +73,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigFlags = value;
     */
 
-    /**
+     /**
      * See ImGuiBackendFlags enum. Set by backend to communicate features supported by the backend.
      */
     public int getBackendFlags() {
@@ -108,7 +116,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->BackendFlags = value;
     */
 
-    /**
+     /**
      * Main display size, in pixels (generally == {@code GetMainViewport()->Size})
      */
     public ImVec2 getDisplaySize() {
@@ -169,7 +177,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->DisplaySize = value;
     */
 
-    /**
+     /**
      * Time elapsed since last frame, in seconds.
      */
     public float getDeltaTime() {
@@ -191,7 +199,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->DeltaTime = value;
     */
 
-    /**
+     /**
      * Minimum time between saving positions/sizes to .ini file, in seconds.
      */
     public float getIniSavingRate() {
@@ -213,7 +221,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->IniSavingRate = value;
     */
 
-    /**
+     /**
      * Path to .ini file. Set NULL to disable automatic .ini loading/saving, if e.g. you want to manually load/save from memory.
      */
     public String getIniFilename() {
@@ -237,7 +245,7 @@ public final class ImGuiIO extends ImGuiStruct {
         if (value != NULL) env->ReleaseStringUTFChars(obj_value, value);
     */
 
-    /**
+     /**
      * Path to .log file (default parameter to ImGui::LogToFile when no file is specified).
      */
     public String getLogFilename() {
@@ -261,7 +269,7 @@ public final class ImGuiIO extends ImGuiStruct {
         if (value != NULL) env->ReleaseStringUTFChars(obj_value, value);
     */
 
-    /**
+     /**
      * Time for a double-click, in seconds.
      */
     public float getMouseDoubleClickTime() {
@@ -283,7 +291,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDoubleClickTime = value;
     */
 
-    /**
+     /**
      * Distance threshold to stay in to validate a double-click, in pixels.
      */
     public float getMouseDoubleClickMaxDist() {
@@ -305,7 +313,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDoubleClickMaxDist = value;
     */
 
-    /**
+     /**
      * Distance threshold before considering we are dragging.
      */
     public float getMouseDragThreshold() {
@@ -327,7 +335,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDragThreshold = value;
     */
 
-    /**
+     /**
      * When holding a key/button, time before it starts repeating, in seconds (for buttons in Repeat mode, etc.).
      */
     public float getKeyRepeatDelay() {
@@ -349,7 +357,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyRepeatDelay = value;
     */
 
-    /**
+     /**
      * When holding a key/button, rate at which it repeats, in seconds.
      */
     public float getKeyRepeatRate() {
@@ -371,7 +379,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyRepeatRate = value;
     */
 
-    private static final ImFontAtlas _GETFONTS_1 = new ImFontAtlas(0);
+     private static final ImFontAtlas _GETFONTS_1 = new ImFontAtlas(0);
 
     /**
      * Font atlas: load, rasterize and pack one or more fonts into a single texture.
@@ -396,7 +404,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->Fonts = reinterpret_cast<ImFontAtlas*>(value);
     */
 
-    /**
+     /**
      * Global scale all fonts
      */
     public float getFontGlobalScale() {
@@ -418,7 +426,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->FontGlobalScale = value;
     */
 
-    /**
+     /**
      * Allow user scaling text of individual window with CTRL+Wheel.
      */
     public boolean getFontAllowUserScaling() {
@@ -440,7 +448,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->FontAllowUserScaling = value;
     */
 
-    /**
+     /**
      * Font to use on NewFrame(). Use NULL to uses Fonts{@code ->}Fonts[0].
      */
     public ImFont getFontDefault() {
@@ -462,7 +470,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->FontDefault = reinterpret_cast<ImFont*>(value);
     */
 
-    /**
+     /**
      * For retina display or other situations where window coordinates are different from framebuffer coordinates. This generally ends up in ImDrawData::FramebufferScale.
      */
     public ImVec2 getDisplayFramebufferScale() {
@@ -525,7 +533,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Docking options (when ImGuiConfigFlags_DockingEnable is set)
 
-    /**
+     /**
      * Simplified docking mode: disable window splitting, so docking is limited to merging multiple windows together into tab-bars.
      */
     public boolean getConfigDockingNoSplit() {
@@ -547,7 +555,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDockingNoSplit = value;
     */
 
-    /**
+     /**
      * Enable docking with holding Shift key (reduce visual noise, allows dropping in wider space)
      */
     public boolean getConfigDockingWithShift() {
@@ -585,7 +593,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDockingAlwaysTabBar = value;
     */
 
-    /**
+     /**
      * Make window or viewport transparent when docking and only display docking boxes on the target viewport. Useful if rendering of multiple viewport cannot be synced. Best used with ConfigViewportsNoAutoMerge.
      */
     public boolean getConfigDockingTransparentPayload() {
@@ -609,7 +617,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Viewport options (when ImGuiConfigFlags_ViewportsEnable is set)
 
-    /**
+     /**
      * Set to make all floating imgui windows always create their own viewport. Otherwise, they are merged into the main host viewports when overlapping it. May also set ImGuiViewportFlags_NoAutoMerge on individual viewport.
      */
     public boolean getConfigViewportsNoAutoMerge() {
@@ -631,7 +639,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigViewportsNoAutoMerge = value;
     */
 
-    /**
+     /**
      * Disable default OS task bar icon flag for secondary viewports. When a viewport doesn't want a task bar icon, ImGuiViewportFlags_NoTaskBarIcon will be set on it.
      */
     public boolean getConfigViewportsNoTaskBarIcon() {
@@ -653,7 +661,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigViewportsNoTaskBarIcon = value;
     */
 
-    /**
+     /**
      * Disable default OS window decoration flag for secondary viewports. When a viewport doesn't want window decorations, ImGuiViewportFlags_NoDecoration will be set on it. Enabling decoration can create subsequent issues at OS levels (e.g. minimum window size).
      */
     public boolean getConfigViewportsNoDecoration() {
@@ -675,7 +683,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigViewportsNoDecoration = value;
     */
 
-    /**
+     /**
      * Disable default OS parenting to main viewport for secondary viewports. By default, viewports are marked with ParentViewportId = {@code <main_viewport>}, expecting the platform backend to setup a parent/child relationship between the OS windows (some backend may ignore this). Set to true if you want the default to be 0, then all viewports will be top-level OS windows.
      */
     public boolean getConfigViewportsNoDefaultParent() {
@@ -699,7 +707,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Miscellaneous options
 
-    /**
+     /**
      * Request ImGui to draw a mouse cursor for you (if you are on a platform without a mouse cursor).
      * Cannot be easily renamed to 'io.ConfigXXX' because this is frequently used by backend implementations.
      */
@@ -723,7 +731,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDrawCursor = value;
     */
 
-    /**
+     /**
      * OS X style: Text editing cursor movement using Alt instead of Ctrl, Shortcuts using Cmd/Super instead of Ctrl,
      * Line/Text Start and End using Cmd+Arrows instead of Home/End, Double click selects by word instead of selecting whole text,
      * Multi-selection in lists uses Cmd/Super instead of Ctrl
@@ -749,7 +757,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigMacOSXBehaviors = value;
     */
 
-    /**
+     /**
      * Enable input queue trickling: some types of events submitted during the same frame (e.g. button down + up) will be spread over multiple frames, improving interactions with low framerates.
      */
     public boolean getConfigInputTrickleEventQueue() {
@@ -771,7 +779,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigInputTrickleEventQueue = value;
     */
 
-    /**
+     /**
      * Set to false to disable blinking cursor, for users who consider it distracting.
      */
     public boolean getConfigInputTextCursorBlink() {
@@ -793,7 +801,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigInputTextCursorBlink = value;
     */
 
-    /**
+     /**
      * [BETA] Enable turning DragXXX widgets into text input with a simple mouse click-release (without moving). Not desirable on devices without a keyboard.
      */
     public boolean getConfigDragClickToInputText() {
@@ -815,7 +823,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDragClickToInputText = value;
     */
 
-    /**
+     /**
      * Enable resizing of windows from their edges and from the lower-left corner.
      * This requires (io.BackendFlags {@code &} ImGuiBackendFlags_HasMouseCursors) because it needs mouse cursor feedback.
      * (This used to be a per-window ImGuiWindowFlags_ResizeFromAnySide flag)
@@ -841,7 +849,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigWindowsResizeFromEdges = value;
     */
 
-    /**
+     /**
      * Enable allowing to move windows only when clicking on their title bar. Does not apply to windows without a title bar.
      */
     public boolean getConfigWindowsMoveFromTitleBarOnly() {
@@ -863,7 +871,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigWindowsMoveFromTitleBarOnly = value;
     */
 
-    /**
+     /**
      * [Timer (in seconds) to free transient windows/tables memory buffers when unused. Set to -1.0f to disable.
      */
     public boolean getConfigMemoryCompactTimer() {
@@ -889,7 +897,7 @@ public final class ImGuiIO extends ImGuiStruct {
     // Platform Functions
     //------------------------------------------------------------------
 
-    /**
+     /**
      * Optional: Platform backend name (informational only! will be displayed in About Window) + User data for backend/wrappers to store their own stuff.
      */
     public String getBackendPlatformName() {
@@ -971,7 +979,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Input Functions
 
-    /**
+     /**
      * Queue a new key down/up event. Key should be "translated" (as in, generally ImGuiKey_A matches the key end-user would use to emit an 'A' character)
      */
     public void addKeyEvent(final int key, final boolean down) {
@@ -982,7 +990,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddKeyEvent(static_cast<ImGuiKey>(key), down);
     */
 
-    /**
+     /**
      * Queue a new key down/up event for analog values (e.g. ImGuiKey_Gamepad_ values). Dead-zones should be handled by the backend.
      */
     public void addKeyAnalogEvent(final int key, final boolean down, final float v) {
@@ -993,7 +1001,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddKeyAnalogEvent(static_cast<ImGuiKey>(key), down, v);
     */
 
-    /**
+     /**
      * Queue a mouse position update. Use -FLT_MAX,-FLT_MAX to signify no mouse (e.g. app not focused and not hovered)
      */
     public void addMousePosEvent(final float x, final float y) {
@@ -1004,7 +1012,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMousePosEvent(x, y);
     */
 
-    /**
+     /**
      * Queue a mouse button change
      */
     public void addMouseButtonEvent(final int button, final boolean down) {
@@ -1015,7 +1023,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMouseButtonEvent(button, down);
     */
 
-    /**
+     /**
      * Queue a mouse wheel update
      */
     public void addMouseWheelEvent(final float whX, final float whY) {
@@ -1026,7 +1034,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMouseWheelEvent(whX, whY);
     */
 
-    /**
+     /**
      * Queue a mouse hovered viewport. Requires backend to set ImGuiBackendFlags_HasMouseHoveredViewport to call this (for multi-viewport support).
      */
     public void addMouseViewportEvent(final int id) {
@@ -1037,7 +1045,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMouseViewportEvent(static_cast<ImGuiID>(id));
     */
 
-    /**
+     /**
      * Queue a gain/loss of focus for the application (generally based on OS/platform focus of your window)
      */
     public void addFocusEvent(final boolean focused) {
@@ -1048,7 +1056,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddFocusEvent(focused);
     */
 
-    /**
+     /**
      * Queue new character input.
      */
     public void addInputCharacter(final int c) {
@@ -1059,7 +1067,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddInputCharacter((unsigned int)c);
     */
 
-    /**
+     /**
      * Queue new character input from an UTF-16 character, it can be a surrogate
      */
     public void addInputCharacterUTF16(final short c) {
@@ -1070,7 +1078,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddInputCharacterUTF16((ImWchar16)c);
     */
 
-    /**
+     /**
      * Queue new characters input from an UTF-8 string.
      */
     public void addInputCharactersUTF8(final String str) {
@@ -1083,7 +1091,7 @@ public final class ImGuiIO extends ImGuiStruct {
         if (str != NULL) env->ReleaseStringUTFChars(obj_str, str);
     */
 
-    /**
+     /**
      * [Internal] Clear the text input buffer manually
      */
     public void clearInputCharacters() {
@@ -1094,7 +1102,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ClearInputCharacters();
     */
 
-    /**
+     /**
      * [Internal] Release all keys
      */
     public void clearInputKeys() {
@@ -1105,7 +1113,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ClearInputKeys();
     */
 
-    /**
+     /**
      * [Optional] Specify index for legacy before 1.87 IsKeyXXX() functions with native indices + specify native keycode, scancode.
      */
     public void setKeyEventNativeData(final int key, final int nativeKeycode, final int nativeScancode) {
@@ -1133,7 +1141,7 @@ public final class ImGuiIO extends ImGuiStruct {
     //  generally easier and more correct to use their state BEFORE calling NewFrame(). See FAQ for details!)
     //------------------------------------------------------------------
 
-    /**
+     /**
      * Set when Dear ImGui will use mouse inputs, in this case do not dispatch them to your main game/application
      * (either way, always pass on mouse inputs to imgui).
      * (e.g. unclicked mouse is hovering over an imgui window, widget is active, mouse was clicked over an imgui window, etc.).
@@ -1159,7 +1167,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantCaptureMouse = value;
     */
 
-    /**
+     /**
      * Set when Dear ImGui will use keyboard inputs, in this case do not dispatch them to your main game/application
      * (either way, always pass keyboard inputs to imgui). (e.g. InputText active, or an imgui window is focused and navigation is enabled, etc.).
      */
@@ -1183,7 +1191,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantCaptureKeyboard = value;
     */
 
-    /**
+     /**
      * Mobile/console: when set, you may display an on-screen keyboard.
      * This is set by Dear ImGui when it wants textual keyboard input to happen (e.g. when a InputText widget is active).
      */
@@ -1207,7 +1215,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantTextInput = value;
     */
 
-    /**
+     /**
      * MousePos has been altered, backend should reposition mouse on next frame. Rarely used! Set only when ImGuiConfigFlags_NavEnableSetMousePos flag is enabled.
      */
     public boolean getWantSetMousePos() {
@@ -1229,7 +1237,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantSetMousePos = value;
     */
 
-    /**
+     /**
      * When manual .ini load/save is active (io.IniFilename == NULL),
      * this will be set to notify your application that you can call SaveIniSettingsToMemory() and save yourself.
      * Important: clear io.WantSaveIniSettings yourself after saving!
@@ -1255,7 +1263,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantSaveIniSettings = value;
     */
 
-    /**
+     /**
      * Keyboard/Gamepad navigation is currently allowed (will handle ImGuiKey_NavXXX events) = a window is focused
      * and it doesn't use the ImGuiWindowFlags_NoNavInputs flag.
      */
@@ -1279,7 +1287,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->NavActive = value;
     */
 
-    /**
+     /**
      * Keyboard/Gamepad navigation is visible and allowed (will handle ImGuiKey_NavXXX events).
      */
     public boolean getNavVisible() {
@@ -1301,7 +1309,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->NavVisible = value;
     */
 
-    /**
+     /**
      * Application framerate estimate, in frame per second. Solely for convenience. Rolling average estimation based on io.DeltaTime over 120 frames.
      * Solely for convenience. Rolling average estimation based on IO.DeltaTime over 120 frames
      */
@@ -1325,7 +1333,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->Framerate = value;
     */
 
-    /**
+     /**
      * Vertices output during last call to Render()
      */
     public int getMetricsRenderVertices() {
@@ -1347,7 +1355,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsRenderVertices = value;
     */
 
-    /**
+     /**
      * Indices output during last call to Render() = number of triangles * 3
      */
     public int getMetricsRenderIndices() {
@@ -1369,7 +1377,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsRenderIndices = value;
     */
 
-    /**
+     /**
      * Number of visible windows
      */
     public int getMetricsRenderWindows() {
@@ -1391,7 +1399,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsRenderWindows = value;
     */
 
-    /**
+     /**
      * Number of active windows
      */
     public int getMetricsActiveWindows() {
@@ -1413,7 +1421,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsActiveWindows = value;
     */
 
-    /**
+     /**
      * Number of active allocations, updated by MemAlloc/MemFree based on current context. May be off if you have multiple imgui contexts.
      */
     public int getMetricsActiveAllocations() {
@@ -1435,7 +1443,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsActiveAllocations = value;
     */
 
-    /**
+     /**
      * Mouse delta. Note that this is zero if either current or previous position are invalid (-FLT_MAX,-FLT_MAX), so a disappearing/reappearing mouse won't have a huge delta.
      */
     public ImVec2 getMouseDelta() {
@@ -1496,7 +1504,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDelta = value;
     */
 
-    /**
+     /**
      * Map of indices into the KeysDown[512] entries array which represent your "native" keyboard state.
      */
     @Deprecated
@@ -1554,7 +1562,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyMap[idx] = value;
     */
 
-    /**
+     /**
      * Keyboard keys that are pressed (ideally left in the "native" order your engine has access to keyboard keys, so you can use your own defines/enums for keys).
      */
     @Deprecated
@@ -1616,7 +1624,7 @@ public final class ImGuiIO extends ImGuiStruct {
     // [Internal] Dear ImGui will maintain those fields. Forward compatibility not guaranteed!
     //------------------------------------------------------------------
 
-    /**
+     /**
      * Mouse position, in pixels. Set to ImVec2(-FLT_MAX, -FLT_MAX) if mouse is unavailable (on another screen, etc.)
      */
     public ImVec2 getMousePos() {
@@ -1677,7 +1685,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MousePos = value;
     */
 
-    /**
+     /**
      * Mouse buttons: 0=left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons.
      * Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
      */
@@ -1731,7 +1739,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDown[idx] = value;
     */
 
-    /**
+     /**
      * Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
      */
     public float getMouseWheel() {
@@ -1753,7 +1761,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseWheel = value;
     */
 
-    /**
+     /**
      * Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all backends.
      */
     public float getMouseWheelH() {
@@ -1775,7 +1783,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseWheelH = value;
     */
 
-    /**
+     /**
      * (Optional) When using multiple viewports: viewport the OS mouse cursor is hovering _IGNORING_ viewports with the ImGuiViewportFlags_NoInputs flag,
      * and _REGARDLESS_ of whether another viewport is focused. Set io.BackendFlags |= ImGuiBackendFlags_HasMouseHoveredViewport if you can provide this info.
      * If you don't imgui will infer the value using the rectangles and last focused time of the viewports it knows about (ignoring other OS windows).
@@ -1801,7 +1809,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseHoveredViewport = value;
     */
 
-    /**
+     /**
      * Keyboard modifier pressed: Control
      */
     public boolean getKeyCtrl() {
@@ -1823,7 +1831,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyCtrl = value;
     */
 
-    /**
+     /**
      * Keyboard modifier pressed: Shift
      */
     public boolean getKeyShift() {
@@ -1845,7 +1853,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyShift = value;
     */
 
-    /**
+     /**
      * Keyboard modifier pressed: Alt
      */
     public boolean getKeyAlt() {
@@ -1867,7 +1875,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyAlt = value;
     */
 
-    /**
+     /**
      * Keyboard modifier pressed: Cmd/Super/Windows
      */
     public boolean getKeySuper() {
@@ -1889,7 +1897,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeySuper = value;
     */
 
-    /**
+     /**
      * Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
      */
     public float[] getNavInputs() {
@@ -1941,7 +1949,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Other state maintained from data above + IO function calls
 
-    /**
+     /**
      * Key mods flags (same as io.KeyCtrl/KeyShift/KeyAlt/KeySuper but merged into flags), updated by NewFrame()
      */
     public int getKeyMods() {
@@ -1963,7 +1971,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyMods = value;
     */
 
-    /**
+     /**
      * Key mods flags (from previous frame)
      */
     public int getKeyModsPrev() {
@@ -1985,7 +1993,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyModsPrev = value;
     */
 
-    /**
+     /**
      * Key state for all known keys. Use IsKeyXXX() functions to access this.
      */
     public ImGuiKeyData[] getKeysData() {
@@ -2007,7 +2015,7 @@ public final class ImGuiIO extends ImGuiStruct {
         Jni::ImGuiKeyDataArrayCpy(env, value, THIS->KeysData, ImGuiKey_KeysData_SIZE);
     */
 
-    /**
+     /**
      * Alternative to WantCaptureMouse: (WantCaptureMouse == true {@code &&} WantCaptureMouseUnlessPopupClose == false) when a click over void is expected to close a popup.
      */
     public boolean getWantCaptureMouseUnlessPopupClose() {
@@ -2029,7 +2037,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantCaptureMouseUnlessPopupClose = value;
     */
 
-    /**
+     /**
      * Previous mouse position (note that MouseDelta is not necessary == MousePos-MousePosPrev, in case either position is invalid)
      */
     public ImVec2 getMousePosPrev() {
@@ -2090,7 +2098,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MousePosPrev = value;
     */
 
-    /**
+     /**
      * Position at time of clicking.
      */
     public ImVec2[] getMouseClickedPos() {
@@ -2112,7 +2120,7 @@ public final class ImGuiIO extends ImGuiStruct {
         Jni::ImVec2ArrayCpy(env, value, THIS->MouseClickedPos, 5);
     */
 
-    /**
+     /**
      * Time of last click (used to figure out double-click)
      */
     public double[] getMouseClickedTime() {
@@ -2162,7 +2170,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseClickedTime[idx] = value;
     */
 
-    /**
+     /**
      * Mouse button went from !Down to Down (same as MouseClickedCount[x] != 0)
      */
     public boolean[] getMouseClicked() {
@@ -2212,7 +2220,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseClicked[idx] = value;
     */
 
-    /**
+     /**
      * Has mouse button been double-clicked? (same as MouseClickedCount[x] == 2)
      */
     public boolean[] getMouseDoubleClicked() {
@@ -2262,7 +2270,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDoubleClicked[idx] = value;
     */
 
-    /**
+     /**
      * == 0 (not clicked), == 1 (same as MouseClicked[]), == 2 (double-clicked), == 3 (triple-clicked) etc. when going from !Down to Down
      */
     public int[] getMouseClickedCount() {
@@ -2312,7 +2320,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseClickedCount[idx] = value;
     */
 
-    /**
+     /**
      * Count successive number of clicks. Stays valid after mouse release. Reset after another click is done.
      */
     public int[] getMouseClickedLastCount() {
@@ -2362,7 +2370,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseClickedLastCount[idx] = value;
     */
 
-    /**
+     /**
      * Mouse button went from Down to !Down
      */
     public boolean[] getMouseReleased() {
@@ -2412,7 +2420,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseReleased[idx] = value;
     */
 
-    /**
+     /**
      * Track if button was clicked inside a dear imgui window or over void blocked by a popup. We don't request mouse capture from the application if click started outside ImGui bounds.
      */
     public boolean[] getMouseDownOwned() {
@@ -2462,7 +2470,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDownOwned[idx] = value;
     */
 
-    /**
+     /**
      * Track if button was clicked inside a dear imgui window.
      */
     public boolean[] getMouseDownOwnedUnlessPopupClose() {
@@ -2512,7 +2520,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDownOwnedUnlessPopupClose[idx] = value;
     */
 
-    /**
+     /**
      * Duration the mouse button has been down (0.0f == just clicked)
      */
     public float[] getMouseDownDuration() {
@@ -2562,7 +2570,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDownDuration[idx] = value;
     */
 
-    /**
+     /**
      * Previous time the mouse button has been down
      */
     public float[] getMouseDownDurationPrev() {
@@ -2612,7 +2620,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDownDurationPrev[idx] = value;
     */
 
-    /**
+     /**
      * Maximum distance, absolute, on each axis, of how much mouse has traveled from the clicking point
      */
     public ImVec2[] getMouseDragMaxDistanceAbs() {
@@ -2634,7 +2642,7 @@ public final class ImGuiIO extends ImGuiStruct {
         Jni::ImVec2ArrayCpy(env, value, THIS->MouseDragMaxDistanceAbs, 5);
     */
 
-    /**
+     /**
      * Squared maximum distance of how much mouse has traveled from the clicking point
      */
     public float[] getMouseDragMaxDistanceSqr() {
@@ -2760,7 +2768,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->NavInputsDownDurationPrev[idx] = value;
     */
 
-    /**
+     /**
      * Touch/Pen pressure (0.0f to 1.0f, should be {@code >}0.0f only when MouseDown[0] == true). Helper storage currently unused by Dear ImGui.
      */
     public float getPenPressure() {
@@ -2798,7 +2806,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AppFocusLost = value;
     */
 
-    /**
+     /**
      * -1: unknown, 0: using AddKeyEvent(), 1: using legacy io.KeysDown[]
      */
     public short getBackendUsingLegacyKeyArrays() {
@@ -2820,7 +2828,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->BackendUsingLegacyKeyArrays = value;
     */
 
-    /**
+     /**
      * 0: using AddKeyAnalogEvent(), 1: writing to legacy io.NavInputs[] directly
      */
     public boolean getBackendUsingLegacyNavInputArray() {
@@ -2842,7 +2850,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->BackendUsingLegacyNavInputArray = value;
     */
 
-    /**
+     /**
      * For AddInputCharacterUTF16
      */
     public short getInputQueueSurrogate() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiInputTextCallbackData.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiInputTextCallbackData.java
@@ -2,6 +2,9 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 /**
  * Shared state of InputText(), passed as an argument to your callback when a ImGuiInputTextFlags_Callback* flag is used.<p>
  * The callback function should return 0 by default.<p>
@@ -13,6 +16,7 @@ import imgui.binding.ImGuiStruct;
  * - ImGuiInputTextFlags_CallbackCharFilter:  Callback on character inputs to replace or discard them. Modify 'EventChar' to replace or discard, or return 1 in callback to discard.<p>
  * - ImGuiInputTextFlags_CallbackResize:      Callback on buffer capacity changes request (beyond 'buf_size' parameter value), allowing the string to grow.<p>
  */
+
 public class ImGuiInputTextCallbackData extends ImGuiStruct {
     public ImGuiInputTextCallbackData(final long ptr) {
         super(ptr);
@@ -23,7 +27,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         #define THIS ((ImGuiInputTextCallbackData*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * One ImGuiInputTextFlags_Callback*
      */
     public int getEventFlag() {
@@ -41,7 +45,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         return THIS->EventFlag;
     */
 
-    /**
+     /**
      * What user passed to InputText()
      */
     public int getFlags() {
@@ -61,7 +65,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
 
     // TODO: UserData
 
-    /**
+     /**
      * [CharFilter] Replace character with another one, or set to zero to drop. return 1 is equivalent to setting EventChar=0;
      */
     public int getEventChar() {
@@ -83,7 +87,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->EventChar = value;
     */
 
-    /**
+     /**
      * [Completion,History]
      */
     public int getEventKey() {
@@ -94,7 +98,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         return THIS->EventKey;
     */
 
-    /**
+     /**
      * [Resize] Can replace pointer <p>
      * [Completion,History,Always] Only write to pointed data, don't replace the actual pointer!
      */
@@ -120,7 +124,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         if (value != NULL) env->ReleaseStringUTFChars(obj_value, value);
     */
 
-    /**
+     /**
      * [Resize,Completion,History,Always] Exclude zero-terminator storage. In C land: == strlen(some_text), in C++ land: string.length()
      */
     public int getBufTextLen() {
@@ -142,7 +146,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->BufTextLen = value;
     */
 
-    /**
+     /**
      * Set if you modify Buf/BufTextLen!
      */
     public boolean getBufDirty() {
@@ -164,7 +168,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->BufDirty = value;
     */
 
-    /**
+     /**
      * Current cursor position
      */
     public int getCursorPos() {
@@ -186,7 +190,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->CursorPos = value;
     */
 
-    /**
+     /**
      * Selection Start
      */
     public int getSelectionStart() {
@@ -208,7 +212,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->SelectionStart = value;
     */
 
-    /**
+     /**
      * Selection End
      */
     public int getSelectionEnd() {
@@ -230,7 +234,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->SelectionEnd = value;
     */
 
-    /**
+     /**
      * Delete Chars
      *
      * @param pos
@@ -246,7 +250,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->DeleteChars(pos, bytesCount);
     */
 
-    /**
+     /**
      * Insert Chars
      *
      * @param pos

--- a/imgui-binding/src/generated/java/imgui/ImGuiKeyData.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiKeyData.java
@@ -2,10 +2,13 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
 /**
  * [Internal] Storage used by IsKeyDown(), IsKeyPressed() etc functions.
  * If prior to 1.87 you used io.KeysDownDuration[] (which was marked as internal), you should use GetKeyData(key).DownDuration and not io.KeysData[key].DownDuration.
  */
+
 public final class ImGuiKeyData extends ImGuiStructDestroyable {
     public ImGuiKeyData() {
         super();
@@ -29,7 +32,7 @@ public final class ImGuiKeyData extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImGuiKeyData());
     */
 
-    /**
+     /**
      * True for if key is down
      */
     public boolean getDown() {
@@ -51,7 +54,7 @@ public final class ImGuiKeyData extends ImGuiStructDestroyable {
         THIS->Down = value;
     */
 
-    /**
+     /**
      * Duration the key has been down ({@code <}0.0f: not pressed, 0.0f: just pressed, {@code >}0.0f: time held)
      */
     public float getDownDuration() {
@@ -73,7 +76,7 @@ public final class ImGuiKeyData extends ImGuiStructDestroyable {
         THIS->DownDuration = value;
     */
 
-    /**
+     /**
      * Last frame duration the key has been down
      */
     public float getDownDurationPrev() {
@@ -95,7 +98,7 @@ public final class ImGuiKeyData extends ImGuiStructDestroyable {
         THIS->DownDurationPrev = value;
     */
 
-    /**
+     /**
      * 0.0f..1.0f for gamepad values
      */
     public float getAnalogValue() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiPlatformMonitor.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiPlatformMonitor.java
@@ -2,10 +2,13 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
 /**
  * (Optional) This is required when enabling multi-viewport. Represent the bounds of each connected monitor/display and their DPI.
  * We use this information for multiple DPI support + clamping the position of popups and tooltips so they don't straddle multiple monitors.
  */
+
 public final class ImGuiPlatformMonitor extends ImGuiStruct {
     public ImGuiPlatformMonitor(final long ptr) {
         super(ptr);
@@ -16,7 +19,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         #define THIS ((ImGuiPlatformMonitor*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Coordinates of the area displayed on this monitor (Min = upper left, Max = bottom right)
      */
     public ImVec2 getMainPos() {
@@ -77,7 +80,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         THIS->MainPos = value;
     */
 
-    /**
+     /**
      * Coordinates of the area displayed on this monitor (Min = upper left, Max = bottom right)
      */
     public ImVec2 getMainSize() {
@@ -138,7 +141,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         THIS->MainSize = value;
     */
 
-    /**
+     /**
      * Coordinates without task bars / side bars / menu bars.
      * Used to avoid positioning popups/tooltips inside this region. If you don't have this info, please copy the value for MainPos/MainSize.
      */
@@ -205,7 +208,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         THIS->WorkPos = value;
     */
 
-    /**
+     /**
      * Coordinates without task bars / side bars / menu bars.
      * Used to avoid positioning popups/tooltips inside this region. If you don't have this info, please copy the value for MainPos/MainSize.
      */
@@ -272,7 +275,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         THIS->WorkSize = value;
     */
 
-    /**
+     /**
      * 1.0f = 96 DPI
      */
     public float getDpiScale() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiStorage.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiStorage.java
@@ -2,6 +2,9 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 /**
  * Helper: Key-Value storage
  * Typically you don't have to worry about this since a storage is held within each Window.
@@ -12,6 +15,7 @@ import imgui.binding.ImGuiStructDestroyable;
  * - You want to store custom debug data easily without adding or editing structures in your code (probably not efficient, but convenient)
  * Types are NOT stored, so it is up to you to make sure your Key don't collide with different types.
  */
+
 public final class ImGuiStorage extends ImGuiStructDestroyable {
     public ImGuiStorage() {
         super();
@@ -119,7 +123,7 @@ public final class ImGuiStorage extends ImGuiStructDestroyable {
         THIS->SetFloat(key, val);
     */
 
-    /**
+     /**
      * Use on your own storage if you know only integer are being stored (open/close all tree nodes)
      */
     public void setAllInt(final int val) {
@@ -130,7 +134,7 @@ public final class ImGuiStorage extends ImGuiStructDestroyable {
         THIS->SetAllInt(val);
     */
 
-    /**
+     /**
      * For quicker full rebuild of a storage (instead of an incremental one), you may add all your contents and then sort once.
      */
     public void buildSortByKey() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiStyle.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiStyle.java
@@ -2,11 +2,16 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
 /**
  * You may modify the ImGui::GetStyle() main instance during initialization and before NewFrame().
  * During the frame, use ImGui::PushStyleVar(ImGuiStyleVar_XXXX)/PopStyleVar() to alter the main style values,
  * and ImGui::PushStyleColor(ImGuiCol_XXX)/PopStyleColor() for colors.
  */
+
 public final class ImGuiStyle extends ImGuiStructDestroyable {
     public ImGuiStyle() {
         super();
@@ -30,7 +35,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImGuiStyle());
     */
 
-    /**
+     /**
      * Global alpha applies to everything in Dear ImGui.
      */
     public float getAlpha() {
@@ -52,7 +57,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->Alpha = value;
     */
 
-    /**
+     /**
      * Additional alpha multiplier applied by BeginDisabled(). Multiply over current value of Alpha.
      */
     public float getDisabledAlpha() {
@@ -74,7 +79,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->DisabledAlpha = value;
     */
 
-    /**
+     /**
      * Padding within a window.
      */
     public ImVec2 getWindowPadding() {
@@ -135,7 +140,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowPadding = value;
     */
 
-    /**
+     /**
      * Radius of window corners rounding. Set to 0.0f to have rectangular windows.
      * Large values tend to lead to variety of artifacts and are not recommended.
      */
@@ -159,7 +164,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
      */
     public float getWindowBorderSize() {
@@ -181,7 +186,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowBorderSize = value;
     */
 
-    /**
+     /**
      * Minimum window size. This is a global setting. If you want to constraint individual windows, use SetNextWindowSizeConstraints().
      */
     public ImVec2 getWindowMinSize() {
@@ -242,7 +247,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowMinSize = value;
     */
 
-    /**
+     /**
      * Alignment for title bar text. Defaults to (0.0f,0.5f) for left-aligned,vertically centered.
      */
     public ImVec2 getWindowTitleAlign() {
@@ -303,7 +308,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowTitleAlign = value;
     */
 
-    /**
+     /**
      * Side of the collapsing/docking button in the title bar (None/Left/Right). Defaults to ImGuiDir_Left.
      */
     public int getWindowMenuButtonPosition() {
@@ -325,7 +330,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowMenuButtonPosition = value;
     */
 
-    /**
+     /**
      * Radius of child window corners rounding. Set to 0.0f to have rectangular windows.
      */
     public float getChildRounding() {
@@ -347,7 +352,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ChildRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around child windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
      */
     public float getChildBorderSize() {
@@ -369,7 +374,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ChildBorderSize = value;
     */
 
-    /**
+     /**
      * Radius of popup window corners rounding. (Note that tooltip windows use WindowRounding)
      */
     public float getPopupRounding() {
@@ -391,7 +396,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->PopupRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around popup/tooltip windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
      */
     public float getPopupBorderSize() {
@@ -413,7 +418,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->PopupBorderSize = value;
     */
 
-    /**
+     /**
      * Padding within a framed rectangle (used by most widgets).
      */
     public ImVec2 getFramePadding() {
@@ -474,7 +479,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->FramePadding = value;
     */
 
-    /**
+     /**
      * Radius of frame corners rounding. Set to 0.0f to have rectangular frame (used by most widgets).
      */
     public float getFrameRounding() {
@@ -496,7 +501,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->FrameRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around frames. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
      */
     public float getFrameBorderSize() {
@@ -518,7 +523,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->FrameBorderSize = value;
     */
 
-    /**
+     /**
      * Horizontal and vertical spacing between widgets/lines.
      */
     public ImVec2 getItemSpacing() {
@@ -579,7 +584,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ItemSpacing = value;
     */
 
-    /**
+     /**
      * Horizontal and vertical spacing between within elements of a composed widget (e.g. a slider and its label).
      */
     public ImVec2 getItemInnerSpacing() {
@@ -640,7 +645,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ItemInnerSpacing = value;
     */
 
-    /**
+     /**
      * Padding within a table cell.
      */
     public ImVec2 getCellPadding() {
@@ -701,7 +706,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->CellPadding = value;
     */
 
-    /**
+     /**
      * Expand reactive bounding box for touch-based system where touch position is not accurate enough.
      * Unfortunately we don't sort widgets so priority on overlap will always be given to the first widget. So don't grow this too much!
      */
@@ -768,7 +773,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->TouchExtraPadding = value;
     */
 
-    /**
+     /**
      * Horizontal indentation when e.g. entering a tree node. Generally == (FontSize + FramePadding.x*2).
      */
     public float getIndentSpacing() {
@@ -790,7 +795,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->IndentSpacing = value;
     */
 
-    /**
+     /**
      * Minimum horizontal spacing between two columns. Preferably {@code >} (FramePadding.x + 1).
      */
     public float getColumnsMinSpacing() {
@@ -812,7 +817,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ColumnsMinSpacing = value;
     */
 
-    /**
+     /**
      * Width of the vertical scrollbar, Height of the horizontal scrollbar.
      */
     public float getScrollbarSize() {
@@ -834,7 +839,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ScrollbarSize = value;
     */
 
-    /**
+     /**
      * Radius of grab corners for scrollbar.
      */
     public float getScrollbarRounding() {
@@ -856,7 +861,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ScrollbarRounding = value;
     */
 
-    /**
+     /**
      * Minimum width/height of a grab box for slider/scrollbar.
      */
     public float getGrabMinSize() {
@@ -878,7 +883,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->GrabMinSize = value;
     */
 
-    /**
+     /**
      * Radius of grabs corners rounding. Set to 0.0f to have rectangular slider grabs.
      */
     public float getGrabRounding() {
@@ -900,7 +905,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->GrabRounding = value;
     */
 
-    /**
+     /**
      * The size in pixels of the dead-zone around zero on logarithmic sliders that cross zero.
      */
     public float getLogSliderDeadzone() {
@@ -922,7 +927,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->LogSliderDeadzone = value;
     */
 
-    /**
+     /**
      * Radius of upper corners of a tab. Set to 0.0f to have rectangular tabs.
      */
     public float getTabRounding() {
@@ -944,7 +949,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->TabRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around tabs.
      */
     public float getTabBorderSize() {
@@ -966,7 +971,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->TabBorderSize = value;
     */
 
-    /**
+     /**
      * Minimum width for close button to appears on an unselected tab when hovered.
      * Set to 0.0f to always show when hovering, set to FLT_MAX to never show close button unless selected.
      */
@@ -990,7 +995,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->TabMinWidthForCloseButton = value;
     */
 
-    /**
+     /**
      * Side of the color button in the ColorEdit4 widget (left/right). Defaults to ImGuiDir_Right.
      */
     public int getColorButtonPosition() {
@@ -1012,7 +1017,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ColorButtonPosition = value;
     */
 
-    /**
+     /**
      * Alignment of button text when button is larger than text. Defaults to (0.5f, 0.5f) (centered).
      */
     public ImVec2 getButtonTextAlign() {
@@ -1073,7 +1078,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ButtonTextAlign = value;
     */
 
-    /**
+     /**
      * Alignment of selectable text. Defaults to (0.0f, 0.0f) (top-left aligned).
      * It's generally important to keep this left-aligned if you want to lay multiple items on a same line.
      */
@@ -1140,7 +1145,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->SelectableTextAlign = value;
     */
 
-    /**
+     /**
      * Window position are clamped to be visible within the display area by at least this amount. Only applies to regular windows.
      */
     public ImVec2 getDisplayWindowPadding() {
@@ -1201,7 +1206,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->DisplayWindowPadding = value;
     */
 
-    /**
+     /**
      * If you cannot see the edges of your screen (e.g. on a TV) increase the safe area padding.
      * Apply to popups/tooltips as well regular windows. NB: Prefer configuring your TV sets correctly!
      */
@@ -1268,7 +1273,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->DisplaySafeAreaPadding = value;
     */
 
-    /**
+     /**
      * Scale software rendered mouse cursor (when io.MouseDrawCursor is enabled). May be removed later.
      */
     public float getMouseCursorScale() {
@@ -1290,7 +1295,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->MouseCursorScale = value;
     */
 
-    /**
+     /**
      * Enable anti-aliased lines/borders. Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame (copied to ImDrawList).
      */
     public boolean getAntiAliasedLines() {
@@ -1312,7 +1317,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->AntiAliasedLines = value;
     */
 
-    /**
+     /**
      * Enable anti-aliased lines/borders using textures where possible.
      * Require backend to render with bilinear filtering.
      * Latched at the beginning of the frame (copied to ImDrawList).
@@ -1338,7 +1343,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->AntiAliasedLinesUseTex = value;
     */
 
-    /**
+     /**
      * Enable anti-aliased edges around filled shapes (rounded rectangles, circles, etc.).
      * Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame (copied to ImDrawList).
      */
@@ -1362,7 +1367,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->AntiAliasedFill = value;
     */
 
-    /**
+     /**
      * Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments.
      * Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
      */
@@ -1386,7 +1391,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->CurveTessellationTol = value;
     */
 
-    /**
+     /**
      * Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified.
      * Decrease for higher quality but more geometry.
      */

--- a/imgui-binding/src/generated/java/imgui/ImGuiTableColumnSortSpecs.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTableColumnSortSpecs.java
@@ -2,9 +2,13 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 /**
  * Sorting specification for one column of a table.
  */
+
 public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
 
     public ImGuiTableColumnSortSpecs(final long ptr) {
@@ -16,7 +20,7 @@ public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
         #define THIS ((ImGuiTableColumnSortSpecs*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * User id of the column (if specified by a TableSetupColumn() call)
      */
     public int getColumnUserID() {
@@ -27,7 +31,7 @@ public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
         return THIS->ColumnUserID;
     */
 
-    /**
+     /**
      * Index of the column
      */
     public int getColumnIndex() {
@@ -38,7 +42,7 @@ public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
         return THIS->ColumnIndex;
     */
 
-    /**
+     /**
      * Index within parent ImGuiTableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
      */
     public int getSortOrder() {
@@ -49,7 +53,7 @@ public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
         return THIS->SortOrder;
     */
 
-    /**
+     /**
      * ImGuiSortDirection_Ascending or ImGuiSortDirection_Descending (you can use this or SortSign, whichever is more convenient for your sort function)
      */
     public int getSortDirection() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiTableSortSpecs.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTableSortSpecs.java
@@ -2,12 +2,16 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 /**
  * Sorting specifications for a table (often handling sort specs for a single column, occasionally more)
  * Obtained by calling TableGetSortSpecs().
  * When 'SpecsDirty == true' you can sort your data. It will be true with sorting specs have changed since last call, or the first time.
  * Make sure to set 'SpecsDirty = false' after sorting, else you may wastefully sort your data every frame!
  */
+
 public final class ImGuiTableSortSpecs extends ImGuiStruct {
     public ImGuiTableSortSpecs(final long ptr) {
         super(ptr);
@@ -43,7 +47,7 @@ public final class ImGuiTableSortSpecs extends ImGuiStruct {
         return result;
     */
 
-    /**
+     /**
      * Sort spec count. Most often 1. May be {@code >} 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
      */
     public int getSpecsCount() {
@@ -54,7 +58,7 @@ public final class ImGuiTableSortSpecs extends ImGuiStruct {
         return THIS->SpecsCount;
     */
 
-    /**
+     /**
      * Set to true when specs have changed since last time! Use this to sort again, then clear the flag.
      */
     public boolean getSpecsDirty() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiTextFilter.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTextFilter.java
@@ -2,9 +2,14 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
 /**
  * Helper: Parse and apply text filters. In format "aaaaa[,bbbb][,ccccc]"
  */
+
 public final class ImGuiTextFilter extends ImGuiStructDestroyable {
     public ImGuiTextFilter() {
         this("");

--- a/imgui-binding/src/generated/java/imgui/ImGuiViewport.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiViewport.java
@@ -2,11 +2,16 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
 /**
  * The viewports created and managed by Dear ImGui. The role of the platform backend is to create the platform/OS windows corresponding to each viewport.
  * - Main Area = entire viewport.
  * - Work Area = entire viewport minus sections optionally used by menu bars, status bars. Some positioning code will prefer to use this. Window are also trying to stay within this area.
  */
+
 public final class ImGuiViewport extends ImGuiStruct {
     public ImGuiViewport(final long ptr) {
         super(ptr);
@@ -17,7 +22,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         #define THIS ((ImGuiViewport*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Unique identifier for the viewport.
      */
     public int getID() {
@@ -39,7 +44,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->ID = value;
     */
 
-    /**
+     /**
      * See {@link imgui.flag.ImGuiViewportFlags}.
      */
     public int getFlags() {
@@ -82,7 +87,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->Flags = value;
     */
 
-    /**
+     /**
      * Main Area: Position of the viewport (the imgui coordinates are the same as OS desktop/native coordinates).
      */
     public ImVec2 getPos() {
@@ -143,7 +148,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->Pos = value;
     */
 
-    /**
+     /**
      * Main Area: Size of the viewport.
      */
     public ImVec2 getSize() {
@@ -204,7 +209,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->Size = value;
     */
 
-    /**
+     /**
      * Work Area: Position of the viewport minus task bars, menus bars, status bars.
      */
     public ImVec2 getWorkPos() {
@@ -265,7 +270,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->WorkPos = value;
     */
 
-    /**
+     /**
      * Work Area: Size of the viewport minus task bars, menu bars, status bars.
      */
     public ImVec2 getWorkSize() {
@@ -326,7 +331,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->WorkSize = value;
     */
 
-    /**
+     /**
      * 1.0f = 96 DPI = No extra scale.
      */
     public float getDpiScale() {
@@ -348,7 +353,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->DpiScale = value;
     */
 
-    /**
+     /**
      * (Advanced) 0: no parent. Instruct the platform backend to setup a parent/child relationship between platform windows.
      */
     public int getParentViewportId() {
@@ -370,7 +375,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->ParentViewportId = value;
     */
 
-    /**
+     /**
      * The ImDrawData corresponding to this viewport. Valid after Render() and until the next call to NewFrame().
      */
     public ImDrawData getDrawData() {
@@ -459,7 +464,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         return (uintptr_t)THIS->PlatformHandleRaw;
     */
 
-    /**
+     /**
      * Platform window requested move (e.g. window was moved by the OS / host window manager, authoritative position will be OS window position).
      */
     public boolean getPlatformRequestMove() {
@@ -481,7 +486,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->PlatformRequestMove = value;
     */
 
-    /**
+     /**
      * Platform window requested resize (e.g. window was resized by the OS / host window manager, authoritative size will be OS window size).
      */
     public boolean getPlatformRequestResize() {
@@ -503,7 +508,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->PlatformRequestResize = value;
     */
 
-    /**
+     /**
      * Platform window requested closure (e.g. window was moved by the OS / host window manager, e.g. pressing ALT-F4).
      */
     public boolean getPlatformRequestClose() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiWindowClass.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiWindowClass.java
@@ -2,6 +2,8 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
 /**
  * [ALPHA] Rarely used / very advanced uses only. Use with SetNextWindowClass() and DockSpace() functions.
  * Important: the content of this class is still highly WIP and likely to change and be refactored
@@ -11,6 +13,7 @@ import imgui.binding.ImGuiStructDestroyable;
  * - To the platform backend for OS level parent/child relationships of viewport.
  * - To the docking system for various options and filtering.
  */
+
 public final class ImGuiWindowClass extends ImGuiStructDestroyable {
     public ImGuiWindowClass() {
         super();
@@ -34,7 +37,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImGuiWindowClass());
     */
 
-    /**
+     /**
      * User data. 0 = Default class (unclassed). Windows of different classes cannot be docked with each others.
      */
     public int getClassId() {
@@ -56,7 +59,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->ClassId = value;
     */
 
-    /**
+     /**
      * Hint for the platform backend. If non-zero, the platform backend can create a parent{@code <>}child relationship between the platform windows.
      * Not conforming backends are free to e.g. parent every viewport to the main viewport or not.
      */
@@ -80,7 +83,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->ParentViewportId = value;
     */
 
-    /**
+     /**
      * Viewport flags to set when a window of this class owns a viewport.
      * This allows you to enforce OS decoration or task bar icon, override the defaults on a per-window basis.
      */
@@ -128,7 +131,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->ViewportFlagsOverrideSet = value;
     */
 
-    /**
+     /**
      * Viewport flags to clear when a window of this class owns a viewport.
      * This allows you to enforce OS decoration or task bar icon, override the defaults on a per-window basis.
      */
@@ -176,7 +179,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->ViewportFlagsOverrideClear = value;
     */
 
-    /**
+     /**
      * [EXPERIMENTAL] TabItem flags to set when a window of this class gets submitted into a dock node tab bar.
      * May use with ImGuiTabItemFlags_Leading or ImGuiTabItemFlags_Trailing.
      */
@@ -224,7 +227,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->TabItemFlagsOverrideSet = value;
     */
 
-    /**
+     /**
      * [EXPERIMENTAL] Dock node flags to set when a window of this class is hosted by a dock node (it doesn't have to be selected!)
      */
     public int getDockNodeFlagsOverrideSet() {
@@ -267,7 +270,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->DockNodeFlagsOverrideSet = value;
     */
 
-    /**
+     /**
      * Set to true to enforce single floating windows of this class always having their own docking node
      * (equivalent of setting the global io.ConfigDockingAlwaysTabBar)
      */
@@ -291,7 +294,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->DockingAlwaysTabBar = value;
     */
 
-    /**
+     /**
      * Set to true to allow windows of this class to be docked/merged with an unclassed window.
      */
     public boolean getDockingAllowUnclassed() {

--- a/imgui-binding/src/generated/java/imgui/extension/imguifiledialog/ImGuiFileDialog.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguifiledialog/ImGuiFileDialog.java
@@ -1,6 +1,11 @@
 package imgui.extension.imguifiledialog;
 
 import imgui.ImVec2;
+
+
+
+
+
 import imgui.extension.imguifiledialog.callback.ImGuiFileDialogPaneFun;
 
 import java.util.HashMap;
@@ -9,6 +14,7 @@ import java.util.HashMap;
  * ImGuiFileDialog extension for ImGui
  * Repo: <a href="https://github.com/aiekick/ImGuiFileDialog">https://github.com/aiekick/ImGuiFileDialog</a>
  */
+
 public final class ImGuiFileDialog {
     private ImGuiFileDialog() {
     }
@@ -30,7 +36,7 @@ public final class ImGuiFileDialog {
         }
     */
 
-    /**
+     /**
      * Open simple dialog (path and fileName can be specified)
      *
      * @param vKey
@@ -152,7 +158,7 @@ public final class ImGuiFileDialog {
         if (vFileName != NULL) env->ReleaseStringUTFChars(obj_vFileName, vFileName);
     */
 
-    /**
+     /**
      * Open simple dialog (path and filename are obtained from filePathName)
      *
      * @param vKey
@@ -266,7 +272,7 @@ public final class ImGuiFileDialog {
         if (vFilePathName != NULL) env->ReleaseStringUTFChars(obj_vFilePathName, vFilePathName);
     */
 
-    /**
+     /**
      * Open dialog with custom right pane (path and fileName can be specified)
      *
      * @param vKey
@@ -460,7 +466,7 @@ public final class ImGuiFileDialog {
         if (vFileName != NULL) env->ReleaseStringUTFChars(obj_vFileName, vFileName);
     */
 
-    /**
+     /**
      * Open dialog with custom right pane (path and filename are obtained from filePathName)
      *
      * @param vKey
@@ -643,7 +649,7 @@ public final class ImGuiFileDialog {
     */
 
 
-    /**
+     /**
      * Open simple modal (path and fileName can be specified)
      *
      * @param vKey
@@ -765,7 +771,7 @@ public final class ImGuiFileDialog {
         if (vFileName != NULL) env->ReleaseStringUTFChars(obj_vFileName, vFileName);
     */
 
-    /**
+     /**
      * open simple modal (path and filename are obtained from filePathName)
      *
      * @param vKey
@@ -880,7 +886,8 @@ public final class ImGuiFileDialog {
     */
 
 
-    /**
+
+     /**
      * Open modal with custom right pane (path and fileName can be specified)
      *
      * @param vKey
@@ -1082,7 +1089,7 @@ public final class ImGuiFileDialog {
         if (vFileName != NULL) env->ReleaseStringUTFChars(obj_vFileName, vFileName);
     */
 
-    /**
+     /**
      * Open modal with custom right pane (path and filename are obtained from filePathName)
      *
      * @param vKey
@@ -1272,7 +1279,7 @@ public final class ImGuiFileDialog {
         if (vFilePathName != NULL) env->ReleaseStringUTFChars(obj_vFilePathName, vFilePathName);
     */
 
-    /**
+     /**
      * Display / Close dialog form
      * Display the dialog. return true if a result was obtained (Ok or not)
      *
@@ -1382,7 +1389,7 @@ public final class ImGuiFileDialog {
     */
 
 
-    /**
+     /**
      * Close dialog
      */
     public static void close() {
@@ -1394,7 +1401,7 @@ public final class ImGuiFileDialog {
     */
 
 
-    /**
+     /**
      * Say if the dialog key was already opened this frame
      *
      * @return if the dialog key was already opened this frame
@@ -1425,7 +1432,7 @@ public final class ImGuiFileDialog {
         return _result;
     */
 
-    /**
+     /**
      * Say if the key is opened
      *
      * @return if the key is opened
@@ -1456,7 +1463,7 @@ public final class ImGuiFileDialog {
         return _result;
     */
 
-    /**
+     /**
      * Return the dialog key who is opened, return nothing if not opened
      *
      * @return the dialog key who is opened or nothing is not opened
@@ -1470,7 +1477,7 @@ public final class ImGuiFileDialog {
     */
 
 
-    /**
+     /**
      * true: Dialog Closed with Ok result / false: Dialog closed with cancel result
      *
      * @return True if the dialog closed with Ok result, or false with cancel result
@@ -1522,7 +1529,7 @@ public final class ImGuiFileDialog {
     */
 
 
-    /**
+     /**
      * Save File behavior : will always return the content of the field with current filter extention and current path
      */
     public static String getFilePathName() {
@@ -1533,7 +1540,7 @@ public final class ImGuiFileDialog {
         return env->NewStringUTF(ImGuiFileDialog::Instance()->GetFilePathName().c_str());
     */
 
-    /**
+     /**
      * Save File behavior : will always return the content of the field with current filter extension
      *
      * @return the content of the field with current filter extension
@@ -1546,7 +1553,7 @@ public final class ImGuiFileDialog {
         return env->NewStringUTF(ImGuiFileDialog::Instance()->GetCurrentFileName().c_str());
     */
 
-    /**
+     /**
      * Will return current path
      *
      * @return the current path
@@ -1559,7 +1566,7 @@ public final class ImGuiFileDialog {
         return env->NewStringUTF(ImGuiFileDialog::Instance()->GetCurrentPath().c_str());
     */
 
-    /**
+     /**
      * Will return selected filter
      *
      * @return the selected filter
@@ -1573,7 +1580,7 @@ public final class ImGuiFileDialog {
     */
 
 
-    /**
+     /**
      * Will return user datas sent with Open Dialog/Modal
      * <p>
      * Can be used to pass a long value to the dialog and get the value back.

--- a/imgui-binding/src/generated/java/imgui/extension/imguifiledialog/flag/ImGuiFileDialogFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguifiledialog/flag/ImGuiFileDialogFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.imguifiledialog.flag;
 
 
+
+
+
 public final class ImGuiFileDialogFlags {
     private ImGuiFileDialogFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imguiknobs/ImGuiKnobs.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguiknobs/ImGuiKnobs.java
@@ -1,5 +1,8 @@
 package imgui.extension.imguiknobs;
 
+
+
+
 import imgui.type.ImFloat;
 import imgui.type.ImInt;
 
@@ -7,6 +10,7 @@ import imgui.type.ImInt;
  * ImGuiKnobs extension for ImGui
  * Repo: https://github.com/altschuler/imgui-knobs
  */
+
 public final class ImGuiKnobs {
     private ImGuiKnobs() {
     }
@@ -15,7 +19,7 @@ public final class ImGuiKnobs {
         #include "_imguiknobs.h"
      */
 
-    /**
+     /**
      * Create a knob with float values
      *
      * @param label
@@ -513,7 +517,7 @@ public final class ImGuiKnobs {
         return _result;
     */
 
-    /**
+     /**
      * Create a knob with int values
      *
      * @param label

--- a/imgui-binding/src/generated/java/imgui/extension/imguiknobs/flag/ImGuiKnobFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguiknobs/flag/ImGuiKnobFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.imguiknobs.flag;
 
 
+
+
+
 public final class ImGuiKnobFlags {
     private ImGuiKnobFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imguiknobs/flag/ImGuiKnobVariant.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguiknobs/flag/ImGuiKnobVariant.java
@@ -1,6 +1,9 @@
 package imgui.extension.imguiknobs.flag;
 
 
+
+
+
 public final class ImGuiKnobVariant {
     private ImGuiKnobVariant() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imguizmo/ImGuizmo.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguizmo/ImGuizmo.java
@@ -2,7 +2,12 @@ package imgui.extension.imguizmo;
 
 import imgui.ImDrawList;
 import imgui.ImVec2;
+
+
+
+
 import imgui.internal.ImGuiContext;
+
 
 public final class ImGuizmo {
     private ImGuizmo() {
@@ -12,7 +17,7 @@ public final class ImGuizmo {
         #include "_imguizmo.h"
      */
 
-    /**
+     /**
      * Call inside your own window and before Manipulate() in order to draw gizmo to that window.
      * Or pass a specific ImDrawList to draw to (e.g. ImGui::GetForegroundDrawList()).
      */
@@ -36,7 +41,7 @@ public final class ImGuizmo {
         ImGuizmo::SetDrawlist(reinterpret_cast<ImDrawList*>(drawList));
     */
 
-    /**
+     /**
      * Call BeginFrame right after ImGui_XXXX_NewFrame();
      */
     public static void beginFrame() {
@@ -47,7 +52,7 @@ public final class ImGuizmo {
         ImGuizmo::BeginFrame();
     */
 
-    /**
+     /**
      * This is necessary because when imguizmo is compiled into a dll, and imgui into another
      * Globals are not shared between them.
      * More details at https://stackoverflow.com/questions/19373061/what-happens-to-global-and-static-variables-in-a-shared-library-when-it-is-dynam
@@ -61,7 +66,7 @@ public final class ImGuizmo {
         ImGuizmo::SetImGuiContext(reinterpret_cast<ImGuiContext*>(ctx));
     */
 
-    /**
+     /**
      * Return true if mouse cursor is over any gizmo control (axis, plan or screen component)
      */
     public static boolean isOver() {
@@ -72,7 +77,7 @@ public final class ImGuizmo {
         return ImGuizmo::IsOver();
     */
 
-    /**
+     /**
      * Return true if mouse IsOver or if the gizmo is in moving state
      */
     public static boolean isUsing() {
@@ -83,7 +88,7 @@ public final class ImGuizmo {
         return ImGuizmo::IsUsing();
     */
 
-    /**
+     /**
      * Enable/disable the gizmo. Stay in the state until next call to Enable.
      * Gizmo is rendered with gray half transparent color when disabled
      */
@@ -95,7 +100,7 @@ public final class ImGuizmo {
         ImGuizmo::Enable(enable);
     */
 
-    /**
+     /**
      * Helper function for manually editing Translation/Rotation/Scale with an input float.
      * Translation, Rotation and Scale float points to 3 floats each.
      * Angles are in degrees (more suitable for human editing).
@@ -126,7 +131,7 @@ public final class ImGuizmo {
         if (scale != NULL) env->ReleasePrimitiveArrayCritical(obj_scale, scale, JNI_FALSE);
     */
 
-    /**
+     /**
      * Helper function for manually editing Translation/Rotation/Scale with an input float.
      * Translation, Rotation and Scale float points to 3 floats each.
      * Angles are in degrees (more suitable for human editing).
@@ -157,7 +162,7 @@ public final class ImGuizmo {
         if (matrix != NULL) env->ReleasePrimitiveArrayCritical(obj_matrix, matrix, JNI_FALSE);
     */
 
-    /**
+     /**
      * This will set the rect position.
      *
      * @param x
@@ -177,7 +182,7 @@ public final class ImGuizmo {
         ImGuizmo::SetRect(x, y, width, height);
     */
 
-    /**
+     /**
      * Making sure if we're set to ortho or not.
      */
     public static void setOrthographic(final boolean isOrthographic) {
@@ -188,7 +193,7 @@ public final class ImGuizmo {
         ImGuizmo::SetOrthographic(isOrthographic);
     */
 
-    /**
+     /**
      * Drawing an arbitrary cube in the world.
      *
      * @param view
@@ -212,7 +217,7 @@ public final class ImGuizmo {
         if (matrices != NULL) env->ReleasePrimitiveArrayCritical(obj_matrices, matrices, JNI_FALSE);
     */
 
-    /**
+     /**
      * Drawing an arbitrary cube in the world.
      *
      * @param view
@@ -259,7 +264,7 @@ public final class ImGuizmo {
         drawCubes(view, projection, cubeMatrices, cubeMatrices.length);
     }
 
-    /**
+     /**
      * Drawing a grid to the world (should only be used for debugging purposes).
      *
      * @param view
@@ -285,7 +290,7 @@ public final class ImGuizmo {
         if (matrix != NULL) env->ReleasePrimitiveArrayCritical(obj_matrix, matrix, JNI_FALSE);
     */
 
-    /**
+     /**
      * Manipulating the given model matrix with delta matrix
      *
      * @param view
@@ -465,7 +470,7 @@ public final class ImGuizmo {
         if (boundsSnap != NULL) env->ReleasePrimitiveArrayCritical(obj_boundsSnap, boundsSnap, JNI_FALSE);
     */
 
-    /**
+     /**
      * Manipulating the view
      *
      * @param view
@@ -497,7 +502,7 @@ public final class ImGuizmo {
         if (view != NULL) env->ReleasePrimitiveArrayCritical(obj_view, view, JNI_FALSE);
     */
 
-    /**
+     /**
      * This will update the current id
      */
     public static void setID(final int id) {
@@ -508,7 +513,7 @@ public final class ImGuizmo {
         ImGuizmo::SetID(id);
     */
 
-    /**
+     /**
      * Return true if the cursor is over the operation's gizmo
      */
     public static boolean isOver(final int operation) {
@@ -527,7 +532,7 @@ public final class ImGuizmo {
         ImGuizmo::SetGizmoSizeClipSpace(value);
     */
 
-    /**
+     /**
      * Allow axis to flip.
      * When true (default), the guizmo axis flip for better visibility.
      * When false, they always stay along the positive world/local axis.

--- a/imgui-binding/src/generated/java/imgui/extension/imguizmo/flag/Mode.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguizmo/flag/Mode.java
@@ -1,6 +1,9 @@
 package imgui.extension.imguizmo.flag;
 
 
+
+
+
 public final class Mode {
     private Mode() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imguizmo/flag/Operation.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguizmo/flag/Operation.java
@@ -1,11 +1,14 @@
 package imgui.extension.imguizmo.flag;
 
 
+
+
 /**
  * Needs view and projection matrices.
  * Matrix parameter is the source matrix (where will be gizmo be drawn) and might be transformed by the function. Return deltaMatrix is optional.
  * Translation is applied in world space.
  */
+
 public final class Operation {
     private Operation() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
@@ -1,6 +1,11 @@
 package imgui.extension.imnodes;
 
 import imgui.ImVec2;
+
+
+
+
+
 import imgui.internal.ImGuiContext;
 import imgui.type.ImBoolean;
 import imgui.type.ImInt;
@@ -11,6 +16,7 @@ import imgui.type.ImInt;
  * <p>
  * Refer to the library's Github page for examples and support
  */
+
 public final class ImNodes {
     private ImNodes() {
     }
@@ -159,7 +165,7 @@ public final class ImNodes {
         return (uintptr_t)&ImNodes::GetIO();
     */
 
-    private static final ImNodesStyle _GETSTYLE_1 = new ImNodesStyle(0);
+     private static final ImNodesStyle _GETSTYLE_1 = new ImNodesStyle(0);
 
     /**
      * Returns the global style struct. See the struct declaration for default values.
@@ -199,7 +205,7 @@ public final class ImNodes {
         ImNodes::StyleColorsLight();
     */
 
-    /**
+     /**
      * The top-level function call. Call this before calling BeginNode/EndNode. Calling this function
      * will result the node editor grid workspace being rendered.
      */
@@ -219,7 +225,7 @@ public final class ImNodes {
         ImNodes::EndNodeEditor();
     */
 
-    /**
+     /**
      * Add a navigable minimap to the editor; call before EndNodeEditor after all nodes and links have been specified
      * // TODO: add callback
      */
@@ -255,7 +261,7 @@ public final class ImNodes {
         ImNodes::MiniMap(miniMapSizeFraction, static_cast<ImNodesMiniMapLocation>(miniMapLocation));
     */
 
-    /**
+     /**
      * Use PushColorStyle and PopColorStyle to modify ImNodesColorStyle mid-frame.
      */
     public static void pushColorStyle(final int item, final int color) {
@@ -349,7 +355,7 @@ public final class ImNodes {
         return ImNodes::GetNodeDimensions(id).y;
     */
 
-    /**
+     /**
      * Place your node title bar content (such as the node title, using ImGui::Text) between the
      * following function calls. These functions have to be called before adding any attributes, or the
      * layout of the node will be incorrect.
@@ -379,7 +385,7 @@ public final class ImNodes {
     //
     // Each attribute id must be unique.
 
-    /**
+     /**
      * Create an input attribute block. The pin is rendered on left side.
      */
     public static void beginInputAttribute(final int id) {
@@ -411,7 +417,7 @@ public final class ImNodes {
         ImNodes::EndInputAttribute();
     */
 
-    /**
+     /**
      * Create an output attribute block. The pin is rendered on the right side.
      */
     public static void beginOutputAttribute(final int id) {
@@ -441,7 +447,7 @@ public final class ImNodes {
         ImNodes::EndOutputAttribute();
     */
 
-    /**
+     /**
      * Create a static attribute block. A static attribute has no pin, and therefore can't be linked to
      * anything. However, you can still use IsAttributeActive() and IsAnyAttributeActive() to check for
      * attribute activity.
@@ -462,7 +468,7 @@ public final class ImNodes {
         ImNodes::EndStaticAttribute();
     */
 
-    /**
+     /**
      * Push a single AttributeFlags value. By default, only AttributeFlags_None is set.
      */
     public static void pushAttributeFlag(final int flag) {
@@ -481,7 +487,7 @@ public final class ImNodes {
         ImNodes::PopAttributeFlag();
     */
 
-    /**
+     /**
      * Render a link between attributes.
      * The attributes ids used here must match the ids used in Begin(Input|Output)Attribute function
      * calls. The order of source and target doesn't make a difference for rendering the link.
@@ -494,7 +500,7 @@ public final class ImNodes {
         ImNodes::Link(id, source, target);
     */
 
-    /**
+     /**
      * Enable or disable the ability to click and drag a specific node.
      */
     public static void setNodeDraggable(final int nodeId, final boolean draggable) {
@@ -552,39 +558,31 @@ public final class ImNodes {
         ImNodes::SetNodeGridSpacePos(nodeId, gridPos);
     */
 
-    public static void getNodeScreenSpacePos(ImVec2 dst, final int nodeId) {
-        nGetNodeScreenSpacePos(dst, nodeId);
+    public static void getNodeScreenSpacePos(final int nodeId) {
+        nGetNodeScreenSpacePos(nodeId);
     }
 
-    private static native void nGetNodeScreenSpacePos(ImVec2 dst, int nodeId); /*
-        Jni::ImVec2Cpy(env, ImNodes::GetNodeScreenSpacePos(nodeId), dst);
+    private static native void nGetNodeScreenSpacePos(int nodeId); /*
+        ImNodes::GetNodeScreenSpacePos(nodeId);
     */
 
-    public static void getNodeEditorSpacePos(ImVec2 dst, final int nodeId) {
-        nGetNodeEditorSpacePos(dst, nodeId);
+    public static void getNodeEditorSpacePos(final int nodeId) {
+        nGetNodeEditorSpacePos(nodeId);
     }
 
-    private static native void nGetNodeEditorSpacePos(ImVec2 dst, int nodeId); /*
-        Jni::ImVec2Cpy(env, ImNodes::GetNodeEditorSpacePos(nodeId), dst);
+    private static native void nGetNodeEditorSpacePos(int nodeId); /*
+        ImNodes::GetNodeEditorSpacePos(nodeId);
     */
 
-    public static void getNodeGridSpacePos(ImVec2 dst, final int nodeId) {
-        nGetNodeGridSpacePos(dst, nodeId);
+    public static void getNodeGridSpacePos(final int nodeId) {
+        nGetNodeGridSpacePos(nodeId);
     }
 
-    private static native void nGetNodeGridSpacePos(ImVec2 dst, int nodeId); /*
-        Jni::ImVec2Cpy(env, ImNodes::GetNodeGridSpacePos(nodeId), dst);
+    private static native void nGetNodeGridSpacePos(int nodeId); /*
+        ImNodes::GetNodeGridSpacePos(nodeId);
     */
 
-    public static void snapNodeToGrid(final int nodeId) {
-        nSnapNodeToGrid(nodeId);
-    }
-
-    private static native void nSnapNodeToGrid(int nodeId); /*
-        ImNodes::SnapNodeToGrid(nodeId);
-    */
-
-    /**
+     /**
      * Returns true if the current node editor canvas is being hovered over by the mouse, and is not
      * blocked by any other windows.
      */
@@ -664,7 +662,7 @@ public final class ImNodes {
         return ImNodes::IsPinHovered(&i) ? i : -1;
     */
 
-    /**
+     /**
      * Use The following two functions to query the number of selected nodes or links in the current
      * editor. Use after calling EndNodeEditor().
      */
@@ -684,7 +682,7 @@ public final class ImNodes {
         return ImNodes::NumSelectedLinks();
     */
 
-    /**
+     /**
      * Get the selected node/link ids. The pointer argument should point to an integer array with at
      * least as many elements as the respective NumSelectedNodes/NumSelectedLinks function call
      * returned.
@@ -699,7 +697,7 @@ public final class ImNodes {
         if (nodeIds != NULL) env->ReleasePrimitiveArrayCritical(obj_nodeIds, nodeIds, JNI_FALSE);
     */
 
-    /**
+     /**
      * Get the selected node/link ids. The pointer argument should point to an integer array with at
      * least as many elements as the respective NumSelectedNodes/NumSelectedLinks function call
      * returned.
@@ -714,7 +712,7 @@ public final class ImNodes {
         if (linkIds != NULL) env->ReleasePrimitiveArrayCritical(obj_linkIds, linkIds, JNI_FALSE);
     */
 
-    /**
+     /**
      * Clears the list of selected nodes/links. Useful if you want to delete a selected node or link.
      */
     public static void clearNodeSelection() {
@@ -725,7 +723,7 @@ public final class ImNodes {
         ImNodes::ClearNodeSelection();
     */
 
-    /**
+     /**
      * Clears the list of selected nodes/links. Useful if you want to delete a selected node or link.
      */
     public static void clearLinkSelection() {
@@ -736,7 +734,7 @@ public final class ImNodes {
         ImNodes::ClearLinkSelection();
     */
 
-    /**
+     /**
      * Manually select a node or link.
      */
     public static void selectNode(final int nodeId) {
@@ -787,7 +785,7 @@ public final class ImNodes {
         return ImNodes::IsLinkSelected(linkId);
     */
 
-    /**
+     /**
      * Was the previous attribute active? This will continuously return true while the left mouse button
      * is being pressed over the UI content of the attribute.
      */
@@ -831,7 +829,7 @@ public final class ImNodes {
     // Use the following functions to query a change of state for an existing link, or new link. Call
     // these after EndNodeEditor().
 
-    /**
+     /**
      * Did the user start dragging a new link from a pin?
      */
     public static boolean isLinkStarted(final ImInt startedAtAttributeId) {
@@ -845,7 +843,7 @@ public final class ImNodes {
         return _result;
     */
 
-    /**
+     /**
      * Did the user drop the dragged link before attaching it to a pin?
      * There are two different kinds of situations to consider when handling this event:
      * 1) a link which is created at a pin and then dropped
@@ -915,7 +913,7 @@ public final class ImNodes {
         return ImNodes::IsLinkDropped(NULL, includingDetachedLinks);
     */
 
-    /**
+     /**
      * Did the user finish creating a new link?
      */
     public static boolean isLinkCreated(final ImInt startedAtAttributeId, final ImInt endedAtAttributeId) {
@@ -949,7 +947,7 @@ public final class ImNodes {
         return _result;
     */
 
-    /**
+     /**
      * Did the user finish creating a new link?
      */
     public static boolean isLinkCreated(final ImInt startedAtNodeId, final ImInt startedAtAttributeId, final ImInt endedAtNodeId, final ImInt endedAtAttributeId) {
@@ -991,7 +989,7 @@ public final class ImNodes {
         return _result;
     */
 
-    /**
+     /**
      * Was an existing link detached from a pin by the user? The detached link's id is assigned to the
      * output argument link_id.
      */

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
@@ -558,31 +558,39 @@ public final class ImNodes {
         ImNodes::SetNodeGridSpacePos(nodeId, gridPos);
     */
 
-    public static void getNodeScreenSpacePos(final int nodeId) {
-        nGetNodeScreenSpacePos(nodeId);
+    public static void getNodeScreenSpacePos(ImVec2 dst, final int nodeId) {
+        nGetNodeScreenSpacePos(dst, nodeId);
     }
 
-    private static native void nGetNodeScreenSpacePos(int nodeId); /*
-        ImNodes::GetNodeScreenSpacePos(nodeId);
+    private static native void nGetNodeScreenSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeScreenSpacePogs(nodeId), dst);
     */
 
-    public static void getNodeEditorSpacePos(final int nodeId) {
-        nGetNodeEditorSpacePos(nodeId);
+    public static void getNodeEditorSpacePos(ImVec2 dst, final int nodeId) {
+        nGetNodeEditorSpacePos(dst, nodeId);
     }
 
-    private static native void nGetNodeEditorSpacePos(int nodeId); /*
-        ImNodes::GetNodeEditorSpacePos(nodeId);
+    private static native void nGetNodeEditorSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeEditorSpacePos(nodeId), dst);
     */
 
-    public static void getNodeGridSpacePos(final int nodeId) {
-        nGetNodeGridSpacePos(nodeId);
+    public static void getNodeGridSpacePos(ImVec2 dst, final int nodeId) {
+        nGetNodeGridSpacePos(dst, nodeId);
     }
 
-    private static native void nGetNodeGridSpacePos(int nodeId); /*
-        ImNodes::GetNodeGridSpacePos(nodeId);
+    private static native void nGetNodeGridSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeGridSpacePos(nodeId), dst);
     */
 
-     /**
+    public static void snapNodeToGrid(final int nodeId) {
+        nSnapNodeToGrid(nodeId);
+    }
+
+    private static native void nSnapNodeToGrid(int nodeId); /*
+        ImNodes::SnapNodeToGrid(nodeId);
+    */
+
+    /**
      * Returns true if the current node editor canvas is being hovered over by the mouse, and is not
      * blocked by any other windows.
      */

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
@@ -552,28 +552,36 @@ public final class ImNodes {
         ImNodes::SetNodeGridSpacePos(nodeId, gridPos);
     */
 
-    public static void getNodeScreenSpacePos(final int nodeId) {
-        nGetNodeScreenSpacePos(nodeId);
+    public static void getNodeScreenSpacePos(ImVec2 dst, final int nodeId) {
+        nGetNodeScreenSpacePos(dst, nodeId);
     }
 
-    private static native void nGetNodeScreenSpacePos(int nodeId); /*
-        ImNodes::GetNodeScreenSpacePos(nodeId);
+    private static native void nGetNodeScreenSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeScreenSpacePos(nodeId), dst);
     */
 
-    public static void getNodeEditorSpacePos(final int nodeId) {
-        nGetNodeEditorSpacePos(nodeId);
+    public static void getNodeEditorSpacePos(ImVec2 dst, final int nodeId) {
+        nGetNodeEditorSpacePos(dst, nodeId);
     }
 
-    private static native void nGetNodeEditorSpacePos(int nodeId); /*
-        ImNodes::GetNodeEditorSpacePos(nodeId);
+    private static native void nGetNodeEditorSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeEditorSpacePos(nodeId), dst);
     */
 
-    public static void getNodeGridSpacePos(final int nodeId) {
-        nGetNodeGridSpacePos(nodeId);
+    public static void getNodeGridSpacePos(ImVec2 dst, final int nodeId) {
+        nGetNodeGridSpacePos(dst, nodeId);
     }
 
-    private static native void nGetNodeGridSpacePos(int nodeId); /*
-        ImNodes::GetNodeGridSpacePos(nodeId);
+    private static native void nGetNodeGridSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeGridSpacePos(nodeId), dst);
+    */
+
+    public static void snapNodeToGrid(final int nodeId) {
+        nSnapNodeToGrid(nodeId);
+    }
+
+    private static native void nSnapNodeToGrid(int nodeId); /*
+        ImNodes::SnapNodeToGrid(nodeId);
     */
 
     /**

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodesIO.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodesIO.java
@@ -2,6 +2,9 @@ package imgui.extension.imnodes;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 public final class ImNodesIO extends ImGuiStruct {
     public ImNodesIO(final long ptr) {
         super(ptr);
@@ -12,7 +15,7 @@ public final class ImNodesIO extends ImGuiStruct {
         #define THIS ((ImNodesIO*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Holding alt mouse button pans the node area, by default middle mouse button will be used
      * Set based on ImGuiMouseButton values
      */
@@ -36,7 +39,7 @@ public final class ImNodesIO extends ImGuiStruct {
         THIS->AltMouseButton = value;
     */
 
-    /**
+     /**
      * Panning speed when dragging an element and mouse is outside the main editor view.
      */
     public float getAutoPanningSpeed() {

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodesStyle.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodesStyle.java
@@ -4,6 +4,10 @@ import imgui.ImVec2;
 import imgui.ImVec4;
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
 public final class ImNodesStyle extends ImGuiStruct {
     public ImNodesStyle(final long ptr) {
         super(ptr);
@@ -153,7 +157,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->LinkHoverDistance = value;
     */
 
-    /**
+     /**
      * The circle radius used when the pin shape is either PinShape_Circle or PinShape_CircleFilled.
      */
     public float getPinCircleRadius() {
@@ -175,7 +179,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinCircleRadius = value;
     */
 
-    /**
+     /**
      * The quad side length used when the shape is either PinShape_Quad or PinShape_QuadFilled.
      */
     public float getPinQuadSideLength() {
@@ -197,7 +201,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinQuadSideLength = value;
     */
 
-    /**
+     /**
      * The equilateral triangle side length used when the pin shape is either PinShape_Triangle or PinShape_TriangleFilled.
      */
     public float getPinTriangleSideLength() {
@@ -219,7 +223,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinTriangleSideLength = value;
     */
 
-    /**
+     /**
      * The thickness of the line used when the pin shape is not filled.
      */
     public float getPinLineThickness() {
@@ -241,7 +245,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinLineThickness = value;
     */
 
-    /**
+     /**
      * The radius from the pin's center position inside of which it is detected as being hovered over.
      */
     public float getPinHoverRadius() {
@@ -263,7 +267,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinHoverRadius = value;
     */
 
-    /**
+     /**
      * Offsets the pins' positions from the edge of the node to the outside of the node.
      */
     public float getPinOffset() {
@@ -285,7 +289,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinOffset = value;
     */
 
-    /**
+     /**
      * Mini-map padding size between mini-map edge and mini-map content.
      */
     public ImVec2 getMiniMapPadding() {
@@ -346,7 +350,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->MiniMapPadding = value;
     */
 
-    /**
+     /**
      * Mini-map offset from the screen side.
      */
     public ImVec2 getMiniMapOffset() {
@@ -407,7 +411,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->MiniMapOffset = value;
     */
 
-    /**
+     /**
      * By default, ImNodesStyleFlags_NodeOutline and ImNodesStyleFlags_Gridlines are enabled.
      */
     public int getFlags() {

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesAttributeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesAttributeFlags.java
@@ -1,9 +1,12 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
 /**
  * This enum controls the way the attribute pins behave.
  */
+
 public final class ImNodesAttributeFlags {
     private ImNodesAttributeFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesCol.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesCol.java
@@ -1,6 +1,9 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
+
 public final class ImNodesCol {
     private ImNodesCol() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesMiniMapLocation.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesMiniMapLocation.java
@@ -1,9 +1,12 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
 /**
  * This enum controls the minimap's location.
  */
+
 public final class ImNodesMiniMapLocation {
     private ImNodesMiniMapLocation() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesPinShape.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesPinShape.java
@@ -1,9 +1,12 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
 /**
  * This enum controls the way attribute pins look.
  */
+
 public final class ImNodesPinShape {
     private ImNodesPinShape() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleFlags.java
@@ -19,4 +19,14 @@ public final class ImNodesStyleFlags {
      * Definition: {@code 1 << 2}
      */
     public static final int GridLines = 4;
+
+    /**
+     * Definition: {@code 1 << 3}
+     */
+    public static final int GridLinesPrimary = 8;
+
+    /**
+     * Definition: {@code 1 << 4}
+     */
+    public static final int GridSnapping = 16;
 }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
+
 public final class ImNodesStyleFlags {
     private ImNodesStyleFlags() {
     }
@@ -19,14 +22,4 @@ public final class ImNodesStyleFlags {
      * Definition: {@code 1 << 2}
      */
     public static final int GridLines = 4;
-
-    /**
-     * Definition: {@code 1 << 3}
-     */
-    public static final int GridLinesPrimary = 8;
-
-    /**
-     * Definition: {@code 1 << 4}
-     */
-    public static final int GridSnapping = 16;
 }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleVar.java
@@ -1,6 +1,9 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
+
 public final class ImNodesStyleVar {
     private ImNodesStyleVar() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
@@ -3,10 +3,17 @@ package imgui.extension.implot;
 import imgui.ImDrawList;
 import imgui.ImVec2;
 import imgui.ImVec4;
+
+
+
+
+
+
 import imgui.internal.ImGuiContext;
 import imgui.type.ImBoolean;
 import imgui.type.ImDouble;
 import imgui.type.ImFloat;
+
 
 public final class ImPlot {
     private ImPlot() {
@@ -20,7 +27,7 @@ public final class ImPlot {
     // [SECTION] Contexts
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Creates a new ImPlot context. Call this after ImGui.createContext().
      */
     public static ImPlotContext createContext() {
@@ -31,7 +38,7 @@ public final class ImPlot {
         return (uintptr_t)ImPlot::CreateContext();
     */
 
-    /**
+     /**
      * Destroys an ImPlot context. Call this before ImGui.destroyContext(). NULL = destroy current context.
      */
     public static void destroyContext() {
@@ -53,7 +60,7 @@ public final class ImPlot {
         ImPlot::DestroyContext(reinterpret_cast<ImPlotContext*>(ctx));
     */
 
-    /**
+     /**
      * Returns the current ImPlot context. NULL if no context has ben set.
      */
     public static ImPlotContext getCurrentContext() {
@@ -64,7 +71,7 @@ public final class ImPlot {
         return (uintptr_t)ImPlot::GetCurrentContext();
     */
 
-    /**
+     /**
      * Sets the current ImPlot context.
      */
     public static void setCurrentContext(final ImPlotContext ctx) {
@@ -158,7 +165,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndPlot() if beginPlot() returns true! Typically called at the end
      * of an if statement conditioned on BeginPlot(). See example in beginPlot().
      */
@@ -310,7 +317,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndSubplots() if BeginSubplots() returns true! Typically called at the end
      * of an if statement conditioned on BeginSublots(). See example above.
      */
@@ -351,7 +358,7 @@ public final class ImPlot {
     //   call it yourself, then the first subsequent plotting or utility function will
     //   call it for you.
 
-    /**
+     /**
      * Enables an axis or sets the label and/or flags for an existing axis.
      * Leave `label` as NULL for no label.
      */
@@ -403,7 +410,7 @@ public final class ImPlot {
         ImPlot::SetupAxis(axis, NULL, flags);
     */
 
-    /**
+     /**
      * Sets an axis range limits. If ImPlotCond_Always is used, the axes limits will be locked.
      */
     public static void setupAxisLimits(final int axis, final double vMin, final double vMax) {
@@ -425,7 +432,7 @@ public final class ImPlot {
         ImPlot::SetupAxisLimits(axis, vMin, vMax, cond);
     */
 
-    /**
+     /**
      * Links an axis range limits to external values. Set to NULL for no linkage.
      * The pointer data must remain valid until EndPlot.
      */
@@ -441,7 +448,7 @@ public final class ImPlot {
         if (linkMax != NULL) env->ReleasePrimitiveArrayCritical(obj_linkMax, linkMax, JNI_FALSE);
     */
 
-    /**
+     /**
      * Sets the format of numeric axis labels via formatter specifier (default="%g").
      * Formatted values will be double (i.e. use %f).
      */
@@ -457,7 +464,7 @@ public final class ImPlot {
 
     // TODO: support ImPlotFormatter
 
-    /**
+     /**
      * Sets an axis' ticks and optionally the labels. To keep the default ticks,
      * set `keepDefault=true`.
      */
@@ -533,7 +540,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Sets an axis' ticks and optionally the labels for the next plot.
      * To keep the default ticks, set `keepDefault=true`.
      */
@@ -601,7 +608,7 @@ public final class ImPlot {
         ImPlot::SetupAxisTicks(axis, vMin, vMax, nTicks, NULL, keepDefault);
     */
 
-    /**
+     /**
      * Sets the label and/or flags for primary X and Y axes (shorthand for two calls to SetupAxis).
      */
     public static void setupAxes(final String xLabel, final String yLabel) {
@@ -646,7 +653,7 @@ public final class ImPlot {
         if (yLabel != NULL) env->ReleaseStringUTFChars(obj_yLabel, yLabel);
     */
 
-    /**
+     /**
      * Sets the primary X and Y axes range limits. If ImPlotCond_Always is used,
      * the axes limits will be locked (shorthand for two calls to SetupAxisLimits).
      */
@@ -670,7 +677,7 @@ public final class ImPlot {
         ImPlot::SetupAxesLimits(xMin, xMax, yMin, yMax, cond);
     */
 
-    /**
+     /**
      * Sets up the plot legend.
      */
     public static void setupLegend(final int location) {
@@ -692,7 +699,7 @@ public final class ImPlot {
         ImPlot::SetupLegend(location, flags);
     */
 
-    /**
+     /**
      * Sets the location of the current plot's mouse position text (default = South|East).
      */
     public static void setupMouseText(final int location) {
@@ -714,7 +721,7 @@ public final class ImPlot {
         ImPlot::SetupMouseText(location, flags);
     */
 
-    /**
+     /**
      * Explicitly finalize plot setup. Once you call this, you cannot make any more
      * Setup calls for the current plot! Note that calling this function is OPTIONAL;
      * it will be called by the first subsequent setup-locking API call.
@@ -750,7 +757,7 @@ public final class ImPlot {
     // - You must still enable non-default axes with SetupAxis for these functions
     //   to work properly.
 
-    /**
+     /**
      * Sets an upcoming axis range limits. If ImPlotCond_Always is used, the axes limits will be locked.
      */
     public static void setNextAxisLimits(final int axis, final double vMin, final double vMax) {
@@ -772,7 +779,7 @@ public final class ImPlot {
         ImPlot::SetNextAxisLimits(axis, vMin, vMax, cond);
     */
 
-    /**
+     /**
      * Links an upcoming axis range limits to external values. Set to NULL for no linkage.
      * The pointer data must remain valid until EndPlot!
      */
@@ -788,7 +795,7 @@ public final class ImPlot {
         if (linkMax != NULL) env->ReleasePrimitiveArrayCritical(obj_linkMax, linkMax, JNI_FALSE);
     */
 
-    /**
+     /**
      * Set an upcoming axis to auto fit to its data.
      */
     public static void setNextAxisToFit(final int axis) {
@@ -799,7 +806,7 @@ public final class ImPlot {
         ImPlot::SetNextAxisToFit(axis);
     */
 
-    /**
+     /**
      * Sets the upcoming primary X and Y axes range limits. If ImPlotCond_Always is used,
      * the axes limits will be locked (shorthand for two calls to SetupAxisLimits).
      */
@@ -823,7 +830,7 @@ public final class ImPlot {
         ImPlot::SetNextAxesLimits(xMin, xMax, yMin, yMax, cond);
     */
 
-    /**
+     /**
      * Sets all upcoming axes to auto fit to their data.
      */
     public static void setNextAxesToFit() {
@@ -894,7 +901,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a standard 2D line plot.
      */
     public static void plotLine(final String labelId, final short[] values) {
@@ -1194,7 +1201,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a standard 2D line plot.
      */
     public static void plotLine(final String labelId, final short[] values, final int count) {
@@ -1496,7 +1503,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a standard 2D line plot.
      */
     public static void plotLine(final String labelId, final short[] xs, final short[] ys) {
@@ -1581,7 +1588,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a standard 2D line plot.
      */
     public static void plotLine(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -1753,7 +1760,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final short[] values) {
@@ -2053,7 +2060,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final short[] values, final int count) {
@@ -2355,7 +2362,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final short[] xs, final short[] ys) {
@@ -2440,7 +2447,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -2612,7 +2619,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final short[] values) {
@@ -2912,7 +2919,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final short[] values, final int count) {
@@ -3214,7 +3221,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final short[] xs, final short[] ys) {
@@ -3299,7 +3306,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -3471,7 +3478,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] values) {
@@ -3846,7 +3853,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] values, final int count) {
@@ -4223,7 +4230,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] xs, final short[] ys) {
@@ -4478,7 +4485,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -4735,7 +4742,7 @@ public final class ImPlot {
 
     // xs,ys1,ys2
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2) {
@@ -4830,7 +4837,7 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int count) {
@@ -5022,7 +5029,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #x0 are in X units.
      */
     public static void plotBars(final String labelId, final short[] values) {
@@ -5322,7 +5329,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #x0 are in X units.
      */
     public static void plotBars(final String labelId, final short[] values, final int count) {
@@ -5624,7 +5631,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #x0 are in X units.
      */
     public static void plotBars(final String labelId, final short[] xs, final short[] ys) {
@@ -5794,7 +5801,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #x0 are in X units.
      */
     public static void plotBars(final String labelId, final short[] xs, final short[] ys, final double barWidth) {
@@ -5964,7 +5971,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #x0 are in X units.
      */
     public static void plotBars(final String labelId, final short[] xs, final short[] ys, final int count, final double barWidth) {
@@ -6136,7 +6143,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a horizontal bar graph. #bar_height and #y0 are in Y units.
      */
     public static void plotBarsH(final String labelId, final short[] values) {
@@ -6436,7 +6443,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a horizontal bar graph. #bar_height and #y0 are in Y units.
      */
     public static void plotBarsH(final String labelId, final short[] values, final int count) {
@@ -6738,7 +6745,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a horizontal bar graph. #bar_height and #y0 are in Y units.
      */
     public static void plotBarsH(final String labelId, final short[] xs, final short[] ys) {
@@ -6908,7 +6915,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a horizontal bar graph. #bar_height and #y0 are in Y units.
      */
     public static void plotBarsH(final String labelId, final short[] xs, final short[] ys, final double barHeight) {
@@ -7078,7 +7085,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a horizontal bar graph. #bar_height and #y0 are in Y units.
      */
     public static void plotBarsH(final String labelId, final short[] xs, final short[] ys, final int count, final double barHeight) {
@@ -7248,7 +7255,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
     public static void plotBarGroups(final String[] labelIds, final short[] values, final int itemCount, final int groupCount) {
@@ -7708,7 +7715,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a group of horizontal bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
     public static void plotBarGroupsH(final String[] labelIds, final short[] values, final int itemCount, final int groupCount) {
@@ -8168,7 +8175,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err) {
@@ -8263,7 +8270,7 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count) {
@@ -8453,7 +8460,7 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos) {
@@ -8558,7 +8565,7 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count) {
@@ -8768,7 +8775,7 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] err) {
@@ -8863,7 +8870,7 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count) {
@@ -9053,7 +9060,7 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots horizontal error bars. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsH(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count) {
@@ -9265,7 +9272,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots vertical stems.
      */
     public static void plotStems(final String labelId, final short[] values) {
@@ -9640,7 +9647,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical stems.
      */
     public static void plotStems(final String labelId, final short[] values, final int count) {
@@ -10017,7 +10024,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots vertical stems.
      */
     public static void plotStems(final String labelId, final short[] xs, final short[] ys) {
@@ -10272,7 +10279,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical stems.
      */
     public static void plotStems(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -10527,7 +10534,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     public static void plotVLines(final String labelId, final short[] xs) {
@@ -10602,7 +10609,7 @@ public final class ImPlot {
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     public static void plotVLines(final String labelId, final short[] xs, final int count) {
@@ -10752,7 +10759,7 @@ public final class ImPlot {
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     public static void plotHLines(final String labelId, final short[] ys) {
@@ -10827,7 +10834,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     public static void plotHLines(final String labelId, final short[] ys, final int count) {
@@ -10977,7 +10984,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
     public static void plotPieChart(final String[] labelIds, final short[] values, final double x, final double y, final double radius) {
@@ -11812,7 +11819,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
     public static void plotPieChart(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius) {
@@ -12647,7 +12654,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
     public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols) {
@@ -13307,7 +13314,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
@@ -14522,7 +14529,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
@@ -15512,7 +15519,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
@@ -16447,7 +16454,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
@@ -17182,7 +17189,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     public static void plotDigital(final String labelId, final short[] xs, final short[] ys) {
@@ -17267,7 +17274,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     public static void plotDigital(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -17437,7 +17444,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
      */
     public static void plotImage(final String labelId, final long userTextureId, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax) {
@@ -17544,7 +17551,7 @@ public final class ImPlot {
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
     */
 
-    /**
+     /**
      * Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
      */
     public static void plotText(final String text, final double x, final double y) {
@@ -17612,7 +17619,7 @@ public final class ImPlot {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)
      */
     public static void plotDummy(final String labelID) {
@@ -17638,7 +17645,7 @@ public final class ImPlot {
     // Like the item plotting functions above, they apply to the current x and y
     // axes, which can be changed with `SetAxis/SetAxes`.
 
-    /**
+     /**
      * Shows a draggable point at x, y. `col` defaults to ImGuiCol_Text.
      */
     public static boolean dragPoint(final int id, final ImDouble x, final ImDouble y, final ImVec4 col) {
@@ -17734,7 +17741,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows a draggable vertical guide line at an x-value. `col` defaults to ImGuiCol_Text.
      */
     public static boolean dragLineX(final int id, final ImDouble x, final ImVec4 col) {
@@ -17822,7 +17829,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows a draggable horizontal guide line at a y-value. `col` defaults to ImGuiCol_Text.
      */
     public static boolean dragLineY(final int id, final ImDouble y, final ImVec4 col) {
@@ -17910,7 +17917,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows a draggable and resizeable rectangle.
      */
     public static boolean dragRect(final int id, final ImDouble xMin, final ImDouble yMin, final ImDouble xMax, final ImDouble yMax, final ImVec4 col) {
@@ -17966,7 +17973,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area.
      * Annotations are always rendered on top.
      */
@@ -18010,7 +18017,7 @@ public final class ImPlot {
         ImPlot::Annotation(x, y, color, pixOffset, clamp, round);
     */
 
-    /**
+     /**
      * Shows an annotation callout at a chosen point with formatted text.
      * Clamping keeps annotations in the plot area. Annotations are always rendered on top.
      */
@@ -18034,7 +18041,7 @@ public final class ImPlot {
         if (fmt != NULL) env->ReleaseStringUTFChars(obj_fmt, fmt);
     */
 
-    /**
+     /**
      * Shows a x-axis tag at the specified coordinate value.
      */
     public static void tagX(final double x, final ImVec4 color) {
@@ -18072,7 +18079,7 @@ public final class ImPlot {
         ImPlot::TagX(x, color, round);
     */
 
-    /**
+     /**
      * Shows a x-axis tag at the specified coordinate value with formatted text.
      */
     public static void tagX(final double x, final ImVec4 color, final String fmt) {
@@ -18093,7 +18100,7 @@ public final class ImPlot {
         if (fmt != NULL) env->ReleaseStringUTFChars(obj_fmt, fmt);
     */
 
-    /**
+     /**
      * Shows a y-axis tag at the specified coordinate value.
      */
     public static void tagY(final double y, final ImVec4 color) {
@@ -18131,7 +18138,7 @@ public final class ImPlot {
         ImPlot::TagY(y, color, round);
     */
 
-    /**
+     /**
      * Shows a y-axis tag at the specified coordinate value with formatted text.
      */
     public static void tagY(final double y, final ImVec4 color, final String fmt) {
@@ -18156,7 +18163,7 @@ public final class ImPlot {
     // [SECTION] Plot Utils
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Selects which axis will be used for subsequent plot elements.
      */
     public static void setAxis(final int axis) {
@@ -18167,7 +18174,7 @@ public final class ImPlot {
         ImPlot::SetAxis(axis);
     */
 
-    /**
+     /**
      * Selects which axes will be used for subsequent plot elements.
      */
     public static void setAxes(final int xAxis, final int yAxis) {
@@ -18178,7 +18185,7 @@ public final class ImPlot {
         ImPlot::SetAxes(xAxis, yAxis);
     */
 
-    /**
+     /**
      * Converts pixels to a position in the current plot's coordinate system.
      * Passing IMPLOT_AUTO uses the current axes.
      */
@@ -18301,7 +18308,7 @@ public final class ImPlot {
         Jni::ImPlotPointCpy(env, ImPlot::PixelsToPlot(pix, xAxis, yAxis), dst);
     */
 
-    /**
+     /**
      * Converts a position in the current plot's coordinate system to pixels.
      * Passing IMPLOT_AUTO uses the current axes.
      */
@@ -18493,7 +18500,7 @@ public final class ImPlot {
         return ImPlot::PlotToPixels(ImPlotPoint(pltX, pltY), xAxis, yAxis).y;
     */
 
-    /**
+     /**
      * Gets the current Plot position (top-left) in pixels.
      */
     public static ImVec2 getPlotPos() {
@@ -18535,7 +18542,7 @@ public final class ImPlot {
         return ImPlot::GetPlotPos().y;
     */
 
-    /**
+     /**
      * Gets the current Plot size in pixels.
      */
     public static ImVec2 getPlotSize() {
@@ -18577,7 +18584,7 @@ public final class ImPlot {
         return ImPlot::GetPlotSize().y;
     */
 
-    /**
+     /**
      * Returns the mouse position in x, y coordinates of the current plot.
      * Passing IMPLOT_AUTO uses the current axes.
      */
@@ -18643,7 +18650,7 @@ public final class ImPlot {
         Jni::ImPlotPointCpy(env, ImPlot::GetPlotMousePos(xAxis, yAxis), dst);
     */
 
-    /**
+     /**
      * Returns the current plot axis range.
      */
     public static ImPlotRect getPlotLimits() {
@@ -18703,7 +18710,7 @@ public final class ImPlot {
         Jni::ImPlotRectCpy(env, ImPlot::GetPlotLimits(xAxis, yAxis), dst);
     */
 
-    /**
+     /**
      * Returns true if the plot area in the current plot is hovered.
      */
     public static boolean isPlotHovered() {
@@ -18714,7 +18721,7 @@ public final class ImPlot {
         return ImPlot::IsPlotHovered();
     */
 
-    /**
+     /**
      * Returns true if the axis label area in the current plot is hovered.
      */
     public static boolean isAxisHovered(final int axis) {
@@ -18725,7 +18732,7 @@ public final class ImPlot {
         return ImPlot::IsAxisHovered(axis);
     */
 
-    /**
+     /**
      * Returns true if the bounding frame of a subplot is hovered.
      */
     public static boolean isSubplotsHovered() {
@@ -18736,7 +18743,7 @@ public final class ImPlot {
         return ImPlot::IsSubplotsHovered();
     */
 
-    /**
+     /**
      * Returns true if the current plot is being box selected.
      */
     public static boolean isPlotSelected() {
@@ -18747,7 +18754,7 @@ public final class ImPlot {
         return ImPlot::IsPlotSelected();
     */
 
-    /**
+     /**
      * Returns the current plot box selection bounds.
      * Passing IMPLOT_AUTO uses the current axes.
      */
@@ -18813,7 +18820,7 @@ public final class ImPlot {
         Jni::ImPlotRectCpy(env, ImPlot::GetPlotSelection(xAxis, yAxis), dst);
     */
 
-    /**
+     /**
      * Cancels the current plot box selection.
      */
     public static void cancelPlotSelection() {
@@ -18824,7 +18831,7 @@ public final class ImPlot {
         ImPlot::CancelPlotSelection();
     */
 
-    /**
+     /**
      * Hides or shows the next plot item (i.e. as if it were toggled from the legend).
      * Use ImPlotCond_Always if you need to forcefully set this every frame.
      */
@@ -18877,7 +18884,7 @@ public final class ImPlot {
     // accomplish the same behaviour by default. The functions below offer lower
     // level control of plot alignment.
 
-    /**
+     /**
      * Aligns axis padding over multiple plots in a single row or column.
      * `group_id` must be unique. If this function returns true, EndAlignedPlots() must be called.
      */
@@ -18907,7 +18914,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Ends aligned plots. Only call EndAlignedPlots() if BeginAlignedPlots() returns true.
      */
     public static void endAlignedPlots() {
@@ -18922,7 +18929,7 @@ public final class ImPlot {
     // [SECTION] Legend Utils
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Begins a popup for a legend entry.
      */
     public static boolean beginLegendPopup(final String labelId) {
@@ -18950,7 +18957,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Ends a popup for a legend entry.
      */
     public static void endLegendPopup() {
@@ -18961,7 +18968,7 @@ public final class ImPlot {
         ImPlot::EndLegendPopup();
     */
 
-    /**
+     /**
      * Returns true if a plot item legend entry is hovered.
      */
     public static boolean isLegendEntryHovered(final String labelId) {
@@ -18979,7 +18986,7 @@ public final class ImPlot {
     // [SECTION] Drag and Drop
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Turns the current plot's plotting area into a drag and drop target.
      * Don't forget to call EndDragDropTarget!
      */
@@ -18991,7 +18998,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropTargetPlot();
     */
 
-    /**
+     /**
      * Turns the current plot's X-axis into a drag and drop target.
      * Don't forget to call EndDragDropTarget!
      */
@@ -19003,7 +19010,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropTargetAxis(axis);
     */
 
-    /**
+     /**
      * Turns the current plot's legend into a drag and drop target.
      * Don't forget to call EndDragDropTarget!
      */
@@ -19015,7 +19022,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropTargetLegend();
     */
 
-    /**
+     /**
      * Ends a drag and drop target (currently just an alias for ImGui::EndDragDropTarget).
      */
     public static void endDragDropTarget() {
@@ -19029,7 +19036,7 @@ public final class ImPlot {
     // NB: By default, plot and axes drag and drop *sources* require holding the Ctrl modifier to initiate the drag.
     // You can change the modifier if desired. If ImGuiKeyModFlags_None is provided, the axes will be locked from panning.
 
-    /**
+     /**
      * Turns the current plot's plotting area into a drag and drop source.
      * You must hold Ctrl. Don't forget to call EndDragDropSource!
      */
@@ -19053,7 +19060,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropSourcePlot(flags);
     */
 
-    /**
+     /**
      * Turns the current plot's X-axis into a drag and drop source.
      * You must hold Ctrl. Don't forget to call EndDragDropSource!
      */
@@ -19077,7 +19084,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropSourceAxis(axis, flags);
     */
 
-    /**
+     /**
      * Turns an item in the current plot's legend into a drag and drop source.
      * Don't forget to call EndDragDropSource!
      */
@@ -19107,7 +19114,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Ends a drag and drop source (currently just an alias for ImGui::EndDragDropSource).
      */
     public static void endDragDropSource() {
@@ -19151,7 +19158,7 @@ public final class ImPlot {
     //        manually set these colors to whatever you like, and further can Push/Pop
     //        them around individual plots for plot-specific styling (e.g. coloring axes).
 
-    private static final ImPlotStyle _GETSTYLE_1 = new ImPlotStyle(0);
+     private static final ImPlotStyle _GETSTYLE_1 = new ImPlotStyle(0);
 
     /**
      * Provides access to plot style structure for permanant modifications to colors, sizes, etc.
@@ -19165,7 +19172,7 @@ public final class ImPlot {
         return (uintptr_t)&ImPlot::GetStyle();
     */
 
-    /**
+     /**
      * Style plot colors for current ImGui style (default).
      */
     public static void styleColorsAuto() {
@@ -19187,7 +19194,7 @@ public final class ImPlot {
         ImPlot::StyleColorsAuto(reinterpret_cast<ImPlotStyle*>(dst));
     */
 
-    /**
+     /**
      * Style plot colors for ImGui "Classic".
      */
     public static void styleColorsClassic() {
@@ -19209,7 +19216,7 @@ public final class ImPlot {
         ImPlot::StyleColorsClassic(reinterpret_cast<ImPlotStyle*>(dst));
     */
 
-    /**
+     /**
      * Style plot colors for ImGui "Dark".
      */
     public static void styleColorsDark() {
@@ -19231,7 +19238,7 @@ public final class ImPlot {
         ImPlot::StyleColorsDark(reinterpret_cast<ImPlotStyle*>(dst));
     */
 
-    /**
+     /**
      * Style plot colors for ImGui "Light".
      */
     public static void styleColorsLight() {
@@ -19264,7 +19271,7 @@ public final class ImPlot {
         ImPlot::PushStyleColor(idx, col);
     */
 
-    /**
+     /**
      * Temporarily modify a style color. Don't forget to call PopStyleColor!
      */
     public static void pushStyleColor(final int idx, final int col) {
@@ -19275,7 +19282,7 @@ public final class ImPlot {
         ImPlot::PushStyleColor(idx, static_cast<ImU32>(col));
     */
 
-    /**
+     /**
      * Temporarily modify a style color. Don't forget to call PopStyleColor!
      */
     public static void pushStyleColor(final int idx, final ImVec4 col) {
@@ -19310,7 +19317,7 @@ public final class ImPlot {
         ImPlot::PopStyleColor(count);
     */
 
-    /**
+     /**
      * Temporarily modify a style variable of float type. Don't forget to call PopStyleVar!
      */
     public static void pushStyleVar(final int idx, final float val) {
@@ -19321,7 +19328,7 @@ public final class ImPlot {
         ImPlot::PushStyleVar(idx, static_cast<float>(val));
     */
 
-    /**
+     /**
      * Temporarily modify a style variable of int type. Don't forget to call PopStyleVar!
      */
     public static void pushStyleVar(final int idx, final int val) {
@@ -19332,7 +19339,7 @@ public final class ImPlot {
         ImPlot::PushStyleVar(idx, static_cast<int>(val));
     */
 
-    /**
+     /**
      * Temporarily modify a style variable of ImVec2 type. Don't forget to call PopStyleVar!
      */
     public static void pushStyleVar(final int idx, final ImVec2 val) {
@@ -19350,7 +19357,7 @@ public final class ImPlot {
         ImVec2 val = ImVec2(valX, valY);
         ImPlot::PushStyleVar(idx, val);
     */
-    /**
+     /**
      * Undo temporary style variable modification(s). Undo multiple pushes at once by increasing count.
      */
     public static void popStyleVar() {
@@ -19372,7 +19379,7 @@ public final class ImPlot {
         ImPlot::PopStyleVar(count);
     */
 
-    /**
+     /**
      * Set the line color and weight for the next item only.
      */
     public static void setNextLineStyle() {
@@ -19432,7 +19439,7 @@ public final class ImPlot {
         ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, weight);
     */
 
-    /**
+     /**
      * Set the fill color for the next item only.
      */
     public static void setNextFillStyle() {
@@ -19492,7 +19499,7 @@ public final class ImPlot {
         ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, alphaMod);
     */
 
-    /**
+     /**
      * Set the marker style for the next item only.
      */
     public static void setNextMarkerStyle() {
@@ -19603,7 +19610,7 @@ public final class ImPlot {
         ImPlot::SetNextMarkerStyle(marker, size, fill, IMPLOT_AUTO, outline);
     */
 
-    /**
+     /**
      * Set the error bar style for the next item only.
      */
     public static void setNextErrorBarStyle() {
@@ -19682,7 +19689,7 @@ public final class ImPlot {
         ImPlot::SetNextErrorBarStyle(IMPLOT_AUTO_COL, size, weight);
     */
 
-    /**
+     /**
      * Gets the last item primary color (i.e. its legend icon color)
      */
     public static ImVec4 getLastItemColor() {
@@ -19746,7 +19753,7 @@ public final class ImPlot {
         return ImPlot::GetLastItemColor().w;
     */
 
-    /**
+     /**
      * Returns the string name for an ImPlotCol.
      */
     public static String getStyleColorName(final int idx) {
@@ -19757,7 +19764,7 @@ public final class ImPlot {
         return env->NewStringUTF(ImPlot::GetStyleColorName(idx));
     */
 
-    /**
+     /**
      * Returns the null terminated string name for an ImPlotMarker.
      */
     public static String getMarkerName(final int idx) {
@@ -19852,7 +19859,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Returns the number of available colormaps (i.e. the built-in + user-added count).
      */
     public static int getColormapCount() {
@@ -19863,7 +19870,7 @@ public final class ImPlot {
         return ImPlot::GetColormapCount();
     */
 
-    /**
+     /**
      * Returns a string name for a colormap given an index.
      */
     public static String getColormapName(final int cmap) {
@@ -19874,7 +19881,7 @@ public final class ImPlot {
         return env->NewStringUTF(ImPlot::GetColormapName(cmap));
     */
 
-    /**
+     /**
      * Returns an index number for a colormap given a valid string name. Returns -1 if the name is invalid.
      */
     public static int getColormapIndex(final String name) {
@@ -19888,7 +19895,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Temporarily switch to one of the built-in (i.e. ImPlotColormap_XXX) or user-added colormaps (i.e. a return value of AddColormap). Don't forget to call PopColormap!
      */
     public static void pushColormap(final int cmap) {
@@ -19899,7 +19906,7 @@ public final class ImPlot {
         ImPlot::PushColormap(cmap);
     */
 
-    /**
+     /**
      * Push a colormap by string name. Use built-in names such as "Default", "Deep", "Jet", etc. or a string you provided to AddColormap. Don't forget to call PopColormap!
      */
     public static void pushColormap(final String name) {
@@ -19912,7 +19919,7 @@ public final class ImPlot {
         if (name != NULL) env->ReleaseStringUTFChars(obj_name, name);
     */
 
-    /**
+     /**
      * Undo temporary colormap modification(s). Undo multiple pushes at once by increasing count.
      */
     public static void popColormap() {
@@ -19934,7 +19941,7 @@ public final class ImPlot {
         ImPlot::PopColormap(count);
     */
 
-    /**
+     /**
      * Returns the next color from the current colormap and advances the colormap for the current plot.
      * Can also be used with no return value to skip colors if desired. You need to call this between Begin/EndPlot!
      */
@@ -20004,7 +20011,7 @@ public final class ImPlot {
         return ImPlot::NextColormapColor().w;
     */
 
-    /**
+     /**
      * Returns the size of a colormap.
      */
     public static int getColormapSize() {
@@ -20026,7 +20033,7 @@ public final class ImPlot {
         return ImPlot::GetColormapSize(cmap);
     */
 
-    /**
+     /**
      * Returns a color from a colormap given an index {@code >=} 0 (modulo will be performed).
      */
     public static ImVec4 getColormapColor(final int idx) {
@@ -20154,7 +20161,7 @@ public final class ImPlot {
         return ImPlot::GetColormapColor(idx, cmap).w;
     */
 
-    /**
+     /**
      * Sample a color from a colormap given t between 0 and 1
      */
     public static ImVec4 sampleColormap(final float t) {
@@ -20282,7 +20289,7 @@ public final class ImPlot {
         return ImPlot::SampleColormap(t, cmap).w;
     */
 
-    /**
+     /**
      * Shows a vertical color scale with linear spaced ticks using the specified color map. Use double hashes to hide label (e.g. "##NoLabel").
      */
     public static void colormapScale(final String label, final double scaleMin, final double scaleMax) {
@@ -20413,7 +20420,7 @@ public final class ImPlot {
         if (format != NULL) env->ReleaseStringUTFChars(obj_format, format);
     */
 
-    /**
+     /**
      * Shows a horizontal slider with a colormap gradient background.
      * TODO: support our argument
      */
@@ -20485,7 +20492,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows a button with a colormap gradient brackground.
      */
     public static boolean colormapButton(final String label) {
@@ -20557,7 +20564,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * When items in a plot sample their color from a colormap, the color is cached and does not change
      * unless explicitly overriden. Therefore, if you change the colormap after the item has already been plotted,
      * item colors will NOT update. If you need item colors to resample the new colormap, then use this
@@ -20597,7 +20604,7 @@ public final class ImPlot {
     // [SECTION] Input Mapping
     //-----------------------------------------------------------------------------
 
-    private static final ImPlotInputMap _GETINPUTMAP_1 = new ImPlotInputMap(0);
+     private static final ImPlotInputMap _GETINPUTMAP_1 = new ImPlotInputMap(0);
 
     /**
      * Provides access to the input mapping structure for permanent modifications to controls for pan, select, etc.
@@ -20611,7 +20618,7 @@ public final class ImPlot {
         return (uintptr_t)&ImPlot::GetInputMap();
     */
 
-    /**
+     /**
      * Default input mapping: pan = LMB drag, box select = RMB drag,
      * fit = LMB double click, context menu = RMB click, zoom = scroll.
      */
@@ -20635,7 +20642,7 @@ public final class ImPlot {
         ImPlot::MapInputDefault(reinterpret_cast<ImPlotInputMap*>(dst));
     */
 
-    /**
+     /**
      * Reverse input mapping: pan = RMB drag, box select = LMB drag,
      * fit = LMB double click, context menu = RMB click, zoom = scroll.
      */
@@ -20694,7 +20701,7 @@ public final class ImPlot {
         ImPlot::ColormapIcon(cmap);
     */
 
-    /**
+     /**
      * Get the plot draw list for custom rendering to the current plot area. Call between Begin/EndPlot.
      */
     public static ImDrawList getPlotDrawList() {
@@ -20705,7 +20712,7 @@ public final class ImPlot {
         return (uintptr_t)ImPlot::GetPlotDrawList();
     */
 
-    /**
+     /**
      * Push clip rect for rendering to current plot area. The rect can be expanded or contracted by #expand pixels. Call between Begin/EndPlot.
      */
     public static void pushPlotClipRect() {
@@ -20727,7 +20734,7 @@ public final class ImPlot {
         ImPlot::PushPlotClipRect(expand);
     */
 
-    /**
+     /**
      * Pop plot clip rect. Call between Begin/EndPlot.
      */
     public static void popPlotClipRect() {
@@ -20738,7 +20745,7 @@ public final class ImPlot {
         ImPlot::PopPlotClipRect();
     */
 
-    /**
+     /**
      * Shows ImPlot style selector dropdown menu.
      */
     public static boolean showStyleSelector(final String label) {
@@ -20752,7 +20759,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows ImPlot colormap selector dropdown menu.
      */
     public static boolean showColormapSelector(final String label) {
@@ -20766,7 +20773,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows ImPlot input map selector dropdown menu.
      */
     public static boolean showInputMapSelector(final String label) {
@@ -20780,7 +20787,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows ImPlot style editor block (not a window).
      */
     public static void showStyleEditor() {
@@ -20802,7 +20809,7 @@ public final class ImPlot {
         ImPlot::ShowStyleEditor(reinterpret_cast<ImPlotStyle*>(ref));
     */
 
-    /**
+     /**
      * Add basic help/info block for end users (not a window).
      */
     public static void showUserGuide() {
@@ -20813,7 +20820,7 @@ public final class ImPlot {
         ImPlot::ShowUserGuide();
     */
 
-    /**
+     /**
      * Shows ImPlot metrics/debug information window.
      */
     public static void showMetricsWindow() {
@@ -20841,7 +20848,7 @@ public final class ImPlot {
     // [SECTION] Demo
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Shows the ImPlot demo window.
      */
     public static void showDemoWindow() {

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotInputMap.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotInputMap.java
@@ -2,6 +2,9 @@ package imgui.extension.implot;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 public final class ImPlotInputMap extends ImGuiStructDestroyable {
     public ImPlotInputMap() {
         super();
@@ -25,7 +28,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImPlotInputMap());
     */
 
-    /**
+     /**
      * LMB enables panning when held
      */
     public int getPan() {
@@ -47,7 +50,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->Pan = value;
     */
 
-    /**
+     /**
      * Optional modifier that must be held for panning/fitting
      */
     public int getPanMod() {
@@ -69,7 +72,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->PanMod = value;
     */
 
-    /**
+     /**
      * LMB initiates fit when double clicked
      */
     public int getFit() {
@@ -91,7 +94,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->Fit = value;
     */
 
-    /**
+     /**
      * RMB begins box selection when pressed and confirms
      * selection when released
      */
@@ -115,7 +118,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->Select = value;
     */
 
-    /**
+     /**
      * LMB cancels active box selection when pressed;
      * cannot be the same as Select
      */
@@ -139,7 +142,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->SelectCancel = value;
     */
 
-    /**
+     /**
      * Optional modifier that must be held for box selection
      */
     public int getSelectMod() {
@@ -161,7 +164,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->SelectMod = value;
     */
 
-    /**
+     /**
      * Alt expands active box selection horizontally
      * to plot edge when held
      */
@@ -185,7 +188,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->SelectHorzMod = value;
     */
 
-    /**
+     /**
      * Shift expands active box selection vertically
      * to plot edge when held
      */
@@ -209,7 +212,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->SelectVertMod = value;
     */
 
-    /**
+     /**
      * RMB opens context menus (if enabled) when clicked
      */
     public int getMenu() {
@@ -231,7 +234,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->Menu = value;
     */
 
-    /**
+     /**
      * Ctrl when held, all input is ignored;
      * used to enable axis/plots as DND sources
      */
@@ -255,7 +258,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->OverrideMod = value;
     */
 
-    /**
+     /**
      * Optional modifier that must be held for scroll wheel zooming
      */
     public int getZoomMod() {
@@ -277,7 +280,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->ZoomMod = value;
     */
 
-    /**
+     /**
      * Zoom rate for scroll (e.g. 0.1f = 10% plot range every scroll click);
      * make negative to invert
      */

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotStyle.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotStyle.java
@@ -4,6 +4,10 @@ import imgui.ImVec2;
 import imgui.ImVec4;
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
 public final class ImPlotStyle extends ImGuiStructDestroyable {
     public ImPlotStyle() {
         super();

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotAxis.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotAxis.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotAxis {
     private ImPlotAxis() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotAxisFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotAxisFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotAxisFlags {
     private ImPlotAxisFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBarGroupsFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBarGroupsFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotBarGroupsFlags {
     private ImPlotBarGroupsFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBin.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBin.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotBin {
     private ImPlotBin() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCol.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCol.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotCol {
     private ImPlotCol() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotColormap.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotColormap.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotColormap {
     private ImPlotColormap() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCond.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCond.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotCond {
     private ImPlotCond() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotDragToolFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotDragToolFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotDragToolFlags {
     private ImPlotDragToolFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotFlags {
     private ImPlotFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLegendFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLegendFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotLegendFlags {
     private ImPlotLegendFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLocation.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLocation.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotLocation {
     private ImPlotLocation() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMarker.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMarker.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotMarker {
     private ImPlotMarker() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMouseTextFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMouseTextFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotMouseTextFlags {
     private ImPlotMouseTextFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStyleVar.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotStyleVar {
     private ImPlotStyleVar() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/memedit/MemoryEditor.java
+++ b/imgui-binding/src/generated/java/imgui/extension/memedit/MemoryEditor.java
@@ -2,10 +2,16 @@ package imgui.extension.memedit;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
+
 /**
  * ImGui Club Memory Editor extension for ImGui
  * Repo: <a href="https://github.com/ocornut/imgui_club">https://github.com/ocornut/imgui_club</a>
  */
+
 public final class MemoryEditor extends ImGuiStructDestroyable {
     public MemoryEditor() {
         super();

--- a/imgui-binding/src/generated/java/imgui/extension/memedit/MemoryEditorSizes.java
+++ b/imgui-binding/src/generated/java/imgui/extension/memedit/MemoryEditorSizes.java
@@ -2,6 +2,9 @@ package imgui.extension.memedit;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 public final class MemoryEditorSizes extends ImGuiStructDestroyable {
     public MemoryEditorSizes() {
         super();

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditor.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditor.java
@@ -3,6 +3,11 @@ package imgui.extension.nodeditor;
 import imgui.ImDrawList;
 import imgui.ImVec2;
 import imgui.ImVec4;
+
+
+
+
+
 import imgui.type.ImLong;
 
 /**
@@ -21,6 +26,7 @@ import imgui.type.ImLong;
  * Binding notice: instead of special types for ids of nodes, links and pins which used in native library
  * we use longs to reduce boilerplate and garbage production
  */
+
 public final class NodeEditor {
     private NodeEditor() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditorConfig.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditorConfig.java
@@ -2,6 +2,9 @@ package imgui.extension.nodeditor;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 public final class NodeEditorConfig extends ImGuiStructDestroyable {
     @Override
     protected long create() {

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditorStyle.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditorStyle.java
@@ -4,6 +4,10 @@ import imgui.ImVec2;
 import imgui.ImVec4;
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
 public final class NodeEditorStyle extends ImGuiStruct {
     public NodeEditorStyle(final long ptr) {
         super(ptr);

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorFlowDirection.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorFlowDirection.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorFlowDirection {
     private NodeEditorFlowDirection() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorPinKind.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorPinKind.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorPinKind {
     private NodeEditorPinKind() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorStyleColor.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorStyleColor.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorStyleColor {
     private NodeEditorStyleColor() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorStyleVar.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorStyleVar {
     private NodeEditorStyleVar() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/texteditor/TextEditor.java
+++ b/imgui-binding/src/generated/java/imgui/extension/texteditor/TextEditor.java
@@ -3,7 +3,13 @@ package imgui.extension.texteditor;
 import imgui.ImVec2;
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
+
 import java.util.Map;
+
 
 public final class TextEditor extends ImGuiStructDestroyable {
     public TextEditor() {

--- a/imgui-binding/src/generated/java/imgui/extension/texteditor/TextEditorLanguageDefinition.java
+++ b/imgui-binding/src/generated/java/imgui/extension/texteditor/TextEditorLanguageDefinition.java
@@ -2,7 +2,13 @@ package imgui.extension.texteditor;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
+
 import java.util.Map;
+
 
 public final class TextEditorLanguageDefinition extends ImGuiStructDestroyable {
     public TextEditorLanguageDefinition() {

--- a/imgui-binding/src/generated/java/imgui/extension/texteditor/flag/TextEditorPaletteIndex.java
+++ b/imgui-binding/src/generated/java/imgui/extension/texteditor/flag/TextEditorPaletteIndex.java
@@ -1,6 +1,9 @@
 package imgui.extension.texteditor.flag;
 
 
+
+
+
 public final class TextEditorPaletteIndex {
     private TextEditorPaletteIndex() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/texteditor/flag/TextEditorSelectionMode.java
+++ b/imgui-binding/src/generated/java/imgui/extension/texteditor/flag/TextEditorSelectionMode.java
@@ -1,6 +1,9 @@
 package imgui.extension.texteditor.flag;
 
 
+
+
+
 public final class TextEditorSelectionMode {
     private TextEditorSelectionMode() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImDrawFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImDrawFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImDrawList functions
  */
+
 public final class ImDrawFlags {
     private ImDrawFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImDrawListFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImDrawListFlags.java
@@ -1,10 +1,13 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImDrawList. Those are set automatically by ImGui:: functions from ImGuiIO settings, and generally not manipulated directly.
  * It is however possible to temporarily alter flags between calls to ImDrawList:: functions.
  */
+
 public final class ImDrawListFlags {
     private ImDrawListFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImFontAtlasFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImFontAtlasFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImFontAtlas build
  */
+
 public final class ImFontAtlasFlags {
     private ImFontAtlasFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiBackendFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiBackendFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Backend capabilities flags stored in io.BackendFlags. Set by imgui_impl_xxx or custom backend.
  */
+
 public final class ImGuiBackendFlags {
     private ImGuiBackendFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiButtonFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiButtonFlags.java
@@ -1,6 +1,9 @@
 package imgui.flag;
 
 
+
+
+
 public final class ImGuiButtonFlags {
     private ImGuiButtonFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiCol.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiCol.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for PushStyleColor() / PopStyleColor()
  */
+
 public final class ImGuiCol {
     private ImGuiCol() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiColorEditFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiColorEditFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()
  */
+
 public final class ImGuiColorEditFlags {
     private ImGuiColorEditFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiComboFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiComboFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginCombo()
  */
+
 public final class ImGuiComboFlags {
     private ImGuiComboFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiCond.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiCond.java
@@ -1,11 +1,14 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for ImGui::SetWindow***(), SetNextWindow***(), SetNextItem***() functions
  * Represent a condition.
  * Important: Treat as a regular enum! Do NOT combine multiple values using binary operators! All the functions above treat 0 as a shortcut to ImGuiCond_Always.
  */
+
 public final class ImGuiCond {
     private ImGuiCond() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiConfigFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiConfigFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Configuration flags stored in io.ConfigFlags. Set by user/application.
  */
+
 public final class ImGuiConfigFlags {
     private ImGuiConfigFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiDataType.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiDataType.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * A primary data type
  */
+
 public final class ImGuiDataType {
     private ImGuiDataType() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiDir.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiDir.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * A cardinal direction
  */
+
 public final class ImGuiDir {
     private ImGuiDir() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiDockNodeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiDockNodeFlags.java
@@ -1,10 +1,13 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::DockSpace(), shared/inherited by child nodes.
  * (Some flags can be applied to individual nodes directly)
  */
+
 public final class ImGuiDockNodeFlags {
     private ImGuiDockNodeFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiDragDropFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiDragDropFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginDragDropSource(), ImGui::AcceptDragDropPayload()
  */
+
 public final class ImGuiDragDropFlags {
     private ImGuiDragDropFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiFocusedFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiFocusedFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::IsWindowFocused()
  */
+
 public final class ImGuiFocusedFlags {
     private ImGuiFocusedFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiFreeTypeBuilderFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiFreeTypeBuilderFlags.java
@@ -1,6 +1,9 @@
 package imgui.flag;
 
 
+
+
+
 public final class ImGuiFreeTypeBuilderFlags {
     private ImGuiFreeTypeBuilderFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiHoveredFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiHoveredFlags.java
@@ -1,11 +1,14 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::IsItemHovered(), ImGui::IsWindowHovered()
  * Note:if you are trying to check whether your mouse should be dispatched to Dear ImGui or to your app,
  * you should use'io.WantCaptureMouse'instead!Please read the FAQ!Note: windows with the ImGuiWindowFlags_NoInputs flag are ignored by IsWindowHovered() calls.
  */
+
 public final class ImGuiHoveredFlags {
     private ImGuiHoveredFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiInputTextFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiInputTextFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::InputText()
  */
+
 public final class ImGuiInputTextFlags {
     private ImGuiInputTextFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiKey.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiKey.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * User fill ImGuiIO.KeyMap[] array with indices into the ImGuiIO.KeysDown[512] array
  */
+
 public final class ImGuiKey {
     private ImGuiKey() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiKeyModFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiKeyModFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * To test io.KeyMods (which is a combination of individual fields io.KeyCtrl, io.KeyShift, io.KeyAlt set by user/backend)
  */
+
 public final class ImGuiKeyModFlags {
     private ImGuiKeyModFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseButton.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseButton.java
@@ -1,10 +1,13 @@
 package imgui.flag;
 
 
+
+
 /**
  * Identify a mouse button.
  * Those values are guaranteed to be stable and we frequently use 0/1 directly. Named enums provided for convenience.
  */
+
 public final class ImGuiMouseButton {
     private ImGuiMouseButton() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseCursor.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseCursor.java
@@ -1,10 +1,13 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for GetMouseCursor()
  * User code may request binding to display given cursor by calling SetMouseCursor(), which is why we have some cursors that are marked unused here
  */
+
 public final class ImGuiMouseCursor {
     private ImGuiMouseCursor() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiNavInput.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiNavInput.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Gamepad/Keyboard directional navigation
  * Keyboard: Set io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard to enable.
@@ -10,6 +12,7 @@ package imgui.flag;
  * Note that io.NavInputs[] is cleared by EndFrame().
  * Read instructions in imgui.cpp for more details. Download PNG/PSD at http://dearimgui.org/controls_sheets.
  */
+
 public final class ImGuiNavInput {
     private ImGuiNavInput() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiPopupFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiPopupFlags.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for OpenPopup*(), BeginPopupContext*(), IsPopupOpen() functions.
  * - To be backward compatible with older API which took an 'int mouse_button = 1' argument, we need to treat
@@ -9,6 +11,7 @@ package imgui.flag;
  * - For the same reason, we exceptionally default the ImGuiPopupFlags argument of BeginPopupContextXXX functions to 1 instead of 0.
  * - Multiple buttons currently cannot be combined/or-ed in those functions (we could allow it later).
  */
+
 public final class ImGuiPopupFlags {
     private ImGuiPopupFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiSelectableFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiSelectableFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::Selectable()
  */
+
 public final class ImGuiSelectableFlags {
     private ImGuiSelectableFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiSliderFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiSliderFlags.java
@@ -1,6 +1,9 @@
 package imgui.flag;
 
 
+
+
+
 public final class ImGuiSliderFlags {
     private ImGuiSliderFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiSortDirection.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiSortDirection.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * A sorting direction
  */
+
 public final class ImGuiSortDirection {
     private ImGuiSortDirection() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiStyleVar.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for PushStyleVar() / PopStyleVar() to temporarily modify the ImGuiStyle structure.
  * - The enum only refers to fields of ImGuiStyle which makes sense to be pushed/popped inside UI code.
@@ -10,6 +12,7 @@ package imgui.flag;
  *   With Visual Assist installed: ALT+G ("VAssistX.GoToImplementation") can also follow symbols in comments.
  * - When changing this enum, you need to update the associated internal table GStyleVarInfo[] accordingly. This is where we link enum values to members offset/type.
  */
+
 public final class ImGuiStyleVar {
     private ImGuiStyleVar() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTabBarFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTabBarFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginTabBar()
  */
+
 public final class ImGuiTabBarFlags {
     private ImGuiTabBarFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTabItemFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTabItemFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginTabItem()
  */
+
 public final class ImGuiTabItemFlags {
     private ImGuiTabItemFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTableBgTarget.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTableBgTarget.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enum for ImGui::TableSetBgColor()
  * Background colors are rendering in 3 layers:
@@ -12,6 +14,7 @@ package imgui.flag;
  * If you set the color of RowBg0 target, your color will override the existing RowBg0 color.
  * If you set the color of RowBg1 or ColumnBg1 target, your color will blend over the RowBg0 color.
  */
+
 public final class ImGuiTableBgTarget {
     private ImGuiTableBgTarget() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTableColumnFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTableColumnFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for {@link imgui.ImGui#tableSetupColumn(String, int)}
  */
+
 public final class ImGuiTableColumnFlags {
     private ImGuiTableColumnFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTableFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTableFlags.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginTable()
  * [BETA API] API may evolve slightly! If you use this, please update to the next version when it comes out!
@@ -26,6 +28,7 @@ package imgui.flag;
  * If you specify a value for 'inner_width' then effectively the scrolling space is known and Stretch or mixed Fixed/Stretch columns become meaningful again.
  * - Read on documentation at the top of imgui_tables.cpp for details.
  */
+
 public final class ImGuiTableFlags {
     private ImGuiTableFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTableRowFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTableRowFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for {@link imgui.ImGui#tableNextRow(int)}
  */
+
 public final class ImGuiTableRowFlags {
     private ImGuiTableRowFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTreeNodeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTreeNodeFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::TreeNodeEx(), ImGui::CollapsingHeader*()
  */
+
 public final class ImGuiTreeNodeFlags {
     private ImGuiTreeNodeFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiViewportFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiViewportFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags stored in ImGuiViewport::Flags, giving indications to the platform backends.
  */
+
 public final class ImGuiViewportFlags {
     private ImGuiViewportFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiWindowFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiWindowFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::Begin()
  */
+
 public final class ImGuiWindowFlags {
     private ImGuiWindowFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/ImGui.java
+++ b/imgui-binding/src/generated/java/imgui/internal/ImGui.java
@@ -1,8 +1,13 @@
 package imgui.internal;
 
 import imgui.ImVec2;
+
+
+
+
 import imgui.type.ImFloat;
 import imgui.type.ImInt;
+
 
 public final class ImGui extends imgui.ImGui {
     /*JNI
@@ -144,7 +149,7 @@ public final class ImGui extends imgui.ImGui {
         return ImGui::DockBuilderAddNode(nodeId, flags);
     */
 
-    /**
+     /**
      * Remove node and all its child, undock all windows.
      */
     public static void dockBuilderRemoveNode(final int nodeId) {
@@ -171,7 +176,7 @@ public final class ImGui extends imgui.ImGui {
         ImGui::DockBuilderRemoveNodeDockedWindows(nodeId, clearSettingsRefs);
     */
 
-    /**
+     /**
      * Remove all split/hierarchy. All remaining docked windows will be re-docked to the remaining root node (node_id).
      */
     public static void dockBuilderRemoveNodeChildNodes(final int nodeId) {
@@ -208,7 +213,7 @@ public final class ImGui extends imgui.ImGui {
         ImGui::DockBuilderSetNodeSize(nodeId, size);
     */
 
-    /**
+     /**
      * Create 2 child nodes in this parent node.
      */
     public static int dockBuilderSplitNode(final int nodeId, final int splitDir, final float sizeRatioForNodeAtDir, final ImInt outIdAtDir, final ImInt outIdAtOppositeDir) {

--- a/imgui-binding/src/generated/java/imgui/internal/ImGuiDockNode.java
+++ b/imgui-binding/src/generated/java/imgui/internal/ImGuiDockNode.java
@@ -4,6 +4,11 @@ import imgui.ImGuiWindowClass;
 import imgui.ImVec2;
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
+
 public final class ImGuiDockNode extends ImGuiStruct {
     public ImGuiDockNode(final long ptr) {
         super(ptr);
@@ -32,7 +37,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->ID = value;
     */
 
-    /**
+     /**
      * Flags shared by all nodes of a same dockspace hierarchy (inherited from the root node)
      */
     public int getSharedFlags() {
@@ -75,7 +80,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->SharedFlags = value;
     */
 
-    /**
+     /**
      * Flags specific to this node
      */
     public int getLocalFlags() {
@@ -118,7 +123,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LocalFlags = value;
     */
 
-    /**
+     /**
      * Flags specific to this node, applied from windows
      */
     public int getLocalFlagsInWindows() {
@@ -161,7 +166,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LocalFlagsInWindows = value;
     */
 
-    /**
+     /**
      * Effective flags (== SharedFlags | LocalFlagsInNode | LocalFlagsInWindows)
      */
     public int getMergedFlags() {
@@ -243,7 +248,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
 
     // TODO  Windows, TabBar
 
-    /**
+     /**
      * Current position
      */
     public ImVec2 getPos() {
@@ -304,7 +309,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->Pos = value;
     */
 
-    /**
+     /**
      * Current size
      */
     public ImVec2 getSize() {
@@ -365,7 +370,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->Size = value;
     */
 
-    /**
+     /**
      * [Split node only] Last explicitly written-to size (overridden when using a splitter affecting the node), used to calculate Size.
      */
     public ImVec2 getSizeRef() {
@@ -426,7 +431,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->SizeRef = value;
     */
 
-    /**
+     /**
      * [Split node only] Split axis (X or Y)
      */
     public int getSplitAxis() {
@@ -437,7 +442,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         return THIS->SplitAxis;
     */
 
-    /**
+     /**
      * [Root node only]
      */
     public ImGuiWindowClass getWindowClass() {
@@ -480,7 +485,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->HostWindow = reinterpret_cast<ImGuiWindow*>(value);
     */
 
-    /**
+     /**
      * Generally point to window which is ID is == SelectedTabID, but when CTRL+Tabbing this can be a different window.
      */
     public ImGuiWindow getVisibleWindow() {
@@ -502,7 +507,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->VisibleWindow = reinterpret_cast<ImGuiWindow*>(value);
     */
 
-    /**
+     /**
      * [Root node only] Pointer to central node.
      */
     public ImGuiDockNode getCentralNode() {
@@ -524,7 +529,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->CentralNode = reinterpret_cast<ImGuiDockNode*>(value);
     */
 
-    /**
+     /**
      * [Root node only] Set when there is a single visible node within the hierarchy.
      */
     public ImGuiDockNode getOnlyNodeWithWindows() {
@@ -546,7 +551,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->OnlyNodeWithWindows = reinterpret_cast<ImGuiDockNode*>(value);
     */
 
-    /**
+     /**
      * Last frame number the node was updated or kept alive explicitly with DockSpace() + int_KeepAliveOnly
      */
     public int getLastFrameAlive() {
@@ -568,7 +573,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LastFrameAlive = value;
     */
 
-    /**
+     /**
      * Last frame number the node was updated.
      */
     public int getLastFrameActive() {
@@ -590,7 +595,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LastFrameActive = value;
     */
 
-    /**
+     /**
      * Last frame number the node was focused.
      */
     public int getLastFrameFocused() {
@@ -612,7 +617,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LastFrameFocused = value;
     */
 
-    /**
+     /**
      * [Root node only] Which of our child docking node (any ancestor in the hierarchy) was last focused.
      */
     public int getLastFocusedNodeId() {
@@ -634,7 +639,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LastFocusedNodeId = value;
     */
 
-    /**
+     /**
      * [Leaf node only] Which of our tab/window is selected.
      */
     public int getSelectedTabId() {
@@ -656,7 +661,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->SelectedTabId = value;
     */
 
-    /**
+     /**
      * [Leaf node only] Set when closing a specific tab/window.
      */
     public int getWantCloseTabId() {
@@ -726,7 +731,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->AuthorityForViewport = value;
     */
 
-    /**
+     /**
      * Set to false when the node is hidden (usually disabled as it has no active window)
      */
     public boolean getIsVisible() {
@@ -812,7 +817,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->HasCentralNodeChild = value;
     */
 
-    /**
+     /**
      * Set when closing all tabs at once.
      */
     public boolean getWantCloseAll() {
@@ -850,7 +855,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->WantLockSizeOnce = value;
     */
 
-    /**
+     /**
      * After a node extraction we need to transition toward moving the newly created host window
      */
     public boolean getWantMouseMove() {
@@ -936,7 +941,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         return THIS->IsCentralNode();
     */
 
-    /**
+     /**
      * Hidden tab bar can be shown back by clicking the small triangle
      */
     public boolean isHiddenTabBar() {
@@ -947,7 +952,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         return THIS->IsHiddenTabBar();
     */
 
-    /**
+     /**
      * Never show a tab bar
      */
     public boolean isNoTabBar() {

--- a/imgui-binding/src/generated/java/imgui/internal/ImGuiWindow.java
+++ b/imgui-binding/src/generated/java/imgui/internal/ImGuiWindow.java
@@ -2,6 +2,9 @@ package imgui.internal;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 public class ImGuiWindow extends ImGuiStruct {
     public ImGuiWindow(final long ptr) {
         super(ptr);
@@ -14,7 +17,7 @@ public class ImGuiWindow extends ImGuiStruct {
         #define THIS ((ImGuiWindow*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Is scrollbar visible?
      */
     public boolean getScrollbarX() {
@@ -25,7 +28,7 @@ public class ImGuiWindow extends ImGuiStruct {
         return THIS->ScrollbarX;
     */
 
-    /**
+     /**
      * Is scrollbar visible?
      */
     public boolean getScrollbarY() {

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiAxis.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiAxis.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public final class ImGuiAxis {
     private ImGuiAxis() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDataAuthority.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDataAuthority.java
@@ -1,9 +1,12 @@
 package imgui.internal.flag;
 
 
+
+
 /**
  * Store the source authority (dock node vs window) of a field
  */
+
 public final class ImGuiDataAuthority {
     private ImGuiDataAuthority() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeFlags.java
@@ -1,9 +1,12 @@
 package imgui.internal.flag;
 
 
+
+
 /**
  * Extend ImGuiDockNodeFlags
  */
+
 public final class ImGuiDockNodeFlags {
     private ImGuiDockNodeFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeState.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeState.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public final class ImGuiDockNodeState {
     private ImGuiDockNodeState() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiItemFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiItemFlags.java
@@ -1,10 +1,13 @@
 package imgui.internal.flag;
 
 
+
+
 /**
  * Transient per-window flags, reset at the beginning of the frame. For child window, inherited from parent on first Begin().
  * This is going to be exposed in imgui.h when stabilized enough.
  */
+
 public final class ImGuiItemFlags {
     private ImGuiItemFlags() {
     }


### PR DESCRIPTION
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->

Aiming to update imnodes to the latest version to take advantage of the IMASSERT callback. Also fixing the ImNodes#getNode____SpacePos methods along the way since they were broken sometime in 1.87.x and they return void instead of the expected ImVec2.

## Type of change

<!-- 
Please check options that are relevant.
-->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
