### PR TITLE
Make ImVec2/ImVec4 math operations immutable

### DIFF
--- a/imgui-binding/src/generated/java/imgui/ImVec2.java
+++ b/imgui-binding/src/generated/java/imgui/ImVec2.java
@@ -31,9 +31,7 @@ public final class ImVec2 implements Cloneable {
     }
 
     public ImVec2 plus(final float x, final float y) {
-        this.x += x;
-        this.y += y;
-        return this;
+        return new ImVec2(this.x + x, this.y + y);
     }
 
     public ImVec2 plus(final ImVec2 value) {
@@ -41,9 +39,7 @@ public final class ImVec2 implements Cloneable {
     }
 
     public ImVec2 minus(final float x, final float y) {
-        this.x -= x;
-        this.y -= y;
-        return this;
+        return new ImVec2(this.x - x, this.y -y);
     }
 
     public ImVec2 minus(final ImVec2 value) {
@@ -51,13 +47,19 @@ public final class ImVec2 implements Cloneable {
     }
 
     public ImVec2 times(final float x, final float y) {
-        this.x *= x;
-        this.y *= y;
-        return this;
+        return new ImVec2(this.x * x, this.y * y);
     }
 
     public ImVec2 times(final ImVec2 value) {
         return times(value.x, value.y);
+    }
+
+    public ImVec2 div(final float x, final float y) {
+        return new ImVec2(this.x / x, this.y / y);
+    }
+
+    public ImVec2 div(final ImVec2 value) {
+        return div(value.x, value.y);
     }
 
     @Override

--- a/imgui-binding/src/generated/java/imgui/ImVec4.java
+++ b/imgui-binding/src/generated/java/imgui/ImVec4.java
@@ -35,11 +35,7 @@ public final class ImVec4 implements Cloneable {
     }
 
     public ImVec4 plus(final float x, final float y, final float z, final float w) {
-        this.x += x;
-        this.y += y;
-        this.z += z;
-        this.w += w;
-        return this;
+        return new ImVec4(this.x + x, this.y + y, this.z + z, this.w + w);
     }
 
     public ImVec4 plus(final ImVec4 value) {
@@ -47,11 +43,7 @@ public final class ImVec4 implements Cloneable {
     }
 
     public ImVec4 minus(final float x, final float y, final float z, final float w) {
-        this.x -= x;
-        this.y -= y;
-        this.z -= z;
-        this.w -= w;
-        return this;
+        return new ImVec4(this.x - x, this.y - y, this.z - z, this.w - w);
     }
 
     public ImVec4 minus(final ImVec4 value) {
@@ -59,15 +51,19 @@ public final class ImVec4 implements Cloneable {
     }
 
     public ImVec4 times(final float x, final float y, final float z, final float w) {
-        this.x *= x;
-        this.y *= y;
-        this.z *= z;
-        this.w *= w;
-        return this;
+        return new ImVec4(this.x * x, this.y * y, this.z * z, this.w * w);
     }
 
     public ImVec4 times(final ImVec4 value) {
         return times(value.x, value.y, value.z, value.w);
+    }
+
+    public ImVec4 div(final float x, final float y, final float z, final float w) {
+        return new ImVec4(this.x / x, this.y / y, this.z / z, this.w / w);
+    }
+
+    public ImVec4 div(final ImVec4 value) {
+        return div(value.x, value.y, value.z, value.w);
     }
 
     @Override

--- a/imgui-binding/src/main/java/imgui/ImVec2.java
+++ b/imgui-binding/src/main/java/imgui/ImVec2.java
@@ -31,9 +31,7 @@ public final class ImVec2 implements Cloneable {
     }
 
     public ImVec2 plus(final float x, final float y) {
-        this.x += x;
-        this.y += y;
-        return this;
+        return new ImVec2(this.x + x, this.y + y);
     }
 
     public ImVec2 plus(final ImVec2 value) {
@@ -41,9 +39,7 @@ public final class ImVec2 implements Cloneable {
     }
 
     public ImVec2 minus(final float x, final float y) {
-        this.x -= x;
-        this.y -= y;
-        return this;
+        return new ImVec2(this.x - x, this.y -y);
     }
 
     public ImVec2 minus(final ImVec2 value) {
@@ -51,13 +47,19 @@ public final class ImVec2 implements Cloneable {
     }
 
     public ImVec2 times(final float x, final float y) {
-        this.x *= x;
-        this.y *= y;
-        return this;
+        return new ImVec2(this.x * x, this.y * y);
     }
 
     public ImVec2 times(final ImVec2 value) {
         return times(value.x, value.y);
+    }
+
+    public ImVec2 div(final float x, final float y) {
+        return new ImVec2(this.x / x, this.y / y);
+    }
+
+    public ImVec2 div(final ImVec2 value) {
+        return div(value.x, value.y);
     }
 
     @Override

--- a/imgui-binding/src/main/java/imgui/ImVec4.java
+++ b/imgui-binding/src/main/java/imgui/ImVec4.java
@@ -35,11 +35,7 @@ public final class ImVec4 implements Cloneable {
     }
 
     public ImVec4 plus(final float x, final float y, final float z, final float w) {
-        this.x += x;
-        this.y += y;
-        this.z += z;
-        this.w += w;
-        return this;
+        return new ImVec4(this.x + x, this.y + y, this.z + z, this.w + w);
     }
 
     public ImVec4 plus(final ImVec4 value) {
@@ -47,11 +43,7 @@ public final class ImVec4 implements Cloneable {
     }
 
     public ImVec4 minus(final float x, final float y, final float z, final float w) {
-        this.x -= x;
-        this.y -= y;
-        this.z -= z;
-        this.w -= w;
-        return this;
+        return new ImVec4(this.x - x, this.y - y, this.z - z, this.w - w);
     }
 
     public ImVec4 minus(final ImVec4 value) {
@@ -59,15 +51,19 @@ public final class ImVec4 implements Cloneable {
     }
 
     public ImVec4 times(final float x, final float y, final float z, final float w) {
-        this.x *= x;
-        this.y *= y;
-        this.z *= z;
-        this.w *= w;
-        return this;
+        return new ImVec4(this.x * x, this.y * y, this.z * z, this.w * w);
     }
 
     public ImVec4 times(final ImVec4 value) {
         return times(value.x, value.y, value.z, value.w);
+    }
+
+    public ImVec4 div(final float x, final float y, final float z, final float w) {
+        return new ImVec4(this.x / x, this.y / y, this.z / z, this.w / w);
+    }
+
+    public ImVec4 div(final ImVec4 value) {
+        return div(value.x, value.y, value.z, value.w);
     }
 
     @Override

--- a/imgui-binding/src/test/java/imgui/ImVec2Test.java
+++ b/imgui-binding/src/test/java/imgui/ImVec2Test.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class ImVec2Test {
     @Nested
@@ -34,16 +36,20 @@ class ImVec2Test {
     class set {
         @Test
         void withFloats() {
-            final ImVec2 value = new ImVec2().set(1, 2);
+            final ImVec2 original = new ImVec2();
+            final ImVec2 value = original.set(1, 2);
             assertEquals(1, value.x);
             assertEquals(2, value.y);
+            assertSame(original, value);
         }
 
         @Test
         void withImVec2() {
-            final ImVec2 value = new ImVec2().set(new ImVec2(1, 2));
+            final ImVec2 original = new ImVec2();
+            final ImVec2 value = original.set(new ImVec2(1, 2));
             assertEquals(1, value.x);
             assertEquals(2, value.y);
+            assertSame(original, value);
         }
     }
 
@@ -51,16 +57,20 @@ class ImVec2Test {
     class plus {
         @Test
         void withFloats() {
-            final ImVec2 value = new ImVec2(5, 5).plus(1, 2);
+            final ImVec2 original = new ImVec2(5, 5);
+            final ImVec2 value = original.plus(1, 2);
             assertEquals(6, value.x);
             assertEquals(7, value.y);
+            assertNotSame(original, value);
         }
 
         @Test
         void withImVec2() {
-            final ImVec2 value = new ImVec2(5, 5).plus(new ImVec2(1, 2));
+            final ImVec2 original = new ImVec2(5, 5);
+            final ImVec2 value = original.plus(new ImVec2(1, 2));
             assertEquals(6, value.x);
             assertEquals(7, value.y);
+            assertNotSame(original, value);
         }
     }
 
@@ -68,16 +78,20 @@ class ImVec2Test {
     class minus {
         @Test
         void withFloats() {
-            final ImVec2 value = new ImVec2(5, 5).minus(1, 2);
+            final ImVec2 original = new ImVec2(5, 5);
+            final ImVec2 value = original.minus(1, 2);
             assertEquals(4, value.x);
             assertEquals(3, value.y);
+            assertNotSame(original, value);
         }
 
         @Test
         void withImVec2() {
-            final ImVec2 value = new ImVec2(5, 5).minus(new ImVec2(1, 2));
+            final ImVec2 original = new ImVec2(5, 5);
+            final ImVec2 value = original.minus(new ImVec2(1, 2));
             assertEquals(4, value.x);
             assertEquals(3, value.y);
+            assertNotSame(original, value);
         }
     }
 
@@ -85,16 +99,41 @@ class ImVec2Test {
     class times {
         @Test
         void withFloats() {
-            final ImVec2 value = new ImVec2(5, 5).times(1, 2);
+            final ImVec2 original = new ImVec2(5, 5);
+            final ImVec2 value = original.times(1, 2);
             assertEquals(5, value.x);
             assertEquals(10, value.y);
+            assertNotSame(original, value);
         }
 
         @Test
         void withImVec2() {
-            final ImVec2 value = new ImVec2(5, 5).times(new ImVec2(1, 2));
+            final ImVec2 original = new ImVec2(5, 5);
+            final ImVec2 value = original.times(new ImVec2(1, 2));
             assertEquals(5, value.x);
             assertEquals(10, value.y);
+            assertNotSame(original, value);
+        }
+    }
+
+    @Nested
+    class div {
+        @Test
+        void withFloats() {
+            final ImVec2 original = new ImVec2(10, 10);
+            final ImVec2 value = original.div(5, 2);
+            assertEquals(2, value.x);
+            assertEquals(5, value.y);
+            assertNotSame(original, value);
+        }
+
+        @Test
+        void withImVec2() {
+            final ImVec2 original = new ImVec2(10, 10);
+            final ImVec2 value = original.div(new ImVec2(5, 2));
+            assertEquals(2, value.x);
+            assertEquals(5, value.y);
+            assertNotSame(original, value);
         }
     }
 }

--- a/imgui-binding/src/test/java/imgui/ImVec4Test.java
+++ b/imgui-binding/src/test/java/imgui/ImVec4Test.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class ImVec4Test {
     @Nested
@@ -27,7 +29,7 @@ class ImVec4Test {
         }
 
         @Test
-        void fromImVec2() {
+        void fromImVec4() {
             final ImVec4 value = new ImVec4(new ImVec4(1, 2, 3, 4));
             assertEquals(1, value.x);
             assertEquals(2, value.y);
@@ -40,20 +42,24 @@ class ImVec4Test {
     class set {
         @Test
         void withFloats() {
-            final ImVec4 value = new ImVec4().set(1, 2, 3, 4);
+            final ImVec4 original = new ImVec4(1, 2, 3, 4);
+            final ImVec4 value = original.set(1, 2, 3, 4);
             assertEquals(1, value.x);
             assertEquals(2, value.y);
             assertEquals(3, value.z);
             assertEquals(4, value.w);
+            assertSame(original, value);
         }
 
         @Test
         void withImVec4() {
-            final ImVec4 value = new ImVec4().set(new ImVec4(1, 2, 3, 4));
+            final ImVec4 original = new ImVec4(1, 2, 3, 4);
+            final ImVec4 value = original.set(new ImVec4(1, 2, 3, 4));
             assertEquals(1, value.x);
             assertEquals(2, value.y);
             assertEquals(3, value.z);
             assertEquals(4, value.w);
+            assertSame(original, value);
         }
     }
 
@@ -61,16 +67,24 @@ class ImVec4Test {
     class plus {
         @Test
         void withFloats() {
-            final ImVec4 value = new ImVec4(5, 5, 5, 5).plus(1, 2, 3, 4);
+            final ImVec4 original = new ImVec4(5, 5, 5, 5);
+            final ImVec4 value = original.plus(1, 2, 3, 4);
             assertEquals(6, value.x);
             assertEquals(7, value.y);
+            assertEquals(8, value.z);
+            assertEquals(9, value.w);
+            assertNotSame(original, value);
         }
 
         @Test
         void withImVec4() {
-            final ImVec4 value = new ImVec4(5, 5, 5, 5).plus(new ImVec4(1, 2, 3, 4));
+            final ImVec4 original = new ImVec4(5, 5, 5, 5);
+            final ImVec4 value = original.plus(new ImVec4(1, 2, 3, 4));
             assertEquals(6, value.x);
             assertEquals(7, value.y);
+            assertEquals(8, value.z);
+            assertEquals(9, value.w);
+            assertNotSame(original, value);
         }
     }
 
@@ -78,20 +92,24 @@ class ImVec4Test {
     class minus {
         @Test
         void withFloats() {
-            final ImVec4 value = new ImVec4(5, 5, 5, 5).minus(1, 2, 3, 4);
+            final ImVec4 original = new ImVec4(5, 5, 5, 5);
+            final ImVec4 value = original.minus(1, 2, 3, 4);
             assertEquals(4, value.x);
             assertEquals(3, value.y);
             assertEquals(2, value.z);
             assertEquals(1, value.w);
+            assertNotSame(original, value);
         }
 
         @Test
         void withImVec4() {
-            final ImVec4 value = new ImVec4(5, 5, 5, 5).minus(new ImVec4(1, 2, 3, 4));
+            final ImVec4 original = new ImVec4(5, 5, 5, 5);
+            final ImVec4 value = original.minus(new ImVec4(1, 2, 3, 4));
             assertEquals(4, value.x);
             assertEquals(3, value.y);
             assertEquals(2, value.z);
             assertEquals(1, value.w);
+            assertNotSame(original, value);
         }
     }
 
@@ -99,20 +117,49 @@ class ImVec4Test {
     class times {
         @Test
         void withFloats() {
-            final ImVec4 value = new ImVec4(5, 5, 5, 5).times(1, 2, 3, 4);
+            final ImVec4 original = new ImVec4(5, 5, 5, 5);
+            final ImVec4 value = original.times(1, 2, 3, 4);
             assertEquals(5, value.x);
             assertEquals(10, value.y);
             assertEquals(15, value.z);
             assertEquals(20, value.w);
+            assertNotSame(original, value);
         }
 
         @Test
         void withImVec4() {
-            final ImVec4 value = new ImVec4(5, 5, 5, 5).times(new ImVec4(1, 2, 3, 4));
+            final ImVec4 original = new ImVec4(5, 5, 5, 5);
+            final ImVec4 value = original.times(new ImVec4(1, 2, 3, 4));
             assertEquals(5, value.x);
             assertEquals(10, value.y);
             assertEquals(15, value.z);
             assertEquals(20, value.w);
+            assertNotSame(original, value);
+        }
+    }
+
+    @Nested
+    class div {
+        @Test
+        void withFloats() {
+            final ImVec4 original = new ImVec4(10, 10, 15, 15);
+            final ImVec4 value = original.div(5, 2, 3, 5);
+            assertEquals(2, value.x);
+            assertEquals(5, value.y);
+            assertEquals(5, value.z);
+            assertEquals(3, value.w);
+            assertNotSame(original, value);
+        }
+
+        @Test
+        void withImVec4() {
+            final ImVec4 original = new ImVec4(10, 10, 15, 15);
+            final ImVec4 value = original.div(new ImVec4(5, 2, 3, 5));
+            assertEquals(2, value.x);
+            assertEquals(5, value.y);
+            assertEquals(5, value.z);
+            assertEquals(3, value.w);
+            assertNotSame(original, value);
         }
     }
 }


### PR DESCRIPTION
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->

Updated math operations (`plus`, `minus`, `times`, `div`) for `ImVec2` and `ImVec4` to return new instances instead of modifying the existing ones, ensuring immutability.

## Type of change

<!-- 
Please check options that are relevant.
-->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
