### PR TITLE
Update imnodes bindings to latest version & fix getNode___SpacePos bindings

### DIFF
--- a/buildSrc/src/main/resources/generator/api/ast/ast-ImGuiFileDialog.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-ImGuiFileDialog.json
@@ -6,451 +6,6 @@
     "revision" : "007091af18c69a2eed15cf5016951eb481a1de79"
   },
   "decls" : [ {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswalnum_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswblank_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswalpha_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswhexnumber_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "timespec",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "tv_sec",
-      "qualType" : "__darwin_time_t",
-      "desugaredQualType" : "long"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tv_nsec",
-      "qualType" : "long",
-      "desugaredQualType" : "long"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswcntrl_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswideogram_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswctype_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswnumber_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswdigit_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswphonogram_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswgraph_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswrune_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswalnum",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswlower_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswspecial_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswalpha",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswblank",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "lconv",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "decimal_point",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "thousands_sep",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "grouping",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_curr_symbol",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "currency_symbol",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "mon_decimal_point",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "mon_thousands_sep",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "mon_grouping",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "positive_sign",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "negative_sign",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_frac_digits",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "frac_digits",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "p_cs_precedes",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "p_sep_by_space",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "n_cs_precedes",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "n_sep_by_space",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "p_sign_posn",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "n_sign_posn",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_p_cs_precedes",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_n_cs_precedes",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_p_sep_by_space",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_n_sep_by_space",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_p_sign_posn",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_n_sign_posn",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswprint_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswcntrl",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswascii",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswpunct_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswctype",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswhexnumber",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswspace_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswdigit",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswideogram",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswgraph",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswupper_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswnumber",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswlower",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswphonogram",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswxdigit_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswprint",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "digittoint_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswrune",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "towlower_l",
-    "resultType" : "wint_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswpunct",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isalnum_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswspecial",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "towupper_l",
-    "resultType" : "wint_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswspace",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isalpha_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswupper",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isblank_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswxdigit",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iscntrl_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "towlower",
-    "resultType" : "wint_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isdigit_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "towupper",
-    "resultType" : "wint_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isgraph_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "ishexnumber_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isideogram_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
     "@type" : "AstRecordDecl",
     "name" : "tm",
     "decls" : [ {
@@ -506,293 +61,153 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "tm_zone",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
     } ]
   }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "islower_l",
-    "resultType" : "int",
+    "@type" : "AstRecordDecl",
+    "name" : "itimerspec",
     "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
+      "@type" : "AstFieldDecl",
+      "name" : "it_interval",
+      "qualType" : "struct timespec",
+      "desugaredQualType" : "timespec"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "it_value",
+      "qualType" : "struct timespec",
+      "desugaredQualType" : "timespec"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "timespec",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "tv_sec",
+      "qualType" : "__time_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tv_nsec",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "timex",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "modes",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "offset",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "freq",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "maxerror",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "esterror",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "status",
       "qualType" : "int",
       "desugaredQualType" : "int"
     }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isnumber_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
+      "@type" : "AstFieldDecl",
+      "name" : "constant",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "precision",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tolerance",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "time",
+      "qualType" : "struct timeval",
+      "desugaredQualType" : "timeval"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tick",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ppsfreq",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "jitter",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "shift",
       "qualType" : "int",
       "desugaredQualType" : "int"
     }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isphonogram_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
+      "@type" : "AstFieldDecl",
+      "name" : "stabil",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "jitcnt",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "calcnt",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "errcnt",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "stbcnt",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tai",
       "qualType" : "int",
       "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
     } ]
   }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isprint_l",
-    "resultType" : "int",
+    "@type" : "AstRecordDecl",
+    "name" : "sched_param",
     "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
+      "@type" : "AstFieldDecl",
+      "name" : "sched_priority",
       "qualType" : "int",
       "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
     } ]
   }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "ispunct_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isrune_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isspace_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isspecial_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isupper_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isxdigit_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "tolower_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "toupper_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isascii",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "major",
-    "resultType" : "__int32_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "minor",
-    "resultType" : "__int32_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "makedev",
-    "resultType" : "dev_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isalnum",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isalpha",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isblank",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iscntrl",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isdigit",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isgraph",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "islower",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isprint",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "ispunct",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isspace",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isupper",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isxdigit",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "toascii",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "tolower",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "toupper",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "digittoint",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "ishexnumber",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isideogram",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isnumber",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isphonogram",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isrune",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isspecial",
-    "resultType" : "int"
+    "@type" : "AstRecordDecl",
+    "name" : "pthread_attr_t"
   }, {
     "@type" : "AstEnumDecl",
     "name" : "IGFD_FileStyleFlags_",
@@ -962,7 +377,7 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puSearchTag",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -985,8 +400,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "FileDialogInternal &",
-          "desugaredQualType" : "FileDialogInternal &"
+          "qualType" : "IGFD::FileDialogInternal &",
+          "desugaredQualType" : "IGFD::FileDialogInternal &"
         } ]
       } ]
     }, {
@@ -1013,17 +428,17 @@
         "decls" : [ {
           "@type" : "AstFieldDecl",
           "name" : "path",
-          "qualType" : "int",
+          "qualType" : "std::string",
           "desugaredQualType" : "int"
         }, {
           "@type" : "AstFieldDecl",
           "name" : "name",
-          "qualType" : "int",
+          "qualType" : "std::string",
           "desugaredQualType" : "int"
         }, {
           "@type" : "AstFieldDecl",
           "name" : "ext",
-          "qualType" : "int",
+          "qualType" : "std::string",
           "desugaredQualType" : "int"
         }, {
           "@type" : "AstFieldDecl",
@@ -1079,18 +494,18 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "str",
-          "qualType" : "int &",
-          "desugaredQualType" : "int &"
+          "qualType" : "std::string &",
+          "desugaredQualType" : "std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "oldStr",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "newStr",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1099,8 +514,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "name",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1109,18 +524,18 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "name",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "ParsePathFileName",
-        "resultType" : "PathStruct",
+        "resultType" : "IGFD::Utils::PathStruct",
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vPathFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1139,8 +554,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vStr",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1169,8 +584,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vStr",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1179,8 +594,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "text",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "delimiter",
@@ -1223,7 +638,7 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "icon",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -1264,7 +679,7 @@
         "decls" : [ {
           "@type" : "AstFieldDecl",
           "name" : "filter",
-          "qualType" : "int",
+          "qualType" : "std::string",
           "desugaredQualType" : "int"
         }, {
           "@type" : "AstFieldDecl",
@@ -1286,8 +701,8 @@
           "decls" : [ {
             "@type" : "AstParmVarDecl",
             "name" : "vFilter",
-            "qualType" : "const int &",
-            "desugaredQualType" : "const int &"
+            "qualType" : "const std::string &",
+            "desugaredQualType" : "const std::string &"
           } ]
         } ]
       }, {
@@ -1297,18 +712,23 @@
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
-        "name" : "prSelectedFilter",
-        "qualType" : "FilterInfos",
-        "desugaredQualType" : "IGFD::FilterManager::FilterInfos"
-      }, {
-        "@type" : "AstFieldDecl",
-        "name" : "puDLGFilters",
+        "name" : "prFilesStyle",
         "qualType" : "int",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
+        "name" : "prSelectedFilter",
+        "qualType" : "IGFD::FilterManager::FilterInfos",
+        "desugaredQualType" : "IGFD::FilterManager::FilterInfos"
+      }, {
+        "@type" : "AstFieldDecl",
+        "name" : "puDLGFilters",
+        "qualType" : "std::string",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFieldDecl",
         "name" : "puDLGdefaultExt",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFunctionDecl",
@@ -1327,8 +747,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFilter",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1357,8 +777,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vInfos",
-          "qualType" : "const FileStyle &",
-          "desugaredQualType" : "const FileStyle &"
+          "qualType" : "const IGFD::FileStyle &",
+          "desugaredQualType" : "const IGFD::FileStyle &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1382,8 +802,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vIcon",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFont",
@@ -1402,8 +822,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vCriteria",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vOutColor",
@@ -1412,8 +832,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vOutIcon",
-          "qualType" : "int *",
-          "desugaredQualType" : "int *"
+          "qualType" : "std::string *",
+          "desugaredQualType" : "std::string *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vOutFont",
@@ -1431,8 +851,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vTag",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1441,22 +861,22 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "FileDialogInternal &",
-          "desugaredQualType" : "FileDialogInternal &"
+          "qualType" : "IGFD::FileDialogInternal &",
+          "desugaredQualType" : "IGFD::FileDialogInternal &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetSelectedFilter",
-        "resultType" : "FilterInfos"
+        "resultType" : "IGFD::FilterManager::FilterInfos"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "ReplaceExtentionWithCurrentFilter",
-        "resultType" : "int",
+        "resultType" : "std::string",
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFile",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1489,22 +909,22 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "filePath",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "fileNameExt",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "fileNameExt_optimized",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "fileExt",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -1514,12 +934,12 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "formatedFileSize",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "fileModifDate",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -1533,8 +953,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vTag",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       } ]
     }, {
@@ -1598,7 +1018,7 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "prCurrentPath",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -1618,7 +1038,7 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "prLastSelectedFileName",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -1668,22 +1088,22 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puHeaderFileName",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puHeaderFileType",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puHeaderFileSize",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puHeaderFileDate",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -1693,7 +1113,7 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puSortingField",
-        "qualType" : "SortingFieldEnum",
+        "qualType" : "IGFD::FileManager::SortingFieldEnum",
         "desugaredQualType" : "IGFD::FileManager::SortingFieldEnum"
       }, {
         "@type" : "AstFieldDecl",
@@ -1703,12 +1123,12 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puDLGpath",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puDLGDefaultFileName",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -1723,12 +1143,12 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puFsRoot",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "prRoundNumber",
-        "resultType" : "int",
+        "resultType" : "std::string",
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vvalue",
@@ -1743,7 +1163,7 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "prFormatFileSize",
-        "resultType" : "int",
+        "resultType" : "std::string",
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vByteSize",
@@ -1753,12 +1173,12 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "prOptimizeFilenameForSearchOperations",
-        "resultType" : "int",
+        "resultType" : "std::string",
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileNameExt",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1777,8 +1197,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1787,8 +1207,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSetLastSelectionFileName",
@@ -1802,18 +1222,18 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "const FileDialogInternal &",
-          "desugaredQualType" : "const FileDialogInternal &"
+          "qualType" : "const IGFD::FileDialogInternal &",
+          "desugaredQualType" : "const IGFD::FileDialogInternal &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFileType",
@@ -1871,13 +1291,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetBack",
-        "resultType" : "int"
+        "resultType" : "std::string"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "ClearComposer",
@@ -1897,8 +1317,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "const FileDialogInternal &",
-          "desugaredQualType" : "const FileDialogInternal &"
+          "qualType" : "const IGFD::FileDialogInternal &",
+          "desugaredQualType" : "const IGFD::FileDialogInternal &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1907,8 +1327,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "const FileDialogInternal &",
-          "desugaredQualType" : "const FileDialogInternal &"
+          "qualType" : "const IGFD::FileDialogInternal &",
+          "desugaredQualType" : "const IGFD::FileDialogInternal &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1917,13 +1337,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "const FileDialogInternal &",
-          "desugaredQualType" : "const FileDialogInternal &"
+          "qualType" : "const IGFD::FileDialogInternal &",
+          "desugaredQualType" : "const IGFD::FileDialogInternal &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSortingField",
-          "qualType" : "const SortingFieldEnum &",
-          "desugaredQualType" : "const SortingFieldEnum &"
+          "qualType" : "const IGFD::FileManager::SortingFieldEnum &",
+          "desugaredQualType" : "const IGFD::FileManager::SortingFieldEnum &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vCanChangeOrder",
@@ -1941,8 +1361,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1961,7 +1381,7 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetCurrentPath",
-        "resultType" : "int"
+        "resultType" : "std::string"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "SetCurrentPath",
@@ -1969,8 +1389,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vCurrentPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1979,8 +1399,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFile",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1989,8 +1409,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2009,8 +1429,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "const FileDialogInternal &",
-          "desugaredQualType" : "const FileDialogInternal &"
+          "qualType" : "const IGFD::FileDialogInternal &",
+          "desugaredQualType" : "const IGFD::FileDialogInternal &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vInfos",
@@ -2024,8 +1444,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstFullComment",
           "decls" : [ {
@@ -2043,37 +1463,37 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "const FileDialogInternal &",
-          "desugaredQualType" : "const FileDialogInternal &"
+          "qualType" : "const IGFD::FileDialogInternal &",
+          "desugaredQualType" : "const IGFD::FileDialogInternal &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetResultingPath",
-        "resultType" : "int"
+        "resultType" : "std::string"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetResultingFileName",
-        "resultType" : "int",
+        "resultType" : "std::string",
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "FileDialogInternal &",
-          "desugaredQualType" : "FileDialogInternal &"
+          "qualType" : "IGFD::FileDialogInternal &",
+          "desugaredQualType" : "IGFD::FileDialogInternal &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetResultingFilePathName",
-        "resultType" : "int",
+        "resultType" : "std::string",
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "FileDialogInternal &",
-          "desugaredQualType" : "FileDialogInternal &"
+          "qualType" : "IGFD::FileDialogInternal &",
+          "desugaredQualType" : "IGFD::FileDialogInternal &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2086,8 +1506,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "const FileDialogInternal &",
-          "desugaredQualType" : "const FileDialogInternal &"
+          "qualType" : "const IGFD::FileDialogInternal &",
+          "desugaredQualType" : "const IGFD::FileDialogInternal &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2096,8 +1516,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "const FileDialogInternal &",
-          "desugaredQualType" : "const FileDialogInternal &"
+          "qualType" : "const IGFD::FileDialogInternal &",
+          "desugaredQualType" : "const IGFD::FileDialogInternal &"
         } ]
       } ]
     }, {
@@ -2110,8 +1530,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "FileDialogInternal &",
-          "desugaredQualType" : "FileDialogInternal &"
+          "qualType" : "IGFD::FileDialogInternal &",
+          "desugaredQualType" : "IGFD::FileDialogInternal &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2120,8 +1540,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "FileDialogInternal &",
-          "desugaredQualType" : "FileDialogInternal &"
+          "qualType" : "IGFD::FileDialogInternal &",
+          "desugaredQualType" : "IGFD::FileDialogInternal &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2130,8 +1550,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vFileDialogInternal",
-          "qualType" : "FileDialogInternal &",
-          "desugaredQualType" : "FileDialogInternal &"
+          "qualType" : "IGFD::FileDialogInternal &",
+          "desugaredQualType" : "IGFD::FileDialogInternal &"
         } ]
       } ]
     }, {
@@ -2172,22 +1592,22 @@
       "decls" : [ {
         "@type" : "AstFieldDecl",
         "name" : "puFileManager",
-        "qualType" : "FileManager",
+        "qualType" : "IGFD::FileManager",
         "desugaredQualType" : "IGFD::FileManager"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puFilterManager",
-        "qualType" : "FilterManager",
+        "qualType" : "IGFD::FilterManager",
         "desugaredQualType" : "IGFD::FilterManager"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puSearchManager",
-        "qualType" : "SearchManager",
+        "qualType" : "IGFD::SearchManager",
         "desugaredQualType" : "IGFD::SearchManager"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puName",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -2237,12 +1657,12 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puDLGkey",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puDLGtitle",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -2252,13 +1672,13 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puDLGuserDatas",
-        "qualType" : "UserDatas",
+        "qualType" : "IGFD::UserDatas",
         "desugaredQualType" : "void *"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puDLGoptionsPane",
-        "qualType" : "PaneFun",
-        "desugaredQualType" : "int"
+        "qualType" : "IGFD::PaneFun",
+        "desugaredQualType" : "std::function<void (const char *, void *, bool *)>"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puDLGoptionsPaneWidth",
@@ -2287,12 +1707,12 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puLocaleBegin",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "puLocaleEnd",
-        "qualType" : "int",
+        "qualType" : "std::string",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFunctionDecl",
@@ -2328,7 +1748,7 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "prFileDialogInternal",
-        "qualType" : "FileDialogInternal",
+        "qualType" : "IGFD::FileDialogInternal",
         "desugaredQualType" : "IGFD::FileDialogInternal"
       }, {
         "@type" : "AstFieldDecl",
@@ -2343,7 +1763,7 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "Instance",
-        "resultType" : "FileDialog *"
+        "resultType" : "IGFD::FileDialog *"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "OpenDialog",
@@ -2351,13 +1771,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilters",
@@ -2366,13 +1786,13 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vCountSelectionMax",
@@ -2382,7 +1802,7 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vUserDatas",
-          "qualType" : "UserDatas",
+          "qualType" : "IGFD::UserDatas",
           "desugaredQualType" : "void *",
           "defaultValue" : "nullptr"
         }, {
@@ -2408,13 +1828,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilters",
@@ -2423,8 +1843,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilePathName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vCountSelectionMax",
@@ -2434,7 +1854,7 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vUserDatas",
-          "qualType" : "UserDatas",
+          "qualType" : "IGFD::UserDatas",
           "desugaredQualType" : "void *",
           "defaultValue" : "nullptr"
         }, {
@@ -2451,13 +1871,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilters",
@@ -2466,18 +1886,18 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSidePane",
-          "qualType" : "const PaneFun &",
-          "desugaredQualType" : "const PaneFun &"
+          "qualType" : "const IGFD::PaneFun &",
+          "desugaredQualType" : "const IGFD::PaneFun &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSidePaneWidth",
@@ -2493,7 +1913,7 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vUserDatas",
-          "qualType" : "UserDatas",
+          "qualType" : "IGFD::UserDatas",
           "desugaredQualType" : "void *",
           "defaultValue" : "nullptr"
         }, {
@@ -2519,13 +1939,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilters",
@@ -2534,13 +1954,13 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilePathName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSidePane",
-          "qualType" : "const PaneFun &",
-          "desugaredQualType" : "const PaneFun &"
+          "qualType" : "const IGFD::PaneFun &",
+          "desugaredQualType" : "const IGFD::PaneFun &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSidePaneWidth",
@@ -2556,7 +1976,7 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vUserDatas",
-          "qualType" : "UserDatas",
+          "qualType" : "IGFD::UserDatas",
           "desugaredQualType" : "void *",
           "defaultValue" : "nullptr"
         }, {
@@ -2573,13 +1993,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilters",
@@ -2588,13 +2008,13 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vCountSelectionMax",
@@ -2604,7 +2024,7 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vUserDatas",
-          "qualType" : "UserDatas",
+          "qualType" : "IGFD::UserDatas",
           "desugaredQualType" : "void *",
           "defaultValue" : "nullptr"
         }, {
@@ -2630,13 +2050,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilters",
@@ -2645,8 +2065,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilePathName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vCountSelectionMax",
@@ -2656,7 +2076,7 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vUserDatas",
-          "qualType" : "UserDatas",
+          "qualType" : "IGFD::UserDatas",
           "desugaredQualType" : "void *",
           "defaultValue" : "nullptr"
         }, {
@@ -2673,13 +2093,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilters",
@@ -2688,18 +2108,18 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vPath",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFileName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSidePane",
-          "qualType" : "const PaneFun &",
-          "desugaredQualType" : "const PaneFun &"
+          "qualType" : "const IGFD::PaneFun &",
+          "desugaredQualType" : "const IGFD::PaneFun &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSidePaneWidth",
@@ -2715,7 +2135,7 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vUserDatas",
-          "qualType" : "UserDatas",
+          "qualType" : "IGFD::UserDatas",
           "desugaredQualType" : "void *",
           "defaultValue" : "nullptr"
         }, {
@@ -2741,13 +2161,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vTitle",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilters",
@@ -2756,13 +2176,13 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFilePathName",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSidePane",
-          "qualType" : "const PaneFun &",
-          "desugaredQualType" : "const PaneFun &"
+          "qualType" : "const IGFD::PaneFun &",
+          "desugaredQualType" : "const IGFD::PaneFun &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vSidePaneWidth",
@@ -2778,7 +2198,7 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vUserDatas",
-          "qualType" : "UserDatas",
+          "qualType" : "IGFD::UserDatas",
           "desugaredQualType" : "void *",
           "defaultValue" : "nullptr"
         }, {
@@ -2795,8 +2215,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vFlags",
@@ -2836,8 +2256,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstFullComment",
           "decls" : [ {
@@ -2859,8 +2279,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "vKey",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -2869,7 +2289,7 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetOpenedKey",
-        "resultType" : "int"
+        "resultType" : "std::string"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "IsOk",
@@ -2891,23 +2311,23 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetFilePathName",
-        "resultType" : "int"
+        "resultType" : "std::string"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetCurrentFileName",
-        "resultType" : "int"
+        "resultType" : "std::string"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetCurrentPath",
-        "resultType" : "int"
+        "resultType" : "std::string"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetCurrentFilter",
-        "resultType" : "int"
+        "resultType" : "std::string"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetUserDatas",
-        "resultType" : "UserDatas"
+        "resultType" : "IGFD::UserDatas"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "SetFileStyle",
@@ -2925,8 +2345,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vInfos",
-          "qualType" : "const FileStyle &",
-          "desugaredQualType" : "const FileStyle &"
+          "qualType" : "const IGFD::FileStyle &",
+          "desugaredQualType" : "const IGFD::FileStyle &"
         }, {
           "@type" : "AstFullComment",
           "decls" : [ {
@@ -2959,8 +2379,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vIcon",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &",
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &",
           "defaultValue" : "="
         }, {
           "@type" : "AstParmVarDecl",
@@ -2981,8 +2401,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vCriteria",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vOutColor",
@@ -2991,8 +2411,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vOutIcon",
-          "qualType" : "int *",
-          "desugaredQualType" : "int *",
+          "qualType" : "std::string *",
+          "desugaredQualType" : "std::string *",
           "defaultValue" : "nullptr"
         }, {
           "@type" : "AstParmVarDecl",
@@ -3017,13 +2437,13 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vLocaleBegin",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vLocaleEnd",
-          "qualType" : "const int &",
-          "desugaredQualType" : "const int &"
+          "qualType" : "const std::string &",
+          "desugaredQualType" : "const std::string &"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -3154,8 +2574,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vOutStr",
-          "qualType" : "int &",
-          "desugaredQualType" : "int &"
+          "qualType" : "std::string &",
+          "desugaredQualType" : "std::string &"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "vOutFont",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-ImGuizmo.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-ImGuizmo.json
@@ -17,7 +17,7 @@
         "name" : "drawlist",
         "qualType" : "int *",
         "desugaredQualType" : "int *",
-        "defaultValue" : "="
+        "defaultValue" : "nullptr"
       }, {
         "@type" : "AstFullComment",
         "decls" : [ {
@@ -471,12 +471,12 @@
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "operation",
-        "qualType" : "OPERATION",
+        "qualType" : "ImGuizmo::OPERATION",
         "desugaredQualType" : "ImGuizmo::OPERATION"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "mode",
-        "qualType" : "MODE",
+        "qualType" : "ImGuizmo::MODE",
         "desugaredQualType" : "ImGuizmo::MODE"
       }, {
         "@type" : "AstParmVarDecl",
@@ -570,7 +570,7 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "op",
-        "qualType" : "OPERATION",
+        "qualType" : "ImGuizmo::OPERATION",
         "desugaredQualType" : "ImGuizmo::OPERATION"
       }, {
         "@type" : "AstFullComment",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-TextEditor.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-TextEditor.json
@@ -7,6 +7,79 @@
   },
   "decls" : [ {
     "@type" : "AstRecordDecl",
+    "name" : "tm",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_sec",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_min",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_hour",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_mday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_mon",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_year",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_wday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_yday",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_isdst",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_gmtoff",
+      "qualType" : "long",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tm_zone",
+      "qualType" : "const char *",
+      "desugaredQualType" : "const char *"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
+    "name" : "itimerspec",
+    "decls" : [ {
+      "@type" : "AstFieldDecl",
+      "name" : "it_interval",
+      "qualType" : "struct timespec",
+      "desugaredQualType" : "timespec"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "it_value",
+      "qualType" : "struct timespec",
+      "desugaredQualType" : "timespec"
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
     "name" : "TextEditor",
     "decls" : [ {
       "@type" : "AstEnumDecl",
@@ -183,7 +256,7 @@
         "@type" : "AstFieldDecl",
         "name" : "mCondition",
         "qualType" : "std::string",
-        "desugaredQualType" : "std::string"
+        "desugaredQualType" : "std::basic_string<char>"
       } ]
     }, {
       "@type" : "AstRecordDecl",
@@ -228,7 +301,7 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "Invalid",
-        "resultType" : "Coordinates"
+        "resultType" : "TextEditor::Coordinates"
       } ]
     }, {
       "@type" : "AstRecordDecl",
@@ -236,13 +309,13 @@
       "decls" : [ {
         "@type" : "AstFieldDecl",
         "name" : "mLocation",
-        "qualType" : "Coordinates",
+        "qualType" : "TextEditor::Coordinates",
         "desugaredQualType" : "TextEditor::Coordinates"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mDeclaration",
         "qualType" : "std::string",
-        "desugaredQualType" : "std::string"
+        "desugaredQualType" : "std::basic_string<char>"
       } ]
     }, {
       "@type" : "AstRecordDecl",
@@ -250,12 +323,12 @@
       "decls" : [ {
         "@type" : "AstFieldDecl",
         "name" : "mChar",
-        "qualType" : "Char",
+        "qualType" : "TextEditor::Char",
         "desugaredQualType" : "unsigned char"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mColorIndex",
-        "qualType" : "PaletteIndex",
+        "qualType" : "TextEditor::PaletteIndex",
         "desugaredQualType" : "TextEditor::PaletteIndex"
       }, {
         "@type" : "AstFieldDecl",
@@ -280,37 +353,37 @@
         "@type" : "AstFieldDecl",
         "name" : "mName",
         "qualType" : "std::string",
-        "desugaredQualType" : "std::string"
+        "desugaredQualType" : "std::basic_string<char>"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mKeywords",
-        "qualType" : "Keywords",
+        "qualType" : "TextEditor::Keywords",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mIdentifiers",
-        "qualType" : "Identifiers",
+        "qualType" : "TextEditor::Identifiers",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mPreprocIdentifiers",
-        "qualType" : "Identifiers",
+        "qualType" : "TextEditor::Identifiers",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mCommentStart",
         "qualType" : "std::string",
-        "desugaredQualType" : "std::string"
+        "desugaredQualType" : "std::basic_string<char>"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mCommentEnd",
         "qualType" : "std::string",
-        "desugaredQualType" : "std::string"
+        "desugaredQualType" : "std::basic_string<char>"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mSingleLineComment",
         "qualType" : "std::string",
-        "desugaredQualType" : "std::string"
+        "desugaredQualType" : "std::basic_string<char>"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mPreprocChar",
@@ -324,12 +397,12 @@
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mTokenize",
-        "qualType" : "TokenizeCallback",
-        "desugaredQualType" : "bool (*)(const char *, const char *, const char *&, const char *&, PaletteIndex &)"
+        "qualType" : "TextEditor::LanguageDefinition::TokenizeCallback",
+        "desugaredQualType" : "bool (*)(const char *, const char *, const char *&, const char *&, TextEditor::PaletteIndex &)"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mTokenRegexStrings",
-        "qualType" : "TokenRegexStrings",
+        "qualType" : "TextEditor::LanguageDefinition::TokenRegexStrings",
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstFieldDecl",
@@ -339,31 +412,31 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "CPlusPlus",
-        "resultType" : "const LanguageDefinition &"
+        "resultType" : "const TextEditor::LanguageDefinition &"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "HLSL",
-        "resultType" : "const LanguageDefinition &"
+        "resultType" : "const TextEditor::LanguageDefinition &"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GLSL",
-        "resultType" : "const LanguageDefinition &"
+        "resultType" : "const TextEditor::LanguageDefinition &"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "C",
-        "resultType" : "const LanguageDefinition &"
+        "resultType" : "const TextEditor::LanguageDefinition &"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "SQL",
-        "resultType" : "const LanguageDefinition &"
+        "resultType" : "const TextEditor::LanguageDefinition &"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "AngelScript",
-        "resultType" : "const LanguageDefinition &"
+        "resultType" : "const TextEditor::LanguageDefinition &"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "Lua",
-        "resultType" : "const LanguageDefinition &"
+        "resultType" : "const TextEditor::LanguageDefinition &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -372,17 +445,17 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aLanguageDef",
-        "qualType" : "const LanguageDefinition &",
-        "desugaredQualType" : "const LanguageDefinition &"
+        "qualType" : "const TextEditor::LanguageDefinition &",
+        "desugaredQualType" : "const TextEditor::LanguageDefinition &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetLanguageDefinition",
-      "resultType" : "const LanguageDefinition &"
+      "resultType" : "const TextEditor::LanguageDefinition &"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetPalette",
-      "resultType" : "const Palette &"
+      "resultType" : "const TextEditor::Palette &"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetPalette",
@@ -390,8 +463,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aValue",
-        "qualType" : "const Palette &",
-        "desugaredQualType" : "const Palette &"
+        "qualType" : "const TextEditor::Palette &",
+        "desugaredQualType" : "const TextEditor::Palette &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -400,8 +473,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aMarkers",
-        "qualType" : "const ErrorMarkers &",
-        "desugaredQualType" : "const ErrorMarkers &"
+        "qualType" : "const TextEditor::ErrorMarkers &",
+        "desugaredQualType" : "const TextEditor::ErrorMarkers &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -410,8 +483,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aMarkers",
-        "qualType" : "const Breakpoints &",
-        "desugaredQualType" : "const Breakpoints &"
+        "qualType" : "const TextEditor::Breakpoints &",
+        "desugaredQualType" : "const TextEditor::Breakpoints &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -518,7 +591,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetCursorPosition",
-      "resultType" : "Coordinates"
+      "resultType" : "TextEditor::Coordinates"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SetCursorPosition",
@@ -526,8 +599,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aPosition",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -750,8 +823,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aPosition",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -760,8 +833,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aPosition",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -770,17 +843,17 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aStart",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "aEnd",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "aMode",
-        "qualType" : "SelectionMode",
+        "qualType" : "TextEditor::SelectionMode",
         "desugaredQualType" : "TextEditor::SelectionMode",
         "defaultValue" : "SelectionMode::Normal"
       } ]
@@ -845,32 +918,32 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetDarkPalette",
-      "resultType" : "const Palette &"
+      "resultType" : "const TextEditor::Palette &"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetLightPalette",
-      "resultType" : "const Palette &"
+      "resultType" : "const TextEditor::Palette &"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetRetroBluePalette",
-      "resultType" : "const Palette &"
+      "resultType" : "const TextEditor::Palette &"
     }, {
       "@type" : "AstRecordDecl",
       "name" : "EditorState",
       "decls" : [ {
         "@type" : "AstFieldDecl",
         "name" : "mSelectionStart",
-        "qualType" : "Coordinates",
+        "qualType" : "TextEditor::Coordinates",
         "desugaredQualType" : "TextEditor::Coordinates"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mSelectionEnd",
-        "qualType" : "Coordinates",
+        "qualType" : "TextEditor::Coordinates",
         "desugaredQualType" : "TextEditor::Coordinates"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mCursorPosition",
-        "qualType" : "Coordinates",
+        "qualType" : "TextEditor::Coordinates",
         "desugaredQualType" : "TextEditor::Coordinates"
       } ]
     }, {
@@ -900,41 +973,41 @@
         "@type" : "AstFieldDecl",
         "name" : "mAdded",
         "qualType" : "std::string",
-        "desugaredQualType" : "std::string"
+        "desugaredQualType" : "std::basic_string<char>"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mAddedStart",
-        "qualType" : "Coordinates",
+        "qualType" : "TextEditor::Coordinates",
         "desugaredQualType" : "TextEditor::Coordinates"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mAddedEnd",
-        "qualType" : "Coordinates",
+        "qualType" : "TextEditor::Coordinates",
         "desugaredQualType" : "TextEditor::Coordinates"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mRemoved",
         "qualType" : "std::string",
-        "desugaredQualType" : "std::string"
+        "desugaredQualType" : "std::basic_string<char>"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mRemovedStart",
-        "qualType" : "Coordinates",
+        "qualType" : "TextEditor::Coordinates",
         "desugaredQualType" : "TextEditor::Coordinates"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mRemovedEnd",
-        "qualType" : "Coordinates",
+        "qualType" : "TextEditor::Coordinates",
         "desugaredQualType" : "TextEditor::Coordinates"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mBefore",
-        "qualType" : "EditorState",
+        "qualType" : "TextEditor::EditorState",
         "desugaredQualType" : "TextEditor::EditorState"
       }, {
         "@type" : "AstFieldDecl",
         "name" : "mAfter",
-        "qualType" : "EditorState",
+        "qualType" : "TextEditor::EditorState",
         "desugaredQualType" : "TextEditor::EditorState"
       } ]
     }, {
@@ -986,8 +1059,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aFrom",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1004,27 +1077,27 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aStart",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "aEnd",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "GetActualCursorCoordinates",
-      "resultType" : "Coordinates"
+      "resultType" : "TextEditor::Coordinates"
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "SanitizeCoordinates",
-      "resultType" : "Coordinates",
+      "resultType" : "TextEditor::Coordinates",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aValue",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1033,8 +1106,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aCoordinates",
-        "qualType" : "Coordinates &",
-        "desugaredQualType" : "Coordinates &"
+        "qualType" : "TextEditor::Coordinates &",
+        "desugaredQualType" : "TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1043,13 +1116,13 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aStart",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "aEnd",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1058,8 +1131,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aWhere",
-        "qualType" : "Coordinates &",
-        "desugaredQualType" : "Coordinates &"
+        "qualType" : "TextEditor::Coordinates &",
+        "desugaredQualType" : "TextEditor::Coordinates &"
       }, {
         "@type" : "AstParmVarDecl",
         "name" : "aValue",
@@ -1073,13 +1146,13 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aValue",
-        "qualType" : "UndoRecord &",
-        "desugaredQualType" : "UndoRecord &"
+        "qualType" : "TextEditor::UndoRecord &",
+        "desugaredQualType" : "TextEditor::UndoRecord &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "ScreenPosToCoordinates",
-      "resultType" : "Coordinates",
+      "resultType" : "TextEditor::Coordinates",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aPosition",
@@ -1089,32 +1162,32 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "FindWordStart",
-      "resultType" : "Coordinates",
+      "resultType" : "TextEditor::Coordinates",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aFrom",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "FindWordEnd",
-      "resultType" : "Coordinates",
+      "resultType" : "TextEditor::Coordinates",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aFrom",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "FindNextWord",
-      "resultType" : "Coordinates",
+      "resultType" : "TextEditor::Coordinates",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aFrom",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1123,8 +1196,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aCoordinates",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1168,8 +1241,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aAt",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1199,7 +1272,7 @@
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "InsertLine",
-      "resultType" : "Line &",
+      "resultType" : "TextEditor::Line &",
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aIndex",
@@ -1240,8 +1313,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aCoords",
-        "qualType" : "const Coordinates &",
-        "desugaredQualType" : "const Coordinates &"
+        "qualType" : "const TextEditor::Coordinates &",
+        "desugaredQualType" : "const TextEditor::Coordinates &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1250,8 +1323,8 @@
       "decls" : [ {
         "@type" : "AstParmVarDecl",
         "name" : "aGlyph",
-        "qualType" : "const Glyph &",
-        "desugaredQualType" : "const Glyph &"
+        "qualType" : "const TextEditor::Glyph &",
+        "desugaredQualType" : "const TextEditor::Glyph &"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -1273,17 +1346,17 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mLines",
-      "qualType" : "Lines",
+      "qualType" : "TextEditor::Lines",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mState",
-      "qualType" : "EditorState",
+      "qualType" : "TextEditor::EditorState",
       "desugaredQualType" : "TextEditor::EditorState"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mUndoBuffer",
-      "qualType" : "UndoBuffer",
+      "qualType" : "TextEditor::UndoBuffer",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -1358,7 +1431,7 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mSelectionMode",
-      "qualType" : "SelectionMode",
+      "qualType" : "TextEditor::SelectionMode",
       "desugaredQualType" : "TextEditor::SelectionMode"
     }, {
       "@type" : "AstFieldDecl",
@@ -1383,22 +1456,22 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mPaletteBase",
-      "qualType" : "Palette",
+      "qualType" : "TextEditor::Palette",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mPalette",
-      "qualType" : "Palette",
+      "qualType" : "TextEditor::Palette",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mLanguageDefinition",
-      "qualType" : "LanguageDefinition",
+      "qualType" : "TextEditor::LanguageDefinition",
       "desugaredQualType" : "TextEditor::LanguageDefinition"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mRegexList",
-      "qualType" : "RegexList",
+      "qualType" : "TextEditor::RegexList",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -1408,12 +1481,12 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mBreakpoints",
-      "qualType" : "Breakpoints",
+      "qualType" : "TextEditor::Breakpoints",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mErrorMarkers",
-      "qualType" : "ErrorMarkers",
+      "qualType" : "TextEditor::ErrorMarkers",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
@@ -1423,23 +1496,23 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mInteractiveStart",
-      "qualType" : "Coordinates",
+      "qualType" : "TextEditor::Coordinates",
       "desugaredQualType" : "TextEditor::Coordinates"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mInteractiveEnd",
-      "qualType" : "Coordinates",
+      "qualType" : "TextEditor::Coordinates",
       "desugaredQualType" : "TextEditor::Coordinates"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mLineBuffer",
       "qualType" : "std::string",
-      "desugaredQualType" : "std::string"
+      "desugaredQualType" : "std::basic_string<char>"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mStartTime",
       "qualType" : "uint64_t",
-      "desugaredQualType" : "unsigned long long"
+      "desugaredQualType" : "unsigned long"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "mLastClick",
@@ -1447,792 +1520,134 @@
       "desugaredQualType" : "float"
     } ]
   }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswalnum_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswblank_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswalpha_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswhexnumber_l",
-    "resultType" : "int"
-  }, {
     "@type" : "AstRecordDecl",
     "name" : "timespec",
     "decls" : [ {
       "@type" : "AstFieldDecl",
       "name" : "tv_sec",
-      "qualType" : "__darwin_time_t",
+      "qualType" : "__time_t",
       "desugaredQualType" : "long"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "tv_nsec",
-      "qualType" : "long",
+      "qualType" : "__syscall_slong_t",
       "desugaredQualType" : "long"
     } ]
   }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswcntrl_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswideogram_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswctype_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswnumber_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswdigit_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswphonogram_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswgraph_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswrune_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswalnum",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswlower_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswspecial_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswalpha",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswblank",
-    "resultType" : "int"
-  }, {
     "@type" : "AstRecordDecl",
-    "name" : "lconv",
+    "name" : "timex",
     "decls" : [ {
       "@type" : "AstFieldDecl",
-      "name" : "decimal_point",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
+      "name" : "modes",
+      "qualType" : "unsigned int",
+      "desugaredQualType" : "unsigned int"
     }, {
       "@type" : "AstFieldDecl",
-      "name" : "thousands_sep",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "grouping",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_curr_symbol",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "currency_symbol",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "mon_decimal_point",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "mon_thousands_sep",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "mon_grouping",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "positive_sign",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "negative_sign",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_frac_digits",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "frac_digits",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "p_cs_precedes",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "p_sep_by_space",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "n_cs_precedes",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "n_sep_by_space",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "p_sign_posn",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "n_sign_posn",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_p_cs_precedes",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_n_cs_precedes",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_p_sep_by_space",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_n_sep_by_space",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_p_sign_posn",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "int_n_sign_posn",
-      "qualType" : "char",
-      "desugaredQualType" : "char"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswprint_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswcntrl",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswascii",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswpunct_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswctype",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswhexnumber",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswspace_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswdigit",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswideogram",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswgraph",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswupper_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswnumber",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswlower",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswphonogram",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswxdigit_l",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswprint",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "digittoint_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswrune",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "towlower_l",
-    "resultType" : "wint_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswpunct",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isalnum_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswspecial",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "towupper_l",
-    "resultType" : "wint_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswspace",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isalpha_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswupper",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isblank_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iswxdigit",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iscntrl_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "towlower",
-    "resultType" : "wint_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isdigit_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "towupper",
-    "resultType" : "wint_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isgraph_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "ishexnumber_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isideogram_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstRecordDecl",
-    "name" : "tm",
-    "decls" : [ {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_sec",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_min",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_hour",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_mday",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_mon",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_year",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_wday",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_yday",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_isdst",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "tm_gmtoff",
-      "qualType" : "long",
+      "name" : "offset",
+      "qualType" : "__syscall_slong_t",
       "desugaredQualType" : "long"
     }, {
       "@type" : "AstFieldDecl",
-      "name" : "tm_zone",
-      "qualType" : "char *",
-      "desugaredQualType" : "char *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "islower_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
+      "name" : "freq",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "maxerror",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "esterror",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "status",
       "qualType" : "int",
       "desugaredQualType" : "int"
     }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isnumber_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
+      "@type" : "AstFieldDecl",
+      "name" : "constant",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "precision",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tolerance",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "time",
+      "qualType" : "struct timeval",
+      "desugaredQualType" : "timeval"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tick",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "ppsfreq",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "jitter",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "shift",
       "qualType" : "int",
       "desugaredQualType" : "int"
     }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isphonogram_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
+      "@type" : "AstFieldDecl",
+      "name" : "stabil",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "jitcnt",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "calcnt",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "errcnt",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "stbcnt",
+      "qualType" : "__syscall_slong_t",
+      "desugaredQualType" : "long"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "tai",
       "qualType" : "int",
       "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
     } ]
   }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isprint_l",
-    "resultType" : "int",
+    "@type" : "AstRecordDecl",
+    "name" : "sched_param",
     "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
+      "@type" : "AstFieldDecl",
+      "name" : "sched_priority",
       "qualType" : "int",
       "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
     } ]
   }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "ispunct_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isrune_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isspace_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isspecial_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isupper_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isxdigit_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "tolower_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "toupper_l",
-    "resultType" : "int",
-    "decls" : [ {
-      "@type" : "AstParmVarDecl",
-      "name" : "c",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
-    }, {
-      "@type" : "AstParmVarDecl",
-      "name" : "l",
-      "qualType" : "locale_t",
-      "desugaredQualType" : "struct _xlocale *"
-    } ]
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isascii",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "major",
-    "resultType" : "__int32_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "minor",
-    "resultType" : "__int32_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "makedev",
-    "resultType" : "dev_t"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isalnum",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isalpha",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isblank",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "iscntrl",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isdigit",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isgraph",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "islower",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isprint",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "ispunct",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isspace",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isupper",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isxdigit",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "toascii",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "tolower",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "toupper",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "digittoint",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "ishexnumber",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isideogram",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isnumber",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isphonogram",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isrune",
-    "resultType" : "int"
-  }, {
-    "@type" : "AstFunctionDecl",
-    "name" : "isspecial",
-    "resultType" : "int"
+    "@type" : "AstRecordDecl",
+    "name" : "pthread_attr_t"
   } ]
 }

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui.json
@@ -13359,8 +13359,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "out",
-          "qualType" : "ImVector<ImGuiTextRange> *",
-          "desugaredQualType" : "ImVector<ImGuiTextRange> *"
+          "qualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange> *",
+          "desugaredQualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange> *"
         } ]
       } ]
     }, {
@@ -13371,7 +13371,7 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Filters",
-      "qualType" : "ImVector<ImGuiTextRange>",
+      "qualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange>",
       "desugaredQualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange>"
     }, {
       "@type" : "AstFieldDecl",
@@ -13539,7 +13539,7 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Data",
-      "qualType" : "ImVector<ImGuiStoragePair>",
+      "qualType" : "ImVector<ImGuiStorage::ImGuiStoragePair>",
       "desugaredQualType" : "ImVector<ImGuiStorage::ImGuiStoragePair>"
     }, {
       "@type" : "AstFunctionDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui_internal.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui_internal.json
@@ -28526,8 +28526,8 @@
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "out",
-          "qualType" : "ImVector<ImGuiTextRange> *",
-          "desugaredQualType" : "ImVector<ImGuiTextRange> *"
+          "qualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange> *",
+          "desugaredQualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange> *"
         } ]
       } ]
     }, {
@@ -28538,7 +28538,7 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Filters",
-      "qualType" : "ImVector<ImGuiTextRange>",
+      "qualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange>",
       "desugaredQualType" : "ImVector<ImGuiTextFilter::ImGuiTextRange>"
     }, {
       "@type" : "AstFieldDecl",
@@ -28705,7 +28705,7 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Data",
-      "qualType" : "ImVector<ImGuiStoragePair>",
+      "qualType" : "ImVector<ImGuiStorage::ImGuiStoragePair>",
       "desugaredQualType" : "ImVector<ImGuiStorage::ImGuiStoragePair>"
     }, {
       "@type" : "AstFunctionDecl",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imgui_node_editor.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imgui_node_editor.json
@@ -99,33 +99,33 @@
         }, {
           "@type" : "AstFieldDecl",
           "name" : "BeginSaveSession",
-          "qualType" : "ConfigSession",
+          "qualType" : "ax::NodeEditor::ConfigSession",
           "desugaredQualType" : "void (*)(void *)"
         }, {
           "@type" : "AstFieldDecl",
           "name" : "EndSaveSession",
-          "qualType" : "ConfigSession",
+          "qualType" : "ax::NodeEditor::ConfigSession",
           "desugaredQualType" : "void (*)(void *)"
         }, {
           "@type" : "AstFieldDecl",
           "name" : "SaveSettings",
-          "qualType" : "ConfigSaveSettings",
-          "desugaredQualType" : "bool (*)(const char *, size_t, SaveReasonFlags, void *)"
+          "qualType" : "ax::NodeEditor::ConfigSaveSettings",
+          "desugaredQualType" : "bool (*)(const char *, int, ax::NodeEditor::SaveReasonFlags, void *)"
         }, {
           "@type" : "AstFieldDecl",
           "name" : "LoadSettings",
-          "qualType" : "ConfigLoadSettings",
-          "desugaredQualType" : "size_t (*)(char *, void *)"
+          "qualType" : "int",
+          "desugaredQualType" : "int"
         }, {
           "@type" : "AstFieldDecl",
           "name" : "SaveNodeSettings",
-          "qualType" : "ConfigSaveNodeSettings",
-          "desugaredQualType" : "bool (*)(NodeId, const char *, size_t, SaveReasonFlags, void *)"
+          "qualType" : "ax::NodeEditor::ConfigSaveNodeSettings",
+          "desugaredQualType" : "bool (*)(ax::NodeEditor::NodeId, const char *, int, ax::NodeEditor::SaveReasonFlags, void *)"
         }, {
           "@type" : "AstFieldDecl",
           "name" : "LoadNodeSettings",
-          "qualType" : "ConfigLoadNodeSettings",
-          "desugaredQualType" : "size_t (*)(NodeId, char *, void *)"
+          "qualType" : "int",
+          "desugaredQualType" : "int"
         }, {
           "@type" : "AstFieldDecl",
           "name" : "UserPointer",
@@ -612,8 +612,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "ctx",
-          "qualType" : "EditorContext *",
-          "desugaredQualType" : "EditorContext *"
+          "qualType" : "ax::NodeEditor::EditorContext *",
+          "desugaredQualType" : "ax::NodeEditor::EditorContext *"
         }, {
           "@type" : "AstFullComment",
           "decls" : [ {
@@ -627,16 +627,16 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetCurrentEditor",
-        "resultType" : "EditorContext *"
+        "resultType" : "ax::NodeEditor::EditorContext *"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "CreateEditor",
-        "resultType" : "EditorContext *",
+        "resultType" : "ax::NodeEditor::EditorContext *",
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "config",
-          "qualType" : "const Config *",
-          "desugaredQualType" : "const Config *",
+          "qualType" : "const ax::NodeEditor::Config *",
+          "desugaredQualType" : "const ax::NodeEditor::Config *",
           "defaultValue" : "nullptr"
         } ]
       }, {
@@ -646,13 +646,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "ctx",
-          "qualType" : "EditorContext *",
-          "desugaredQualType" : "EditorContext *"
+          "qualType" : "ax::NodeEditor::EditorContext *",
+          "desugaredQualType" : "ax::NodeEditor::EditorContext *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetStyle",
-        "resultType" : "Style &"
+        "resultType" : "ax::NodeEditor::Style &"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetStyleColorName",
@@ -660,7 +660,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "colorIndex",
-          "qualType" : "StyleColor",
+          "qualType" : "ax::NodeEditor::StyleColor",
           "desugaredQualType" : "ax::NodeEditor::StyleColor"
         } ]
       }, {
@@ -670,7 +670,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "colorIndex",
-          "qualType" : "StyleColor",
+          "qualType" : "ax::NodeEditor::StyleColor",
           "desugaredQualType" : "ax::NodeEditor::StyleColor"
         }, {
           "@type" : "AstParmVarDecl",
@@ -696,7 +696,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "varIndex",
-          "qualType" : "StyleVar",
+          "qualType" : "ax::NodeEditor::StyleVar",
           "desugaredQualType" : "ax::NodeEditor::StyleVar"
         }, {
           "@type" : "AstParmVarDecl",
@@ -711,7 +711,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "varIndex",
-          "qualType" : "StyleVar",
+          "qualType" : "ax::NodeEditor::StyleVar",
           "desugaredQualType" : "ax::NodeEditor::StyleVar"
         }, {
           "@type" : "AstParmVarDecl",
@@ -726,7 +726,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "varIndex",
-          "qualType" : "StyleVar",
+          "qualType" : "ax::NodeEditor::StyleVar",
           "desugaredQualType" : "ax::NodeEditor::StyleVar"
         }, {
           "@type" : "AstParmVarDecl",
@@ -772,7 +772,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "id",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -782,12 +782,12 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "id",
-          "qualType" : "PinId",
+          "qualType" : "ax::NodeEditor::PinId",
           "desugaredQualType" : "ax::NodeEditor::PinId"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "kind",
-          "qualType" : "PinKind",
+          "qualType" : "ax::NodeEditor::PinKind",
           "desugaredQualType" : "ax::NodeEditor::PinKind"
         } ]
       }, {
@@ -875,7 +875,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -905,7 +905,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         }, {
           "@type" : "AstFullComment",
@@ -924,17 +924,17 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "id",
-          "qualType" : "LinkId",
+          "qualType" : "ax::NodeEditor::LinkId",
           "desugaredQualType" : "ax::NodeEditor::LinkId"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "startPinId",
-          "qualType" : "PinId",
+          "qualType" : "ax::NodeEditor::PinId",
           "desugaredQualType" : "ax::NodeEditor::PinId"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "endPinId",
-          "qualType" : "PinId",
+          "qualType" : "ax::NodeEditor::PinId",
           "desugaredQualType" : "ax::NodeEditor::PinId"
         }, {
           "@type" : "AstParmVarDecl",
@@ -956,12 +956,12 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "linkId",
-          "qualType" : "LinkId",
+          "qualType" : "ax::NodeEditor::LinkId",
           "desugaredQualType" : "ax::NodeEditor::LinkId"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "direction",
-          "qualType" : "FlowDirection",
+          "qualType" : "ax::NodeEditor::FlowDirection",
           "desugaredQualType" : "ax::NodeEditor::FlowDirection",
           "defaultValue" : "FlowDirection::Forward"
         } ]
@@ -989,13 +989,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "startId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "endId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1004,13 +1004,13 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "startId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "endId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "color",
@@ -1030,8 +1030,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "pinId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1040,8 +1040,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "pinId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "color",
@@ -1109,19 +1109,19 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "linkId",
-          "qualType" : "LinkId *",
-          "desugaredQualType" : "LinkId *"
+          "qualType" : "ax::NodeEditor::LinkId *",
+          "desugaredQualType" : "ax::NodeEditor::LinkId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "startId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *",
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *",
           "defaultValue" : "nullptr"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "endId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *",
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *",
           "defaultValue" : "nullptr"
         } ]
       }, {
@@ -1131,8 +1131,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId *",
-          "desugaredQualType" : "NodeId *"
+          "qualType" : "ax::NodeEditor::NodeId *",
+          "desugaredQualType" : "ax::NodeEditor::NodeId *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1160,7 +1160,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         }, {
           "@type" : "AstParmVarDecl",
@@ -1175,7 +1175,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         }, {
           "@type" : "AstParmVarDecl",
@@ -1190,7 +1190,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1200,7 +1200,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1210,7 +1210,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1220,7 +1220,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         }, {
           "@type" : "AstParmVarDecl",
@@ -1235,7 +1235,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1245,7 +1245,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1279,8 +1279,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodes",
-          "qualType" : "NodeId *",
-          "desugaredQualType" : "NodeId *"
+          "qualType" : "ax::NodeEditor::NodeId *",
+          "desugaredQualType" : "ax::NodeEditor::NodeId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "size",
@@ -1294,8 +1294,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "links",
-          "qualType" : "LinkId *",
-          "desugaredQualType" : "LinkId *"
+          "qualType" : "ax::NodeEditor::LinkId *",
+          "desugaredQualType" : "ax::NodeEditor::LinkId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "size",
@@ -1309,7 +1309,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1319,7 +1319,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "linkId",
-          "qualType" : "LinkId",
+          "qualType" : "ax::NodeEditor::LinkId",
           "desugaredQualType" : "ax::NodeEditor::LinkId"
         } ]
       }, {
@@ -1333,7 +1333,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         }, {
           "@type" : "AstParmVarDecl",
@@ -1349,7 +1349,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "linkId",
-          "qualType" : "LinkId",
+          "qualType" : "ax::NodeEditor::LinkId",
           "desugaredQualType" : "ax::NodeEditor::LinkId"
         }, {
           "@type" : "AstParmVarDecl",
@@ -1365,7 +1365,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1375,7 +1375,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "linkId",
-          "qualType" : "LinkId",
+          "qualType" : "ax::NodeEditor::LinkId",
           "desugaredQualType" : "ax::NodeEditor::LinkId"
         } ]
       }, {
@@ -1385,7 +1385,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1395,7 +1395,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "linkId",
-          "qualType" : "LinkId",
+          "qualType" : "ax::NodeEditor::LinkId",
           "desugaredQualType" : "ax::NodeEditor::LinkId"
         } ]
       }, {
@@ -1405,7 +1405,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1415,7 +1415,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "pinId",
-          "qualType" : "PinId",
+          "qualType" : "ax::NodeEditor::PinId",
           "desugaredQualType" : "ax::NodeEditor::PinId"
         } ]
       }, {
@@ -1425,7 +1425,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId",
+          "qualType" : "ax::NodeEditor::NodeId",
           "desugaredQualType" : "ax::NodeEditor::NodeId"
         } ]
       }, {
@@ -1435,7 +1435,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "pinId",
-          "qualType" : "PinId",
+          "qualType" : "ax::NodeEditor::PinId",
           "desugaredQualType" : "ax::NodeEditor::PinId"
         } ]
       }, {
@@ -1473,8 +1473,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodeId",
-          "qualType" : "NodeId *",
-          "desugaredQualType" : "NodeId *"
+          "qualType" : "ax::NodeEditor::NodeId *",
+          "desugaredQualType" : "ax::NodeEditor::NodeId *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1483,8 +1483,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "pinId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1493,8 +1493,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "linkId",
-          "qualType" : "LinkId *",
-          "desugaredQualType" : "LinkId *"
+          "qualType" : "ax::NodeEditor::LinkId *",
+          "desugaredQualType" : "ax::NodeEditor::LinkId *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1549,8 +1549,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodes",
-          "qualType" : "NodeId *",
-          "desugaredQualType" : "NodeId *"
+          "qualType" : "ax::NodeEditor::NodeId *",
+          "desugaredQualType" : "ax::NodeEditor::NodeId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "size",
@@ -1564,8 +1564,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "links",
-          "qualType" : "LinkId *",
-          "desugaredQualType" : "LinkId *"
+          "qualType" : "ax::NodeEditor::LinkId *",
+          "desugaredQualType" : "ax::NodeEditor::LinkId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "size",
@@ -1583,27 +1583,27 @@
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetHoveredNode",
-        "resultType" : "NodeId"
+        "resultType" : "ax::NodeEditor::NodeId"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetHoveredPin",
-        "resultType" : "PinId"
+        "resultType" : "ax::NodeEditor::PinId"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetHoveredLink",
-        "resultType" : "LinkId"
+        "resultType" : "ax::NodeEditor::LinkId"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetDoubleClickedNode",
-        "resultType" : "NodeId"
+        "resultType" : "ax::NodeEditor::NodeId"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetDoubleClickedPin",
-        "resultType" : "PinId"
+        "resultType" : "ax::NodeEditor::PinId"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "GetDoubleClickedLink",
-        "resultType" : "LinkId"
+        "resultType" : "ax::NodeEditor::LinkId"
       }, {
         "@type" : "AstFunctionDecl",
         "name" : "IsBackgroundClicked",
@@ -1619,18 +1619,18 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "linkId",
-          "qualType" : "LinkId",
+          "qualType" : "ax::NodeEditor::LinkId",
           "desugaredQualType" : "ax::NodeEditor::LinkId"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "startPinId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "endPinId",
-          "qualType" : "PinId *",
-          "desugaredQualType" : "PinId *"
+          "qualType" : "ax::NodeEditor::PinId *",
+          "desugaredQualType" : "ax::NodeEditor::PinId *"
         } ]
       }, {
         "@type" : "AstFunctionDecl",
@@ -1639,7 +1639,7 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "pinId",
-          "qualType" : "PinId",
+          "qualType" : "ax::NodeEditor::PinId",
           "desugaredQualType" : "ax::NodeEditor::PinId"
         } ]
       }, {
@@ -1677,8 +1677,8 @@
         "decls" : [ {
           "@type" : "AstParmVarDecl",
           "name" : "nodes",
-          "qualType" : "NodeId *",
-          "desugaredQualType" : "NodeId *"
+          "qualType" : "ax::NodeEditor::NodeId *",
+          "desugaredQualType" : "ax::NodeEditor::NodeId *"
         }, {
           "@type" : "AstParmVarDecl",
           "name" : "size",

--- a/buildSrc/src/main/resources/generator/api/ast/ast-imnodes.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-imnodes.json
@@ -1,9 +1,9 @@
 {
   "info" : {
     "source" : "include/imnodes/imnodes.h",
-    "hash" : "652280ae054728987fb8b2201f9a88fa",
+    "hash" : "4ea12e1472e9f121b5084ac0b72237de",
     "url" : "https://github.com/Nelarius/imnodes",
-    "revision" : "e563371cee49eb42da08cca1e0209d30d452c665"
+    "revision" : "8563e1655bd9bb1f249e6552cc6274d506ee788b"
   },
   "decls" : [ {
     "@type" : "AstEnumDecl",
@@ -107,82 +107,88 @@
       "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapBackground",
+      "name" : "ImNodesCol_GridLinePrimary",
       "qualType" : "ImNodesCol_",
       "order" : 16,
       "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapBackgroundHovered",
+      "name" : "ImNodesCol_MiniMapBackground",
       "qualType" : "ImNodesCol_",
       "order" : 17,
       "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapOutline",
+      "name" : "ImNodesCol_MiniMapBackgroundHovered",
       "qualType" : "ImNodesCol_",
       "order" : 18,
       "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapOutlineHovered",
+      "name" : "ImNodesCol_MiniMapOutline",
       "qualType" : "ImNodesCol_",
       "order" : 19,
       "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapNodeBackground",
+      "name" : "ImNodesCol_MiniMapOutlineHovered",
       "qualType" : "ImNodesCol_",
       "order" : 20,
       "evaluatedValue" : 20
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapNodeBackgroundHovered",
+      "name" : "ImNodesCol_MiniMapNodeBackground",
       "qualType" : "ImNodesCol_",
       "order" : 21,
       "evaluatedValue" : 21
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapNodeBackgroundSelected",
+      "name" : "ImNodesCol_MiniMapNodeBackgroundHovered",
       "qualType" : "ImNodesCol_",
       "order" : 22,
       "evaluatedValue" : 22
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapNodeOutline",
+      "name" : "ImNodesCol_MiniMapNodeBackgroundSelected",
       "qualType" : "ImNodesCol_",
       "order" : 23,
       "evaluatedValue" : 23
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapLink",
+      "name" : "ImNodesCol_MiniMapNodeOutline",
       "qualType" : "ImNodesCol_",
       "order" : 24,
       "evaluatedValue" : 24
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapLinkSelected",
+      "name" : "ImNodesCol_MiniMapLink",
       "qualType" : "ImNodesCol_",
       "order" : 25,
       "evaluatedValue" : 25
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapCanvas",
+      "name" : "ImNodesCol_MiniMapLinkSelected",
       "qualType" : "ImNodesCol_",
       "order" : 26,
       "evaluatedValue" : 26
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_MiniMapCanvasOutline",
+      "name" : "ImNodesCol_MiniMapCanvas",
       "qualType" : "ImNodesCol_",
       "order" : 27,
       "evaluatedValue" : 27
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImNodesCol_COUNT",
+      "name" : "ImNodesCol_MiniMapCanvasOutline",
       "qualType" : "ImNodesCol_",
       "order" : 28,
       "evaluatedValue" : 28
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImNodesCol_COUNT",
+      "qualType" : "ImNodesCol_",
+      "order" : 29,
+      "evaluatedValue" : 29
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -309,6 +315,20 @@
       "order" : 2,
       "value" : "1 << 2",
       "evaluatedValue" : 4
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImNodesStyleFlags_GridLinesPrimary",
+      "qualType" : "ImNodesStyleFlags_",
+      "order" : 3,
+      "value" : "1 << 3",
+      "evaluatedValue" : 8
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImNodesStyleFlags_GridSnapping",
+      "qualType" : "ImNodesStyleFlags_",
+      "order" : 4,
+      "value" : "1 << 4",
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -418,6 +438,20 @@
       "qualType" : "struct LinkDetachWithModifierClick",
       "desugaredQualType" : "ImNodesIO::LinkDetachWithModifierClick"
     }, {
+      "@type" : "AstRecordDecl",
+      "name" : "MultipleSelectModifier",
+      "decls" : [ {
+        "@type" : "AstFieldDecl",
+        "name" : "Modifier",
+        "qualType" : "const bool *",
+        "desugaredQualType" : "const bool *"
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MultipleSelectModifier",
+      "qualType" : "struct MultipleSelectModifier",
+      "desugaredQualType" : "ImNodesIO::MultipleSelectModifier"
+    }, {
       "@type" : "AstFieldDecl",
       "name" : "AltMouseButton",
       "qualType" : "int",
@@ -514,8 +548,8 @@
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Colors",
-      "qualType" : "unsigned int[28]",
-      "desugaredQualType" : "unsigned int[28]"
+      "qualType" : "unsigned int[29]",
+      "desugaredQualType" : "unsigned int[29]"
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -683,23 +717,46 @@
       "name" : "StyleColorsDark",
       "resultType" : "void",
       "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dest",
+        "qualType" : "ImNodesStyle *",
+        "desugaredQualType" : "ImNodesStyle *",
+        "defaultValue" : "NULL"
+      }, {
         "@type" : "AstFullComment",
         "decls" : [ {
           "@type" : "AstParagraphComment",
           "decls" : [ {
             "@type" : "AstTextComment",
-            "text" : " Style presets matching the dear imgui styles of the same name."
+            "text" : " Style presets matching the dear imgui styles of the same name. If dest is NULL, the active"
+          }, {
+            "@type" : "AstTextComment",
+            "text" : " context's ImNodesStyle instance will be used as the destination."
           } ]
         } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "StyleColorsClassic",
-      "resultType" : "void"
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dest",
+        "qualType" : "ImNodesStyle *",
+        "desugaredQualType" : "ImNodesStyle *",
+        "defaultValue" : "NULL"
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "StyleColorsLight",
-      "resultType" : "void"
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "dest",
+        "qualType" : "ImNodesStyle *",
+        "desugaredQualType" : "ImNodesStyle *",
+        "defaultValue" : "NULL"
+      } ]
     }, {
       "@type" : "AstFunctionDecl",
       "name" : "BeginNodeEditor",
@@ -1140,6 +1197,25 @@
         "name" : "node_id",
         "qualType" : "const int",
         "desugaredQualType" : "const int"
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SnapNodeToGrid",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "node_id",
+        "qualType" : "int",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " If ImNodesStyleFlags_GridSnapping is enabled, snap the specified node's origin to the grid."
+          } ]
+        } ]
       } ]
     }, {
       "@type" : "AstFunctionDecl",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2000m

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
@@ -179,24 +179,48 @@ public final class ImNodes {
         nStyleColorsDark();
     }
 
+    public static void styleColorsDark(final ImNodesStyle style) {
+        nStyleColorsDark(style.ptr);
+    }
+
     private static native void nStyleColorsDark(); /*
         ImNodes::StyleColorsDark();
+    */
+
+    private static native void nStyleColorsDark(long style); /*
+        ImNodes::StyleColorsDark(reinterpret_cast<ImNodesStyle*>(style));
     */
 
     public static void styleColorsClassic() {
         nStyleColorsClassic();
     }
 
+    public static void styleColorsClassic(final ImNodesStyle style) {
+        nStyleColorsClassic(style.ptr);
+    }
+
     private static native void nStyleColorsClassic(); /*
         ImNodes::StyleColorsClassic();
+    */
+
+    private static native void nStyleColorsClassic(long style); /*
+        ImNodes::StyleColorsClassic(reinterpret_cast<ImNodesStyle*>(style));
     */
 
     public static void styleColorsLight() {
         nStyleColorsLight();
     }
 
+    public static void styleColorsLight(final ImNodesStyle style) {
+        nStyleColorsLight(style.ptr);
+    }
+
     private static native void nStyleColorsLight(); /*
         ImNodes::StyleColorsLight();
+    */
+
+    private static native void nStyleColorsLight(long style); /*
+        ImNodes::StyleColorsLight(reinterpret_cast<ImNodesStyle*>(style));
     */
 
     /**

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
@@ -551,29 +551,106 @@ public final class ImNodes {
         ImVec2 gridPos = ImVec2(gridPosX, gridPosY);
         ImNodes::SetNodeGridSpacePos(nodeId, gridPos);
     */
-
-    public static void getNodeScreenSpacePos(final int nodeId) {
-        nGetNodeScreenSpacePos(nodeId);
+    
+    public static ImVec2 getNodeScreenSpacePos(final int nodeId) {
+        final ImVec2 dst = new ImVec2();
+        nGetNodeScreenSpacePos(dst, nodeId);
+        return dst;
     }
 
-    private static native void nGetNodeScreenSpacePos(int nodeId); /*
-        ImNodes::GetNodeScreenSpacePos(nodeId);
+    public static float getNodeScreenSpacePosX(final int nodeId) {
+        return nGetNodeScreenSpacePosX(nodeId);
+    }
+
+    public static float getNodeScreenSpacePosY(final int nodeId) {
+        return nGetNodeScreenSpacePosY(nodeId);
+    }
+
+    public static void getNodeScreenSpacePos(final ImVec2 dst, final int nodeId) {
+        nGetNodeScreenSpacePos(dst, nodeId);
+    }
+
+    private static native void nGetNodeScreenSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeScreenSpacePos(nodeId), dst);
     */
 
-    public static void getNodeEditorSpacePos(final int nodeId) {
-        nGetNodeEditorSpacePos(nodeId);
-    }
-
-    private static native void nGetNodeEditorSpacePos(int nodeId); /*
-        ImNodes::GetNodeEditorSpacePos(nodeId);
+    private static native float nGetNodeScreenSpacePosX(int nodeId); /*
+        return ImNodes::GetNodeScreenSpacePos(nodeId).x;
     */
 
-    public static void getNodeGridSpacePos(final int nodeId) {
-        nGetNodeGridSpacePos(nodeId);
+    private static native float nGetNodeScreenSpacePosY(int nodeId); /*
+        return ImNodes::GetNodeScreenSpacePos(nodeId).y;
+    */
+
+    public static ImVec2 getNodeEditorSpacePos(final int nodeId) {
+        final ImVec2 dst = new ImVec2();
+        nGetNodeEditorSpacePos(dst, nodeId);
+        return dst;
     }
 
-    private static native void nGetNodeGridSpacePos(int nodeId); /*
-        ImNodes::GetNodeGridSpacePos(nodeId);
+    public static float getNodeEditorSpacePosX(final int nodeId) {
+        return nGetNodeEditorSpacePosX(nodeId);
+    }
+
+    public static float getNodeEditorSpacePosY(final int nodeId) {
+        return nGetNodeEditorSpacePosY(nodeId);
+    }
+
+    public static void getNodeEditorSpacePos(final ImVec2 dst, final int nodeId) {
+        nGetNodeEditorSpacePos(dst, nodeId);
+    }
+
+    private static native void nGetNodeEditorSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeEditorSpacePos(nodeId), dst);
+    */
+
+    private static native float nGetNodeEditorSpacePosX(int nodeId); /*
+        return ImNodes::GetNodeEditorSpacePos(nodeId).x;
+    */
+
+    private static native float nGetNodeEditorSpacePosY(int nodeId); /*
+        return ImNodes::GetNodeEditorSpacePos(nodeId).y;
+    */
+
+    public static ImVec2 getNodeGridSpacePos(final int nodeId) {
+        final ImVec2 dst = new ImVec2();
+        nGetNodeGridSpacePos(dst, nodeId);
+        return dst;
+    }
+
+    public static float getNodeGridSpacePosX(final int nodeId) {
+        return nGetNodeGridSpacePosX(nodeId);
+    }
+
+    public static float getNodeGridSpacePosY(final int nodeId) {
+        return nGetNodeGridSpacePosY(nodeId);
+    }
+
+    public static void getNodeGridSpacePos(final ImVec2 dst, final int nodeId) {
+        nGetNodeGridSpacePos(dst, nodeId);
+    }
+
+    private static native void nGetNodeGridSpacePos(ImVec2 dst, int nodeId); /*
+        Jni::ImVec2Cpy(env, ImNodes::GetNodeGridSpacePos(nodeId), dst);
+    */
+
+    private static native float nGetNodeGridSpacePosX(int nodeId); /*
+        return ImNodes::GetNodeGridSpacePos(nodeId).x;
+    */
+
+    private static native float nGetNodeGridSpacePosY(int nodeId); /*
+        return ImNodes::GetNodeGridSpacePos(nodeId).y;
+    */
+
+    /**
+     * Enable or disable grid snapping.
+     */
+    public static void snapNodeToGrid(final int nodeId) {
+        nSnapNodeToGrid(nodeId);
+    }
+
+    private static native void nSnapNodeToGrid(int nodeId); /*
+        ImNodes::SnapNodeToGrid(nodeId);
     */
 
     /**

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesCol.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesCol.java
@@ -40,29 +40,31 @@ public final class ImNodesCol {
 
     public static final int GridLine = 15;
 
-    public static final int MiniMapBackground = 16;
+    public static final int GridLinePrimary = 16;
 
-    public static final int MiniMapBackgroundHovered = 17;
+    public static final int MiniMapBackground = 17;
 
-    public static final int MiniMapOutline = 18;
+    public static final int MiniMapBackgroundHovered = 18;
 
-    public static final int MiniMapOutlineHovered = 19;
+    public static final int MiniMapOutline = 19;
 
-    public static final int MiniMapNodeBackground = 20;
+    public static final int MiniMapOutlineHovered = 20;
 
-    public static final int MiniMapNodeBackgroundHovered = 21;
+    public static final int MiniMapNodeBackground = 21;
 
-    public static final int MiniMapNodeBackgroundSelected = 22;
+    public static final int MiniMapNodeBackgroundHovered = 22;
 
-    public static final int MiniMapNodeOutline = 23;
+    public static final int MiniMapNodeBackgroundSelected = 23;
 
-    public static final int MiniMapLink = 24;
+    public static final int MiniMapNodeOutline = 24;
 
-    public static final int MiniMapLinkSelected = 25;
+    public static final int MiniMapLink = 25;
 
-    public static final int MiniMapCanvas = 26;
+    public static final int MiniMapLinkSelected = 26;
 
-    public static final int MiniMapCanvasOutline = 27;
+    public static final int MiniMapCanvas = 27;
 
-    public static final int COUNT = 28;
+    public static final int MiniMapCanvasOutline = 28;
+
+    public static final int COUNT = 29;
 }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleFlags.java
@@ -19,4 +19,14 @@ public final class ImNodesStyleFlags {
      * Definition: {@code 1 << 2}
      */
     public static final int GridLines = 4;
+
+    /**
+     * Definition: {@code 1 << 3}
+     */
+    public static final int GridLinesPrimary = 8;
+
+    /**
+     * Definition: {@code 1 << 4}
+     */
+    public static final int GridSnapping = 16;
 }

--- a/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
@@ -220,15 +220,21 @@ public final class ImNodes {
 
     @BindingMethod
     public static native void SetNodeGridSpacePos(int nodeId, ImVec2 gridPos);
+    
+    @BindingMethod
+    public static native ImVec2 GetNodeScreenSpacePos(int nodeId);
 
     @BindingMethod
-    public static native void GetNodeScreenSpacePos(int nodeId);
+    public static native ImVec2 GetNodeEditorSpacePos(int nodeId);
 
     @BindingMethod
-    public static native void GetNodeEditorSpacePos(int nodeId);
+    public static native ImVec2 GetNodeGridSpacePos(int nodeId);
 
+    /**
+     * Enable or disable grid snapping.
+     */
     @BindingMethod
-    public static native void GetNodeGridSpacePos(int nodeId);
+    public static native void SnapNodeToGrid(int nodeId);
 
     /**
      * Returns true if the current node editor canvas is being hovered over by the mouse, and is not

--- a/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/main/java/imgui/extension/imnodes/ImNodes.java
@@ -78,13 +78,13 @@ public final class ImNodes {
     // Style presets matching the dear imgui styles of the same name.
 
     @BindingMethod
-    public static native void StyleColorsDark();
+    public static native void StyleColorsDark(@OptArg ImNodesStyle style);
 
     @BindingMethod
-    public static native void StyleColorsClassic();
+    public static native void StyleColorsClassic(@OptArg ImNodesStyle style);
 
     @BindingMethod
-    public static native void StyleColorsLight();
+    public static native void StyleColorsLight(@OptArg ImNodesStyle style);
 
     /**
      * The top-level function call. Call this before calling BeginNode/EndNode. Calling this function


### PR DESCRIPTION
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->

Pulls latest commit of imnodes which includes new function SnapNodeToGrid, generates ast & api, fixes getNode___SpacePos functions to actually return ImVec2

(_sigh_... finally got this right using WSL)

## Type of change

<!-- 
Please check options that are relevant.
-->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
