### PR TITLE
feat(api): bump ImPlot to v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,13 +316,13 @@ If using Java 9 modules, ImGui Java has Automatic Module Names:
 All extensions are already included in the binding and can be used as it is.
 See examples in the `example` module for more information about how to use them.
 
-- [ImNodes](https://github.com/Nelarius/imnodes/tree/b2ec254ce576ac3d42dfb7aef61deadbff8e7211) | [Example](https://github.com/SpaiR/imgui-java/blob/main/example/src/main/java/ExampleImNodes.java) <br>
+- [ImNodes](https://github.com/Nelarius/imnodes/tree/857cc860af05ac0f6a4039c2af33d982377b6cf4) | [Example](https://github.com/SpaiR/imgui-java/blob/main/example/src/main/java/ExampleImNodes.java) <br>
   A small, dependency-free node editor for Dear ImGui. (A good choice for simple start.)
-- [imgui-node-editor](https://github.com/thedmd/imgui-node-editor/tree/021aa0ea4da13fed864bafb2a92d4c5205076866) | [Example](https://github.com/SpaiR/imgui-java/blob/main/example/src/main/java/ExampleImGuiNodeEditor.java) <br>
+- [imgui-node-editor](https://github.com/thedmd/imgui-node-editor/tree/687a72f940c76cf5064e13fe55fa0408c18fcbe4) | [Example](https://github.com/SpaiR/imgui-java/blob/main/example/src/main/java/ExampleImGuiNodeEditor.java) <br>
   Node Editor using ImGui. (A bit more complex than ImNodes, but has more features.)
 - [ImGuizmo](https://github.com/CedricGuillemet/ImGuizmo/tree/f7bbbe39971d9d45816417a70e9b53a0f698c56e) | [Example](https://github.com/SpaiR/imgui-java/blob/main/example/src/main/java/ExampleImGuizmo.java) <br>
   Immediate mode 3D gizmo for scene editing and other controls based on Dear ImGui.
-- [implot](https://github.com/epezent/implot/tree/v0.17) | [Example](https://github.com/SpaiR/imgui-java/blob/main/example/src/main/java/ExampleImPlot.java) <br>
+- [implot](https://github.com/epezent/implot/tree/v1.0) | [Example](https://github.com/SpaiR/imgui-java/blob/main/example/src/main/java/ExampleImPlot.java) <br>
   Advanced 2D Plotting for Dear ImGui.  
 - [ImGuiColorTextEdit](https://github.com/BalazsJako/ImGuiColorTextEdit/tree/0a88824f7de8d0bd11d8419066caa7d3469395c4) | [Example](https://github.com/SpaiR/imgui-java/blob/main/example/src/main/java/ExampleImGuiColorTextEdit.java) <br>
   Syntax highlighting text editor for ImGui.

--- a/buildSrc/src/main/resources/generator/api/ast/ast-implot.json
+++ b/buildSrc/src/main/resources/generator/api/ast/ast-implot.json
@@ -1,9 +1,9 @@
 {
   "info" : {
     "source" : "include/implot/implot.h",
-    "hash" : "12fbbac559018475f060bca386b45ed6",
+    "hash" : "a15908f407436d673c4272d3ce3d74c8",
     "url" : "https://github.com/epezent/implot.git",
-    "revision" : "4707b245fbcd69075b1a8a74fa8d2435561b3134"
+    "revision" : "524f9fcd48d76c13fdf94c5ffbba8787a1ff7e39"
   },
   "decls" : [ {
     "@type" : "AstRecordDecl",
@@ -80,6 +80,138 @@
       "qualType" : "ImAxis_",
       "order" : 6,
       "evaluatedValue" : 6
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImPlotProp_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Plotting properties. These provide syntactic sugar for creating ImPlotSpecs from (ImPlotProp,value) pairs. See ImPlotSpec documentation."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_LineColor",
+      "docComment" : "line color (applies to lines, bar edges); IMPLOT_AUTO_COL will use next Colormap color or current item color",
+      "qualType" : "ImPlotProp_",
+      "order" : 0,
+      "evaluatedValue" : 0
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_LineColors",
+      "docComment" : "array of colors for each line; if nullptr, use LineColor for all lines",
+      "qualType" : "ImPlotProp_",
+      "order" : 1,
+      "evaluatedValue" : 1
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_LineWeight",
+      "docComment" : "line weight in pixels (applies to lines, bar edges, marker edges)",
+      "qualType" : "ImPlotProp_",
+      "order" : 2,
+      "evaluatedValue" : 2
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_FillColor",
+      "docComment" : "fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color",
+      "qualType" : "ImPlotProp_",
+      "order" : 3,
+      "evaluatedValue" : 3
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_FillColors",
+      "docComment" : "array of colors for each fill; if nullptr, use FillColor for all fills",
+      "qualType" : "ImPlotProp_",
+      "order" : 4,
+      "evaluatedValue" : 4
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_FillAlpha",
+      "docComment" : "alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)",
+      "qualType" : "ImPlotProp_",
+      "order" : 5,
+      "evaluatedValue" : 5
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_Marker",
+      "docComment" : "marker type; specify ImPlotMarker_Auto to use the next unused marker",
+      "qualType" : "ImPlotProp_",
+      "order" : 6,
+      "evaluatedValue" : 6
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_MarkerSize",
+      "docComment" : "size of markers (radius) *in pixels*",
+      "qualType" : "ImPlotProp_",
+      "order" : 7,
+      "evaluatedValue" : 7
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_MarkerSizes",
+      "docComment" : "array of sizes for each marker; if nullptr, use MarkerSize for all markers",
+      "qualType" : "ImPlotProp_",
+      "order" : 8,
+      "evaluatedValue" : 8
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_MarkerLineColor",
+      "docComment" : "marker edge color; IMPLOT_AUTO_COL will use LineColor",
+      "qualType" : "ImPlotProp_",
+      "order" : 9,
+      "evaluatedValue" : 9
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_MarkerLineColors",
+      "docComment" : "array of colors for each marker edge; if nullptr, use MarkerLineColor for all markers",
+      "qualType" : "ImPlotProp_",
+      "order" : 10,
+      "evaluatedValue" : 10
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_MarkerFillColor",
+      "docComment" : "marker face color; IMPLOT_AUTO_COL will use LineColor",
+      "qualType" : "ImPlotProp_",
+      "order" : 11,
+      "evaluatedValue" : 11
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_MarkerFillColors",
+      "docComment" : "array of colors for each marker face; if nullptr, use MarkerFillColor for all markers",
+      "qualType" : "ImPlotProp_",
+      "order" : 12,
+      "evaluatedValue" : 12
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_Size",
+      "docComment" : "size of error bar whiskers (width or height), and digital bars (height) *in pixels*",
+      "qualType" : "ImPlotProp_",
+      "order" : 13,
+      "evaluatedValue" : 13
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_Offset",
+      "docComment" : "data index offset",
+      "qualType" : "ImPlotProp_",
+      "order" : 14,
+      "evaluatedValue" : 14
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_Stride",
+      "docComment" : "data stride in bytes; IMPLOT_AUTO will result in sizeof(T) where T is the type passed to PlotX",
+      "qualType" : "ImPlotProp_",
+      "order" : 15,
+      "evaluatedValue" : 15
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotProp_Flags",
+      "docComment" : "optional item flags; can be composed from common ImPlotItemFlags and/or specialized ImPlotXFlags",
+      "qualType" : "ImPlotProp_",
+      "order" : 16,
+      "evaluatedValue" : 16
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -697,7 +829,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for ANY PlotX function"
+          "text" : " Flags for ANY PlotX function. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -733,7 +865,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotLine"
+          "text" : " Flags for PlotLine. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -794,7 +926,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotScatter"
+          "text" : " Flags for PlotScatter. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -816,6 +948,56 @@
     } ]
   }, {
     "@type" : "AstEnumDecl",
+    "name" : "ImPlotBubblesFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for PlotBubbles. Used by setting ImPlotSpec::Flags."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotBubblesFlags_None",
+      "docComment" : "default",
+      "qualType" : "ImPlotBubblesFlags_",
+      "order" : 0,
+      "value" : "0",
+      "evaluatedValue" : 0
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
+    "name" : "ImPlotPolygonFlags_",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Flags for PlotPolygon. Used by setting ImPlotSpec::Flags."
+        } ]
+      } ]
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotPolygonFlags_None",
+      "docComment" : "default (closed, convex polygon)",
+      "qualType" : "ImPlotPolygonFlags_",
+      "order" : 0,
+      "value" : "0",
+      "evaluatedValue" : 0
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotPolygonFlags_Concave",
+      "docComment" : "use concave polygon filling (slower but supports concave shapes)",
+      "qualType" : "ImPlotPolygonFlags_",
+      "order" : 1,
+      "value" : "1 << 10",
+      "evaluatedValue" : 1024
+    } ]
+  }, {
+    "@type" : "AstEnumDecl",
     "name" : "ImPlotStairsFlags_",
     "decls" : [ {
       "@type" : "AstFullComment",
@@ -823,7 +1005,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotStairs"
+          "text" : " Flags for PlotStairs. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -860,7 +1042,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotShaded (placeholder)"
+          "text" : " Flags for PlotShaded (placeholder). Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -881,7 +1063,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotBars"
+          "text" : " Flags for PlotBars. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -910,7 +1092,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotBarGroups"
+          "text" : " Flags for PlotBarGroups. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -947,7 +1129,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotErrorBars"
+          "text" : " Flags for PlotErrorBars. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -976,7 +1158,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotStems"
+          "text" : " Flags for PlotStems. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1005,7 +1187,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotInfLines"
+          "text" : " Flags for PlotInfLines. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1034,7 +1216,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotPieChart"
+          "text" : " Flags for PlotPieChart. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1064,11 +1246,19 @@
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotPieChartFlags_Exploding",
-      "docComment" : "Explode legend-hovered slice",
+      "docComment" : "explode legend-hovered slice",
       "qualType" : "ImPlotPieChartFlags_",
       "order" : 3,
       "value" : "1 << 12",
       "evaluatedValue" : 4096
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotPieChartFlags_NoSliceBorder",
+      "docComment" : "do not draw slice borders",
+      "qualType" : "ImPlotPieChartFlags_",
+      "order" : 4,
+      "value" : "1 << 13",
+      "evaluatedValue" : 8192
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1079,7 +1269,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotHeatmap"
+          "text" : " Flags for PlotHeatmap. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1108,7 +1298,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotHistogram and PlotHistogram2D"
+          "text" : " Flags for PlotHistogram and PlotHistogram2D. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1169,7 +1359,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotDigital (placeholder)"
+          "text" : " Flags for PlotDigital (placeholder). Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1190,7 +1380,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotImage (placeholder)"
+          "text" : " Flags for PlotImage (placeholder). Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1211,7 +1401,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotText"
+          "text" : " Flags for PlotText. Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1240,7 +1430,7 @@
         "@type" : "AstParagraphComment",
         "decls" : [ {
           "@type" : "AstTextComment",
-          "text" : " Flags for PlotDummy (placeholder)"
+          "text" : " Flags for PlotDummy (placeholder). Used by setting ImPlotSpec::Flags."
         } ]
       } ]
     }, {
@@ -1300,157 +1490,122 @@
       } ]
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_Line",
-      "docComment" : "plot line/outline color (defaults to next unused color in current colormap)",
+      "name" : "ImPlotCol_FrameBg",
+      "docComment" : "plot frame background color (defaults to ImGuiCol_FrameBg)",
       "qualType" : "ImPlotCol_",
       "order" : 0,
       "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_Fill",
-      "docComment" : "plot fill color for bars (defaults to the current line color)",
+      "name" : "ImPlotCol_PlotBg",
+      "docComment" : "plot area background color (defaults to ImGuiCol_WindowBg)",
       "qualType" : "ImPlotCol_",
       "order" : 1,
       "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_MarkerOutline",
-      "docComment" : "marker outline color (defaults to the current line color)",
+      "name" : "ImPlotCol_PlotBorder",
+      "docComment" : "plot area border color (defaults to ImGuiCol_Border)",
       "qualType" : "ImPlotCol_",
       "order" : 2,
       "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_MarkerFill",
-      "docComment" : "marker fill color (defaults to the current line color)",
+      "name" : "ImPlotCol_LegendBg",
+      "docComment" : "legend background color (defaults to ImGuiCol_PopupBg)",
       "qualType" : "ImPlotCol_",
       "order" : 3,
       "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_ErrorBar",
-      "docComment" : "error bar color (defaults to ImGuiCol_Text)",
+      "name" : "ImPlotCol_LegendBorder",
+      "docComment" : "legend border color (defaults to ImPlotCol_PlotBorder)",
       "qualType" : "ImPlotCol_",
       "order" : 4,
       "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_FrameBg",
-      "docComment" : "plot frame background color (defaults to ImGuiCol_FrameBg)",
+      "name" : "ImPlotCol_LegendText",
+      "docComment" : "legend text color (defaults to ImPlotCol_InlayText)",
       "qualType" : "ImPlotCol_",
       "order" : 5,
       "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_PlotBg",
-      "docComment" : "plot area background color (defaults to ImGuiCol_WindowBg)",
+      "name" : "ImPlotCol_TitleText",
+      "docComment" : "plot title text color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 6,
       "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_PlotBorder",
-      "docComment" : "plot area border color (defaults to ImGuiCol_Border)",
+      "name" : "ImPlotCol_InlayText",
+      "docComment" : "color of text appearing inside of plots (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 7,
       "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_LegendBg",
-      "docComment" : "legend background color (defaults to ImGuiCol_PopupBg)",
+      "name" : "ImPlotCol_AxisText",
+      "docComment" : "axis label and tick labels color (defaults to ImGuiCol_Text)",
       "qualType" : "ImPlotCol_",
       "order" : 8,
       "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_LegendBorder",
-      "docComment" : "legend border color (defaults to ImPlotCol_PlotBorder)",
+      "name" : "ImPlotCol_AxisGrid",
+      "docComment" : "axis grid color (defaults to 25% ImPlotCol_AxisText)",
       "qualType" : "ImPlotCol_",
       "order" : 9,
       "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_LegendText",
-      "docComment" : "legend text color (defaults to ImPlotCol_InlayText)",
+      "name" : "ImPlotCol_AxisTick",
+      "docComment" : "axis tick color (defaults to AxisGrid)",
       "qualType" : "ImPlotCol_",
       "order" : 10,
       "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_TitleText",
-      "docComment" : "plot title text color (defaults to ImGuiCol_Text)",
+      "name" : "ImPlotCol_AxisBg",
+      "docComment" : "background color of axis hover region (defaults to transparent)",
       "qualType" : "ImPlotCol_",
       "order" : 11,
       "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_InlayText",
-      "docComment" : "color of text appearing inside of plots (defaults to ImGuiCol_Text)",
+      "name" : "ImPlotCol_AxisBgHovered",
+      "docComment" : "axis hover color (defaults to ImGuiCol_ButtonHovered)",
       "qualType" : "ImPlotCol_",
       "order" : 12,
       "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_AxisText",
-      "docComment" : "axis label and tick labels color (defaults to ImGuiCol_Text)",
+      "name" : "ImPlotCol_AxisBgActive",
+      "docComment" : "axis active color (defaults to ImGuiCol_ButtonActive)",
       "qualType" : "ImPlotCol_",
       "order" : 13,
       "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_AxisGrid",
-      "docComment" : "axis grid color (defaults to 25% ImPlotCol_AxisText)",
+      "name" : "ImPlotCol_Selection",
+      "docComment" : "box-selection color (defaults to yellow)",
       "qualType" : "ImPlotCol_",
       "order" : 14,
       "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_AxisTick",
-      "docComment" : "axis tick color (defaults to AxisGrid)",
+      "name" : "ImPlotCol_Crosshairs",
+      "docComment" : "crosshairs color (defaults to ImPlotCol_PlotBorder)",
       "qualType" : "ImPlotCol_",
       "order" : 15,
       "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_AxisBg",
-      "docComment" : "background color of axis hover region (defaults to transparent)",
+      "name" : "ImPlotCol_COUNT",
       "qualType" : "ImPlotCol_",
       "order" : 16,
       "evaluatedValue" : 16
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_AxisBgHovered",
-      "docComment" : "axis hover color (defaults to ImGuiCol_ButtonHovered)",
-      "qualType" : "ImPlotCol_",
-      "order" : 17,
-      "evaluatedValue" : 17
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_AxisBgActive",
-      "docComment" : "axis active color (defaults to ImGuiCol_ButtonActive)",
-      "qualType" : "ImPlotCol_",
-      "order" : 18,
-      "evaluatedValue" : 18
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_Selection",
-      "docComment" : "box-selection color (defaults to yellow)",
-      "qualType" : "ImPlotCol_",
-      "order" : 19,
-      "evaluatedValue" : 19
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_Crosshairs",
-      "docComment" : "crosshairs color (defaults to ImPlotCol_PlotBorder)",
-      "qualType" : "ImPlotCol_",
-      "order" : 20,
-      "evaluatedValue" : 20
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotCol_COUNT",
-      "qualType" : "ImPlotCol_",
-      "order" : 21,
-      "evaluatedValue" : 21
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1466,199 +1621,150 @@
       } ]
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_LineWeight",
-      "docComment" : "float,  plot item line weight in pixels",
+      "name" : "ImPlotStyleVar_PlotDefaultSize",
+      "docComment" : "ImVec2, default size used when ImVec2(0,0) is passed to BeginPlot",
       "qualType" : "ImPlotStyleVar_",
       "order" : 0,
       "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_Marker",
-      "docComment" : "int,    marker specification",
+      "name" : "ImPlotStyleVar_PlotMinSize",
+      "docComment" : "ImVec2, minimum size plot frame can be when shrunk",
       "qualType" : "ImPlotStyleVar_",
       "order" : 1,
       "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MarkerSize",
-      "docComment" : "float,  marker size in pixels (roughly the marker's \"radius\")",
+      "name" : "ImPlotStyleVar_PlotBorderSize",
+      "docComment" : "float,  thickness of border around plot area",
       "qualType" : "ImPlotStyleVar_",
       "order" : 2,
       "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MarkerWeight",
-      "docComment" : "float,  plot outline weight of markers in pixels",
+      "name" : "ImPlotStyleVar_MinorAlpha",
+      "docComment" : "float,  alpha multiplier applied to minor axis grid lines",
       "qualType" : "ImPlotStyleVar_",
       "order" : 3,
       "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_FillAlpha",
-      "docComment" : "float,  alpha modifier applied to all plot item fills",
+      "name" : "ImPlotStyleVar_MajorTickLen",
+      "docComment" : "ImVec2, major tick lengths for X and Y axes",
       "qualType" : "ImPlotStyleVar_",
       "order" : 4,
       "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_ErrorBarSize",
-      "docComment" : "float,  error bar whisker width in pixels",
+      "name" : "ImPlotStyleVar_MinorTickLen",
+      "docComment" : "ImVec2, minor tick lengths for X and Y axes",
       "qualType" : "ImPlotStyleVar_",
       "order" : 5,
       "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_ErrorBarWeight",
-      "docComment" : "float,  error bar whisker weight in pixels",
+      "name" : "ImPlotStyleVar_MajorTickSize",
+      "docComment" : "ImVec2, line thickness of major ticks",
       "qualType" : "ImPlotStyleVar_",
       "order" : 6,
       "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_DigitalBitHeight",
-      "docComment" : "float,  digital channels bit height (at 1) in pixels",
+      "name" : "ImPlotStyleVar_MinorTickSize",
+      "docComment" : "ImVec2, line thickness of minor ticks",
       "qualType" : "ImPlotStyleVar_",
       "order" : 7,
       "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_DigitalBitGap",
-      "docComment" : "float,  digital channels bit padding gap in pixels",
+      "name" : "ImPlotStyleVar_MajorGridSize",
+      "docComment" : "ImVec2, line thickness of major grid lines",
       "qualType" : "ImPlotStyleVar_",
       "order" : 8,
       "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_PlotBorderSize",
-      "docComment" : "float,  thickness of border around plot area",
+      "name" : "ImPlotStyleVar_MinorGridSize",
+      "docComment" : "ImVec2, line thickness of minor grid lines",
       "qualType" : "ImPlotStyleVar_",
       "order" : 9,
       "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MinorAlpha",
-      "docComment" : "float,  alpha multiplier applied to minor axis grid lines",
+      "name" : "ImPlotStyleVar_PlotPadding",
+      "docComment" : "ImVec2, padding between widget frame and plot area, labels, or outside legends (i.e. main padding)",
       "qualType" : "ImPlotStyleVar_",
       "order" : 10,
       "evaluatedValue" : 10
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MajorTickLen",
-      "docComment" : "ImVec2, major tick lengths for X and Y axes",
+      "name" : "ImPlotStyleVar_LabelPadding",
+      "docComment" : "ImVec2, padding between axes labels, tick labels, and plot edge",
       "qualType" : "ImPlotStyleVar_",
       "order" : 11,
       "evaluatedValue" : 11
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MinorTickLen",
-      "docComment" : "ImVec2, minor tick lengths for X and Y axes",
+      "name" : "ImPlotStyleVar_LegendPadding",
+      "docComment" : "ImVec2, legend padding from plot edges",
       "qualType" : "ImPlotStyleVar_",
       "order" : 12,
       "evaluatedValue" : 12
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MajorTickSize",
-      "docComment" : "ImVec2, line thickness of major ticks",
+      "name" : "ImPlotStyleVar_LegendInnerPadding",
+      "docComment" : "ImVec2, legend inner padding from legend edges",
       "qualType" : "ImPlotStyleVar_",
       "order" : 13,
       "evaluatedValue" : 13
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MinorTickSize",
-      "docComment" : "ImVec2, line thickness of minor ticks",
+      "name" : "ImPlotStyleVar_LegendSpacing",
+      "docComment" : "ImVec2, spacing between legend entries",
       "qualType" : "ImPlotStyleVar_",
       "order" : 14,
       "evaluatedValue" : 14
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MajorGridSize",
-      "docComment" : "ImVec2, line thickness of major grid lines",
+      "name" : "ImPlotStyleVar_MousePosPadding",
+      "docComment" : "ImVec2, padding between plot edge and interior info text",
       "qualType" : "ImPlotStyleVar_",
       "order" : 15,
       "evaluatedValue" : 15
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MinorGridSize",
-      "docComment" : "ImVec2, line thickness of minor grid lines",
+      "name" : "ImPlotStyleVar_AnnotationPadding",
+      "docComment" : "ImVec2, text padding around annotation labels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 16,
       "evaluatedValue" : 16
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_PlotPadding",
-      "docComment" : "ImVec2, padding between widget frame and plot area, labels, or outside legends (i.e. main padding)",
+      "name" : "ImPlotStyleVar_FitPadding",
+      "docComment" : "ImVec2, additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)",
       "qualType" : "ImPlotStyleVar_",
       "order" : 17,
       "evaluatedValue" : 17
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_LabelPadding",
-      "docComment" : "ImVec2, padding between axes labels, tick labels, and plot edge",
+      "name" : "ImPlotStyleVar_DigitalPadding",
+      "docComment" : "float,  digital plot padding from bottom in pixels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 18,
       "evaluatedValue" : 18
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_LegendPadding",
-      "docComment" : "ImVec2, legend padding from plot edges",
+      "name" : "ImPlotStyleVar_DigitalSpacing",
+      "docComment" : "float,  digital plot spacing gap in pixels",
       "qualType" : "ImPlotStyleVar_",
       "order" : 19,
       "evaluatedValue" : 19
     }, {
       "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_LegendInnerPadding",
-      "docComment" : "ImVec2, legend inner padding from legend edges",
+      "name" : "ImPlotStyleVar_COUNT",
       "qualType" : "ImPlotStyleVar_",
       "order" : 20,
       "evaluatedValue" : 20
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_LegendSpacing",
-      "docComment" : "ImVec2, spacing between legend entries",
-      "qualType" : "ImPlotStyleVar_",
-      "order" : 21,
-      "evaluatedValue" : 21
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_MousePosPadding",
-      "docComment" : "ImVec2, padding between plot edge and interior info text",
-      "qualType" : "ImPlotStyleVar_",
-      "order" : 22,
-      "evaluatedValue" : 22
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_AnnotationPadding",
-      "docComment" : "ImVec2, text padding around annotation labels",
-      "qualType" : "ImPlotStyleVar_",
-      "order" : 23,
-      "evaluatedValue" : 23
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_FitPadding",
-      "docComment" : "ImVec2, additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)",
-      "qualType" : "ImPlotStyleVar_",
-      "order" : 24,
-      "evaluatedValue" : 24
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_PlotDefaultSize",
-      "docComment" : "ImVec2, default size used when ImVec2(0,0) is passed to BeginPlot",
-      "qualType" : "ImPlotStyleVar_",
-      "order" : 25,
-      "evaluatedValue" : 25
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_PlotMinSize",
-      "docComment" : "ImVec2, minimum size plot frame can be when shrunk",
-      "qualType" : "ImPlotStyleVar_",
-      "order" : 26,
-      "evaluatedValue" : 26
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotStyleVar_COUNT",
-      "qualType" : "ImPlotStyleVar_",
-      "order" : 27,
-      "evaluatedValue" : 27
     } ]
   }, {
     "@type" : "AstEnumDecl",
@@ -1720,6 +1826,14 @@
       "docComment" : "no marker",
       "qualType" : "ImPlotMarker_",
       "order" : 0,
+      "value" : "-2",
+      "evaluatedValue" : -2
+    }, {
+      "@type" : "AstEnumConstantDecl",
+      "name" : "ImPlotMarker_Auto",
+      "docComment" : "automatic marker selection",
+      "qualType" : "ImPlotMarker_",
+      "order" : 1,
       "value" : "-1",
       "evaluatedValue" : -1
     }, {
@@ -1727,76 +1841,76 @@
       "name" : "ImPlotMarker_Circle",
       "docComment" : "a circle marker (default)",
       "qualType" : "ImPlotMarker_",
-      "order" : 1,
+      "order" : 2,
       "evaluatedValue" : 0
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Square",
       "docComment" : "a square maker",
       "qualType" : "ImPlotMarker_",
-      "order" : 2,
+      "order" : 3,
       "evaluatedValue" : 1
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Diamond",
       "docComment" : "a diamond marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 3,
+      "order" : 4,
       "evaluatedValue" : 2
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Up",
       "docComment" : "an upward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 4,
+      "order" : 5,
       "evaluatedValue" : 3
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Down",
       "docComment" : "an downward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 5,
+      "order" : 6,
       "evaluatedValue" : 4
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Left",
       "docComment" : "an leftward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 6,
+      "order" : 7,
       "evaluatedValue" : 5
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Right",
       "docComment" : "an rightward-pointing triangle marker",
       "qualType" : "ImPlotMarker_",
-      "order" : 7,
+      "order" : 8,
       "evaluatedValue" : 6
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Cross",
-      "docComment" : "a cross marker (not fillable)",
+      "docComment" : "a cross marker (not fill-able)",
       "qualType" : "ImPlotMarker_",
-      "order" : 8,
+      "order" : 9,
       "evaluatedValue" : 7
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Plus",
-      "docComment" : "a plus marker (not fillable)",
+      "docComment" : "a plus marker (not fill-able)",
       "qualType" : "ImPlotMarker_",
-      "order" : 9,
+      "order" : 10,
       "evaluatedValue" : 8
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_Asterisk",
-      "docComment" : "a asterisk marker (not fillable)",
+      "docComment" : "a asterisk marker (not fill-able)",
       "qualType" : "ImPlotMarker_",
-      "order" : 10,
+      "order" : 11,
       "evaluatedValue" : 9
     }, {
       "@type" : "AstEnumConstantDecl",
       "name" : "ImPlotMarker_COUNT",
       "qualType" : "ImPlotMarker_",
-      "order" : 11,
+      "order" : 12,
       "evaluatedValue" : 10
     } ]
   }, {
@@ -2072,6 +2186,233 @@
     } ]
   }, {
     "@type" : "AstRecordDecl",
+    "name" : "ImPlotSpec",
+    "decls" : [ {
+      "@type" : "AstFullComment",
+      "decls" : [ {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " Plot item styling specification. Provide these to PlotX functions to override styling, specify"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : " offsetting or stride, or set optional flags. This struct can be used in the following ways:"
+        } ]
+      }, {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " 1. By declaring and defining a struct instance:"
+        } ]
+      }, {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : "    ImPlotSpec spec;"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    spec.LineColor = ImVec4(1,0,0,1);"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    spec.LineWeight = 2.0f;"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    spec.Marker = ImPlotMarker_Circle;"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    spec.Flags = ImPlotItemFlags_NoLegend | ImPlotLineFlags_Segments;"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    ImPlot::PlotLine(\"MyLine\", xs, ys, 100, spec);"
+        } ]
+      }, {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : " 2. Inline using (ImPlotProp,value) pairs (order does NOT matter):"
+        } ]
+      }, {
+        "@type" : "AstParagraphComment",
+        "decls" : [ {
+          "@type" : "AstTextComment",
+          "text" : "    ImPlot::PlotLine(\"MyLine\", xs, ys, 100, {"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "      ImPlotProp_LineColor, ImVec4(1,0,0,1),"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "      ImPlotProp_LineWeight, 2.0f,"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "      ImPlotProp_Marker, ImPlotMarker_Circle,"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "      ImPlotProp_Flags, ImPlotItemFlags_NoLegend | ImPlotLineFlags_Segments"
+        }, {
+          "@type" : "AstTextComment",
+          "text" : "    });"
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LineColor",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LineColors",
+      "qualType" : "int *",
+      "desugaredQualType" : "int *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "LineWeight",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FillColor",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FillColors",
+      "qualType" : "int *",
+      "desugaredQualType" : "int *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "FillAlpha",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Marker",
+      "qualType" : "ImPlotMarker",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MarkerSize",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MarkerSizes",
+      "qualType" : "float *",
+      "desugaredQualType" : "float *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MarkerLineColor",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MarkerLineColors",
+      "qualType" : "int *",
+      "desugaredQualType" : "int *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MarkerFillColor",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "MarkerFillColors",
+      "qualType" : "int *",
+      "desugaredQualType" : "int *"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Size",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Offset",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Stride",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFieldDecl",
+      "name" : "Flags",
+      "qualType" : "ImPlotItemFlags",
+      "desugaredQualType" : "int"
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetProp",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "prop",
+        "qualType" : "ImPlotProp",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "int *",
+        "desugaredQualType" : "int *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set a property from a pointer value."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetProp",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "prop",
+        "qualType" : "ImPlotProp",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "float *",
+        "desugaredQualType" : "float *"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set a property from a float pointer value."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "SetProp",
+      "resultType" : "void",
+      "decls" : [ {
+        "@type" : "AstParmVarDecl",
+        "name" : "prop",
+        "qualType" : "ImPlotProp",
+        "desugaredQualType" : "int"
+      }, {
+        "@type" : "AstParmVarDecl",
+        "name" : "v",
+        "qualType" : "const int &",
+        "desugaredQualType" : "const int &"
+      }, {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Set a property from an ImVec4 value."
+          } ]
+        } ]
+      } ]
+    } ]
+  }, {
+    "@type" : "AstRecordDecl",
     "name" : "ImPlotPoint",
     "decls" : [ {
       "@type" : "AstFullComment",
@@ -2239,49 +2580,14 @@
       } ]
     }, {
       "@type" : "AstFieldDecl",
-      "name" : "LineWeight",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "Marker",
+      "name" : "PlotDefaultSize",
       "qualType" : "int",
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
-      "name" : "MarkerSize",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "MarkerWeight",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "FillAlpha",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "ErrorBarSize",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "ErrorBarWeight",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "DigitalBitHeight",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
-    }, {
-      "@type" : "AstFieldDecl",
-      "name" : "DigitalBitGap",
-      "qualType" : "float",
-      "desugaredQualType" : "float"
+      "name" : "PlotMinSize",
+      "qualType" : "int",
+      "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "PlotBorderSize",
@@ -2364,19 +2670,19 @@
       "desugaredQualType" : "int"
     }, {
       "@type" : "AstFieldDecl",
-      "name" : "PlotDefaultSize",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "name" : "DigitalPadding",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
     }, {
       "@type" : "AstFieldDecl",
-      "name" : "PlotMinSize",
-      "qualType" : "int",
-      "desugaredQualType" : "int"
+      "name" : "DigitalSpacing",
+      "qualType" : "float",
+      "desugaredQualType" : "float"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Colors",
-      "qualType" : "int[21]",
-      "desugaredQualType" : "int[21]"
+      "qualType" : "int[16]",
+      "desugaredQualType" : "int[16]"
     }, {
       "@type" : "AstFieldDecl",
       "name" : "Colormap",
@@ -2865,7 +3171,7 @@
             "text" : " Only call EndSubplots() if BeginSubplots() returns true! Typically called at the end"
           }, {
             "@type" : "AstTextComment",
-            "text" : " of an if statement conditioned on BeginSublots(). See example above."
+            "text" : " of an if statement conditioned on BeginSubplots(). See example above."
           } ]
         } ]
       } ]
@@ -2984,7 +3290,7 @@
           "@type" : "AstParagraphComment",
           "decls" : [ {
             "@type" : "AstTextComment",
-            "text" : " Sets the format of numeric axis labels via formater specifier (default=\"%g\"). Formated values will be double (i.e. use %f)."
+            "text" : " Sets the format of numeric axis labels via formatter specifier (default=\"%g\"). Formatted values will be double (i.e. use %f)."
           } ]
         } ]
       } ]
@@ -3528,10 +3834,10 @@
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotLineFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3559,10 +3865,10 @@
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotScatterFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3590,10 +3896,10 @@
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotStairsFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3631,10 +3937,10 @@
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotShadedFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3667,10 +3973,10 @@
         "desugaredQualType" : "double"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotBarsFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3698,10 +4004,10 @@
         "desugaredQualType" : "int"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotDigitalFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3747,10 +4053,10 @@
         "defaultValue" : "ImVec4(1,1,1,1)"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotImageFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       } ]
     }, {
       "@type" : "AstFunctionDecl",
@@ -3779,10 +4085,10 @@
         "defaultValue" : "ImVec2(0,0)"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotTextFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       }, {
         "@type" : "AstFullComment",
         "decls" : [ {
@@ -3804,10 +4110,10 @@
         "desugaredQualType" : "const char *"
       }, {
         "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotDummyFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "0"
+        "name" : "spec",
+        "qualType" : "const ImPlotSpec &",
+        "desugaredQualType" : "const ImPlotSpec &",
+        "defaultValue" : "ImPlotSpec()"
       }, {
         "@type" : "AstFullComment",
         "decls" : [ {
@@ -5025,134 +5331,6 @@
       } ]
     }, {
       "@type" : "AstFunctionDecl",
-      "name" : "SetNextLineStyle",
-      "resultType" : "void",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "col",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
-        "defaultValue" : "IMPLOT_AUTO_COL"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "weight",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "IMPLOT_AUTO"
-      }, {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the line color and weight for the next item only."
-          } ]
-        } ]
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "SetNextFillStyle",
-      "resultType" : "void",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "col",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
-        "defaultValue" : "IMPLOT_AUTO_COL"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "alpha_mod",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "IMPLOT_AUTO"
-      }, {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the fill color for the next item only."
-          } ]
-        } ]
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "SetNextMarkerStyle",
-      "resultType" : "void",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "marker",
-        "qualType" : "ImPlotMarker",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_AUTO"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "IMPLOT_AUTO"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "fill",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
-        "defaultValue" : "IMPLOT_AUTO_COL"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "weight",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "IMPLOT_AUTO"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "outline",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
-        "defaultValue" : "IMPLOT_AUTO_COL"
-      }, {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the marker style for the next item only."
-          } ]
-        } ]
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
-      "name" : "SetNextErrorBarStyle",
-      "resultType" : "void",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "col",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
-        "defaultValue" : "IMPLOT_AUTO_COL"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "IMPLOT_AUTO"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "weight",
-        "qualType" : "float",
-        "desugaredQualType" : "float",
-        "defaultValue" : "IMPLOT_AUTO"
-      }, {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " Set the error bar style for the next item only."
-          } ]
-        } ]
-      } ]
-    }, {
-      "@type" : "AstFunctionDecl",
       "name" : "GetLastItemColor",
       "resultType" : "int",
       "decls" : [ {
@@ -5200,6 +5378,20 @@
           "decls" : [ {
             "@type" : "AstTextComment",
             "text" : " Returns the null terminated string name for an ImPlotMarker."
+          } ]
+        } ]
+      } ]
+    }, {
+      "@type" : "AstFunctionDecl",
+      "name" : "NextMarker",
+      "resultType" : "ImPlotMarker",
+      "decls" : [ {
+        "@type" : "AstFullComment",
+        "decls" : [ {
+          "@type" : "AstParagraphComment",
+          "decls" : [ {
+            "@type" : "AstTextComment",
+            "text" : " Returns the next marker and advances the marker for the current plot. You need to call this between Begin/EndPlot!"
           } ]
         } ]
       } ]
@@ -5906,105 +6098,6 @@
           "decls" : [ {
             "@type" : "AstTextComment",
             "text" : " Shows the ImPlot demo window (add implot_demo.cpp to your sources!)"
-          } ]
-        } ]
-      } ]
-    } ]
-  }, {
-    "@type" : "AstEnumDecl",
-    "name" : "ImPlotFlagsObsolete_",
-    "decls" : [ {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotFlags_YAxis2",
-      "qualType" : "ImPlotFlagsObsolete_",
-      "order" : 0,
-      "value" : "1 << 20",
-      "evaluatedValue" : 1048576
-    }, {
-      "@type" : "AstEnumConstantDecl",
-      "name" : "ImPlotFlags_YAxis3",
-      "qualType" : "ImPlotFlagsObsolete_",
-      "order" : 1,
-      "value" : "1 << 21",
-      "evaluatedValue" : 2097152
-    } ]
-  }, {
-    "@type" : "AstNamespaceDecl",
-    "name" : "ImPlot",
-    "decls" : [ {
-      "@type" : "AstFunctionDecl",
-      "name" : "BeginPlot",
-      "resultType" : "bool",
-      "decls" : [ {
-        "@type" : "AstParmVarDecl",
-        "name" : "title_id",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "x_label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "size",
-        "qualType" : "const int &",
-        "desugaredQualType" : "const int &",
-        "defaultValue" : "IMPLOT_DEPRECATED"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "flags",
-        "qualType" : "ImPlotFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_DEPRECATED"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "x_flags",
-        "qualType" : "ImPlotAxisFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_DEPRECATED"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y_flags",
-        "qualType" : "ImPlotAxisFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_DEPRECATED"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y2_flags",
-        "qualType" : "ImPlotAxisFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_DEPRECATED"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y3_flags",
-        "qualType" : "ImPlotAxisFlags",
-        "desugaredQualType" : "int",
-        "defaultValue" : "IMPLOT_DEPRECATED"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y2_label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "IMPLOT_DEPRECATED"
-      }, {
-        "@type" : "AstParmVarDecl",
-        "name" : "y3_label",
-        "qualType" : "const char *",
-        "desugaredQualType" : "const char *",
-        "defaultValue" : "IMPLOT_DEPRECATED"
-      }, {
-        "@type" : "AstFullComment",
-        "decls" : [ {
-          "@type" : "AstParagraphComment",
-          "decls" : [ {
-            "@type" : "AstTextComment",
-            "text" : " OBSOLETED in v0.13 -> PLANNED REMOVAL in v1.0"
           } ]
         } ]
       } ]

--- a/example/src/main/java/ExampleImPlot.java
+++ b/example/src/main/java/ExampleImPlot.java
@@ -1,5 +1,8 @@
+import imgui.ImColor;
 import imgui.extension.implot.ImPlot;
 import imgui.extension.implot.ImPlotPoint;
+import imgui.extension.implot.ImPlotSpec;
+import imgui.extension.implot.flag.ImPlotMarker;
 import imgui.flag.ImGuiCond;
 import imgui.internal.ImGui;
 import imgui.type.ImBoolean;
@@ -8,7 +11,7 @@ import java.awt.Desktop;
 import java.net.URI;
 
 public class ExampleImPlot {
-    private static final String URL = "https://github.com/epezent/implot/tree/555ff68";
+    private static final String URL = "https://github.com/epezent/implot/tree/v1.0";
     private static final ImBoolean showDemo = new ImBoolean(false);
 
     private static final int[] xs = {0, 1, 2, 3, 4, 5};
@@ -16,8 +19,31 @@ public class ExampleImPlot {
     private static final int[] ys1 = {0, 0, 1, 2, 3, 4};
     private static final int[] ys2 = {1, 2, 3, 4, 5, 6};
 
+    // Showcase for implot v1.0 PR #672: per-index LineColors, MarkerFillColors, and MarkerSizes.
+    private static final ImPlotSpec perIndexSpec;
+
     static {
         ImPlot.createContext();
+
+        perIndexSpec = new ImPlotSpec();
+        perIndexSpec.setMarker(ImPlotMarker.Circle);
+        perIndexSpec.setLineColors(new int[]{
+            ImColor.rgb(239, 83, 80),   // red
+            ImColor.rgb(255, 167, 38),  // orange
+            ImColor.rgb(255, 238, 88),  // yellow
+            ImColor.rgb(102, 187, 106), // green
+            ImColor.rgb(66, 165, 245),  // blue
+            ImColor.rgb(171, 71, 188),  // purple
+        });
+        perIndexSpec.setMarkerFillColors(new int[]{
+            ImColor.rgb(239, 83, 80),
+            ImColor.rgb(255, 167, 38),
+            ImColor.rgb(255, 238, 88),
+            ImColor.rgb(102, 187, 106),
+            ImColor.rgb(66, 165, 245),
+            ImColor.rgb(171, 71, 188),
+        });
+        perIndexSpec.setMarkerSizes(new float[]{4f, 6f, 8f, 10f, 12f, 14f});
     }
 
     public static void show(ImBoolean showImPlotWindow) {
@@ -61,6 +87,12 @@ public class ExampleImPlot {
 
                 if (ImPlot.beginPlot("Example Heatmap")) {
                     ImPlot.plotHeatmap("Heatmap", new int[]{1, 3, 6, 2, 8, 5, 4, 3}, 2, 4, 0, 0, "%d", new ImPlotPoint(0, 0), new ImPlotPoint(10, 10));
+                    ImPlot.endPlot();
+                }
+
+                // ImPlot v1.0 PR #672: per-index color/size via ImPlotSpec.
+                if (ImPlot.beginPlot("Per-Index Colors (v1.0 PR #672)")) {
+                    ImPlot.plotLine("Rainbow", xs, ys, perIndexSpec);
                     ImPlot.endPlot();
                 }
             }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
@@ -953,15 +953,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final short[] values, final double xscale, final double xstart, final int flags) {
-        nPlotLine(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final short[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLine(labelId, values, xscale, xstart, flags, offset);
+    public static void plotLine(final String labelId, final short[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLine(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, short[] values); /*MANUAL
@@ -988,18 +981,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, short[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, short[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, short[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1028,15 +1013,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final int[] values, final double xscale, final double xstart, final int flags) {
-        nPlotLine(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final int[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLine(labelId, values, xscale, xstart, flags, offset);
+    public static void plotLine(final String labelId, final int[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLine(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, int[] values); /*MANUAL
@@ -1063,18 +1041,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, int[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, int[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, int[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1103,15 +1073,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final long[] values, final double xscale, final double xstart, final int flags) {
-        nPlotLine(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final long[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLine(labelId, values, xscale, xstart, flags, offset);
+    public static void plotLine(final String labelId, final long[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLine(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, long[] values); /*MANUAL
@@ -1138,18 +1101,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, long[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, long[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, long[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1178,15 +1133,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final float[] values, final double xscale, final double xstart, final int flags) {
-        nPlotLine(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final float[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLine(labelId, values, xscale, xstart, flags, offset);
+    public static void plotLine(final String labelId, final float[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLine(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, float[] values); /*MANUAL
@@ -1213,18 +1161,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, float[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, float[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, float[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1253,15 +1193,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final double[] values, final double xscale, final double xstart, final int flags) {
-        nPlotLine(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLine(final String labelId, final double[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLine(labelId, values, xscale, xstart, flags, offset);
+    public static void plotLine(final String labelId, final double[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLine(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, double[] values); /*MANUAL
@@ -1288,18 +1221,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, double[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, double[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLine(String labelId, double[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1328,15 +1253,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotLineV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLineV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, short[] values, int count); /*MANUAL
@@ -1363,18 +1281,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, short[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, short[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, short[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1403,15 +1313,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotLineV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLineV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, int[] values, int count); /*MANUAL
@@ -1438,18 +1341,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, int[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, int[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, int[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1478,15 +1373,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotLineV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLineV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, long[] values, int count); /*MANUAL
@@ -1513,18 +1401,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, long[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, long[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, long[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1553,15 +1433,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotLineV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLineV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, float[] values, int count); /*MANUAL
@@ -1588,18 +1461,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, float[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, float[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, float[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1628,15 +1493,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotLineV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotLineV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotLineV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, double[] values, int count); /*MANUAL
@@ -1663,18 +1521,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, double[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, double[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, double[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotLine(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -1691,8 +1541,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final short[] xs, final short[] ys, final int flags) {
-        nPlotLine(labelId, xs, ys, flags);
+    public static void plotLine(final String labelId, final short[] xs, final short[] ys, final ImPlotSpec spec) {
+        nPlotLine(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -1705,11 +1555,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, short[] xs, short[] ys, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, short[] xs, short[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1725,8 +1575,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final int[] xs, final int[] ys, final int flags) {
-        nPlotLine(labelId, xs, ys, flags);
+    public static void plotLine(final String labelId, final int[] xs, final int[] ys, final ImPlotSpec spec) {
+        nPlotLine(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -1739,11 +1589,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, int[] xs, int[] ys, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, int[] xs, int[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1759,8 +1609,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final long[] xs, final long[] ys, final int flags) {
-        nPlotLine(labelId, xs, ys, flags);
+    public static void plotLine(final String labelId, final long[] xs, final long[] ys, final ImPlotSpec spec) {
+        nPlotLine(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -1773,11 +1623,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, long[] xs, long[] ys, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, long[] xs, long[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1793,8 +1643,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final float[] xs, final float[] ys, final int flags) {
-        nPlotLine(labelId, xs, ys, flags);
+    public static void plotLine(final String labelId, final float[] xs, final float[] ys, final ImPlotSpec spec) {
+        nPlotLine(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -1807,11 +1657,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, float[] xs, float[] ys, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, float[] xs, float[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1827,8 +1677,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLine(final String labelId, final double[] xs, final double[] ys, final int flags) {
-        nPlotLine(labelId, xs, ys, flags);
+    public static void plotLine(final String labelId, final double[] xs, final double[] ys, final ImPlotSpec spec) {
+        nPlotLine(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotLine(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -1841,11 +1691,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLine(String labelId, double[] xs, double[] ys, int flags); /*MANUAL
+    private static native void nPlotLine(String labelId, double[] xs, double[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1861,15 +1711,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final short[] xs, final short[] ys, final int count, final int flags) {
-        nPlotLineV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final short[] xs, final short[] ys, final int count, final int flags, final int offset) {
-        nPlotLineV(labelId, xs, ys, count, flags, offset);
+    public static void plotLineV(final String labelId, final short[] xs, final short[] ys, final int count, final ImPlotSpec spec) {
+        nPlotLineV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, short[] xs, short[] ys, int count); /*MANUAL
@@ -1882,21 +1725,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, short[] xs, short[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, short[] xs, short[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, short[] xs, short[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1912,15 +1745,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final int[] xs, final int[] ys, final int count, final int flags) {
-        nPlotLineV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final int[] xs, final int[] ys, final int count, final int flags, final int offset) {
-        nPlotLineV(labelId, xs, ys, count, flags, offset);
+    public static void plotLineV(final String labelId, final int[] xs, final int[] ys, final int count, final ImPlotSpec spec) {
+        nPlotLineV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, int[] xs, int[] ys, int count); /*MANUAL
@@ -1933,21 +1759,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, int[] xs, int[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, int[] xs, int[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, int[] xs, int[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -1963,15 +1779,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final long[] xs, final long[] ys, final int count, final int flags) {
-        nPlotLineV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final long[] xs, final long[] ys, final int count, final int flags, final int offset) {
-        nPlotLineV(labelId, xs, ys, count, flags, offset);
+    public static void plotLineV(final String labelId, final long[] xs, final long[] ys, final int count, final ImPlotSpec spec) {
+        nPlotLineV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, long[] xs, long[] ys, int count); /*MANUAL
@@ -1984,21 +1793,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, long[] xs, long[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, long[] xs, long[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, long[] xs, long[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -2014,15 +1813,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final float[] xs, final float[] ys, final int count, final int flags) {
-        nPlotLineV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final float[] xs, final float[] ys, final int count, final int flags, final int offset) {
-        nPlotLineV(labelId, xs, ys, count, flags, offset);
+    public static void plotLineV(final String labelId, final float[] xs, final float[] ys, final int count, final ImPlotSpec spec) {
+        nPlotLineV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, float[] xs, float[] ys, int count); /*MANUAL
@@ -2035,21 +1827,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, float[] xs, float[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, float[] xs, float[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, float[] xs, float[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -2065,15 +1847,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D line plot.
      */
-    public static void plotLineV(final String labelId, final double[] xs, final double[] ys, final int count, final int flags) {
-        nPlotLineV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D line plot.
-     */
-    public static void plotLineV(final String labelId, final double[] xs, final double[] ys, final int count, final int flags, final int offset) {
-        nPlotLineV(labelId, xs, ys, count, flags, offset);
+    public static void plotLineV(final String labelId, final double[] xs, final double[] ys, final int count, final ImPlotSpec spec) {
+        nPlotLineV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotLineV(String labelId, double[] xs, double[] ys, int count); /*MANUAL
@@ -2086,21 +1861,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotLineV(String labelId, double[] xs, double[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotLineV(String labelId, double[] xs, double[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotLineV(String labelId, double[] xs, double[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotLine(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -2132,15 +1897,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final short[] values, final double xscale, final double xstart, final int flags) {
-        nPlotScatter(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final short[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatter(labelId, values, xscale, xstart, flags, offset);
+    public static void plotScatter(final String labelId, final short[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatter(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, short[] values); /*MANUAL
@@ -2167,18 +1925,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, short[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, short[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatter(String labelId, short[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2207,15 +1957,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final int[] values, final double xscale, final double xstart, final int flags) {
-        nPlotScatter(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final int[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatter(labelId, values, xscale, xstart, flags, offset);
+    public static void plotScatter(final String labelId, final int[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatter(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, int[] values); /*MANUAL
@@ -2242,18 +1985,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, int[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, int[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatter(String labelId, int[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2282,15 +2017,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final long[] values, final double xscale, final double xstart, final int flags) {
-        nPlotScatter(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final long[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatter(labelId, values, xscale, xstart, flags, offset);
+    public static void plotScatter(final String labelId, final long[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatter(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, long[] values); /*MANUAL
@@ -2317,18 +2045,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, long[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, long[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatter(String labelId, long[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2357,15 +2077,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final float[] values, final double xscale, final double xstart, final int flags) {
-        nPlotScatter(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final float[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatter(labelId, values, xscale, xstart, flags, offset);
+    public static void plotScatter(final String labelId, final float[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatter(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, float[] values); /*MANUAL
@@ -2392,18 +2105,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, float[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, float[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatter(String labelId, float[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2432,15 +2137,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final double[] values, final double xscale, final double xstart, final int flags) {
-        nPlotScatter(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatter(final String labelId, final double[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatter(labelId, values, xscale, xstart, flags, offset);
+    public static void plotScatter(final String labelId, final double[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatter(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, double[] values); /*MANUAL
@@ -2467,18 +2165,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, double[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, double[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatter(String labelId, double[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2507,15 +2197,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotScatterV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, short[] values, int count); /*MANUAL
@@ -2542,18 +2225,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, short[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, short[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, short[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2582,15 +2257,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotScatterV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, int[] values, int count); /*MANUAL
@@ -2617,18 +2285,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, int[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, int[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, int[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2657,15 +2317,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotScatterV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, long[] values, int count); /*MANUAL
@@ -2692,18 +2345,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, long[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, long[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, long[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2732,15 +2377,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotScatterV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, float[] values, int count); /*MANUAL
@@ -2767,18 +2405,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, float[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, float[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, float[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2807,15 +2437,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotScatterV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotScatterV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, double[] values, int count); /*MANUAL
@@ -2842,18 +2465,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, double[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, double[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, double[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotScatter(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -2870,8 +2485,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final short[] xs, final short[] ys, final int flags) {
-        nPlotScatter(labelId, xs, ys, flags);
+    public static void plotScatter(final String labelId, final short[] xs, final short[] ys, final ImPlotSpec spec) {
+        nPlotScatter(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -2884,11 +2499,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, short[] xs, short[] ys, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, short[] xs, short[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -2904,8 +2519,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final int[] xs, final int[] ys, final int flags) {
-        nPlotScatter(labelId, xs, ys, flags);
+    public static void plotScatter(final String labelId, final int[] xs, final int[] ys, final ImPlotSpec spec) {
+        nPlotScatter(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -2918,11 +2533,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, int[] xs, int[] ys, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, int[] xs, int[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -2938,8 +2553,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final long[] xs, final long[] ys, final int flags) {
-        nPlotScatter(labelId, xs, ys, flags);
+    public static void plotScatter(final String labelId, final long[] xs, final long[] ys, final ImPlotSpec spec) {
+        nPlotScatter(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -2952,11 +2567,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, long[] xs, long[] ys, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, long[] xs, long[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -2972,8 +2587,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final float[] xs, final float[] ys, final int flags) {
-        nPlotScatter(labelId, xs, ys, flags);
+    public static void plotScatter(final String labelId, final float[] xs, final float[] ys, final ImPlotSpec spec) {
+        nPlotScatter(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -2986,11 +2601,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, float[] xs, float[] ys, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, float[] xs, float[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -3006,8 +2621,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatter(final String labelId, final double[] xs, final double[] ys, final int flags) {
-        nPlotScatter(labelId, xs, ys, flags);
+    public static void plotScatter(final String labelId, final double[] xs, final double[] ys, final ImPlotSpec spec) {
+        nPlotScatter(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotScatter(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -3020,11 +2635,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatter(String labelId, double[] xs, double[] ys, int flags); /*MANUAL
+    private static native void nPlotScatter(String labelId, double[] xs, double[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -3040,15 +2655,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final short[] xs, final short[] ys, final int count, final int flags) {
-        nPlotScatterV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final short[] xs, final short[] ys, final int count, final int flags, final int offset) {
-        nPlotScatterV(labelId, xs, ys, count, flags, offset);
+    public static void plotScatterV(final String labelId, final short[] xs, final short[] ys, final int count, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, short[] xs, short[] ys, int count); /*MANUAL
@@ -3061,21 +2669,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, short[] xs, short[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, short[] xs, short[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, short[] xs, short[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -3091,15 +2689,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final int[] xs, final int[] ys, final int count, final int flags) {
-        nPlotScatterV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final int[] xs, final int[] ys, final int count, final int flags, final int offset) {
-        nPlotScatterV(labelId, xs, ys, count, flags, offset);
+    public static void plotScatterV(final String labelId, final int[] xs, final int[] ys, final int count, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, int[] xs, int[] ys, int count); /*MANUAL
@@ -3112,21 +2703,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, int[] xs, int[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, int[] xs, int[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, int[] xs, int[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -3142,15 +2723,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final long[] xs, final long[] ys, final int count, final int flags) {
-        nPlotScatterV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final long[] xs, final long[] ys, final int count, final int flags, final int offset) {
-        nPlotScatterV(labelId, xs, ys, count, flags, offset);
+    public static void plotScatterV(final String labelId, final long[] xs, final long[] ys, final int count, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, long[] xs, long[] ys, int count); /*MANUAL
@@ -3163,21 +2737,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, long[] xs, long[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, long[] xs, long[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, long[] xs, long[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -3193,15 +2757,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final float[] xs, final float[] ys, final int count, final int flags) {
-        nPlotScatterV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final float[] xs, final float[] ys, final int count, final int flags, final int offset) {
-        nPlotScatterV(labelId, xs, ys, count, flags, offset);
+    public static void plotScatterV(final String labelId, final float[] xs, final float[] ys, final int count, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, float[] xs, float[] ys, int count); /*MANUAL
@@ -3214,21 +2771,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, float[] xs, float[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, float[] xs, float[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, float[] xs, float[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -3244,15 +2791,8 @@ public final class ImPlot {
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
-    public static void plotScatterV(final String labelId, final double[] xs, final double[] ys, final int count, final int flags) {
-        nPlotScatterV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-     */
-    public static void plotScatterV(final String labelId, final double[] xs, final double[] ys, final int count, final int flags, final int offset) {
-        nPlotScatterV(labelId, xs, ys, count, flags, offset);
+    public static void plotScatterV(final String labelId, final double[] xs, final double[] ys, final int count, final ImPlotSpec spec) {
+        nPlotScatterV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotScatterV(String labelId, double[] xs, double[] ys, int count); /*MANUAL
@@ -3265,21 +2805,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotScatterV(String labelId, double[] xs, double[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotScatterV(String labelId, double[] xs, double[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotScatterV(String labelId, double[] xs, double[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotScatter(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -3311,15 +2841,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final short[] values, final double xscale, final double xstart, final int flags) {
-        nPlotStairs(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final short[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairs(labelId, values, xscale, xstart, flags, offset);
+    public static void plotStairs(final String labelId, final short[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairs(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, short[] values); /*MANUAL
@@ -3346,18 +2869,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, short[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, short[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairs(String labelId, short[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3386,15 +2901,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final int[] values, final double xscale, final double xstart, final int flags) {
-        nPlotStairs(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final int[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairs(labelId, values, xscale, xstart, flags, offset);
+    public static void plotStairs(final String labelId, final int[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairs(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, int[] values); /*MANUAL
@@ -3421,18 +2929,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, int[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, int[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairs(String labelId, int[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3461,15 +2961,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final long[] values, final double xscale, final double xstart, final int flags) {
-        nPlotStairs(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final long[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairs(labelId, values, xscale, xstart, flags, offset);
+    public static void plotStairs(final String labelId, final long[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairs(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, long[] values); /*MANUAL
@@ -3496,18 +2989,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, long[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, long[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairs(String labelId, long[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3536,15 +3021,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final float[] values, final double xscale, final double xstart, final int flags) {
-        nPlotStairs(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final float[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairs(labelId, values, xscale, xstart, flags, offset);
+    public static void plotStairs(final String labelId, final float[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairs(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, float[] values); /*MANUAL
@@ -3571,18 +3049,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, float[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, float[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairs(String labelId, float[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3611,15 +3081,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final double[] values, final double xscale, final double xstart, final int flags) {
-        nPlotStairs(labelId, values, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairs(final String labelId, final double[] values, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairs(labelId, values, xscale, xstart, flags, offset);
+    public static void plotStairs(final String labelId, final double[] values, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairs(labelId, values, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, double[] values); /*MANUAL
@@ -3646,18 +3109,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, double[] values, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, double[] values, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairs(String labelId, double[] values, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3686,15 +3141,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotStairsV(final String labelId, final short[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, short[] values, int count); /*MANUAL
@@ -3721,18 +3169,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, short[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, short[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, short[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3761,15 +3201,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotStairsV(final String labelId, final int[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, int[] values, int count); /*MANUAL
@@ -3796,18 +3229,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, int[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, int[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, int[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3836,15 +3261,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotStairsV(final String labelId, final long[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, long[] values, int count); /*MANUAL
@@ -3871,18 +3289,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, long[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, long[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, long[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3911,15 +3321,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotStairsV(final String labelId, final float[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, float[] values, int count); /*MANUAL
@@ -3946,18 +3349,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, float[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, float[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, float[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -3986,15 +3381,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final int flags) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStairsV(labelId, values, count, xscale, xstart, flags, offset);
+    public static void plotStairsV(final String labelId, final double[] values, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, values, count, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, double[] values, int count); /*MANUAL
@@ -4021,18 +3409,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, double[] values, int count, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, double[] values, int count, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, double[] values, int count, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, flags, offset);
+        ImPlot::PlotStairs(labelId, &values[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -4049,8 +3429,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final short[] xs, final short[] ys, final int flags) {
-        nPlotStairs(labelId, xs, ys, flags);
+    public static void plotStairs(final String labelId, final short[] xs, final short[] ys, final ImPlotSpec spec) {
+        nPlotStairs(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -4063,11 +3443,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, short[] xs, short[] ys, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, short[] xs, short[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4083,8 +3463,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final int[] xs, final int[] ys, final int flags) {
-        nPlotStairs(labelId, xs, ys, flags);
+    public static void plotStairs(final String labelId, final int[] xs, final int[] ys, final ImPlotSpec spec) {
+        nPlotStairs(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -4097,11 +3477,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, int[] xs, int[] ys, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, int[] xs, int[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4117,8 +3497,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final long[] xs, final long[] ys, final int flags) {
-        nPlotStairs(labelId, xs, ys, flags);
+    public static void plotStairs(final String labelId, final long[] xs, final long[] ys, final ImPlotSpec spec) {
+        nPlotStairs(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -4131,11 +3511,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, long[] xs, long[] ys, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, long[] xs, long[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4151,8 +3531,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final float[] xs, final float[] ys, final int flags) {
-        nPlotStairs(labelId, xs, ys, flags);
+    public static void plotStairs(final String labelId, final float[] xs, final float[] ys, final ImPlotSpec spec) {
+        nPlotStairs(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -4165,11 +3545,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, float[] xs, float[] ys, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, float[] xs, float[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4185,8 +3565,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairs(final String labelId, final double[] xs, final double[] ys, final int flags) {
-        nPlotStairs(labelId, xs, ys, flags);
+    public static void plotStairs(final String labelId, final double[] xs, final double[] ys, final ImPlotSpec spec) {
+        nPlotStairs(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotStairs(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -4199,11 +3579,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairs(String labelId, double[] xs, double[] ys, int flags); /*MANUAL
+    private static native void nPlotStairs(String labelId, double[] xs, double[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), flags);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4219,15 +3599,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final short[] xs, final short[] ys, final int count, final int flags) {
-        nPlotStairsV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final short[] xs, final short[] ys, final int count, final int flags, final int offset) {
-        nPlotStairsV(labelId, xs, ys, count, flags, offset);
+    public static void plotStairsV(final String labelId, final short[] xs, final short[] ys, final int count, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, short[] xs, short[] ys, int count); /*MANUAL
@@ -4240,21 +3613,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, short[] xs, short[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, short[] xs, short[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, short[] xs, short[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4270,15 +3633,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final int[] xs, final int[] ys, final int count, final int flags) {
-        nPlotStairsV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final int[] xs, final int[] ys, final int count, final int flags, final int offset) {
-        nPlotStairsV(labelId, xs, ys, count, flags, offset);
+    public static void plotStairsV(final String labelId, final int[] xs, final int[] ys, final int count, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, int[] xs, int[] ys, int count); /*MANUAL
@@ -4291,21 +3647,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, int[] xs, int[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, int[] xs, int[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, int[] xs, int[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4321,15 +3667,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final long[] xs, final long[] ys, final int count, final int flags) {
-        nPlotStairsV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final long[] xs, final long[] ys, final int count, final int flags, final int offset) {
-        nPlotStairsV(labelId, xs, ys, count, flags, offset);
+    public static void plotStairsV(final String labelId, final long[] xs, final long[] ys, final int count, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, long[] xs, long[] ys, int count); /*MANUAL
@@ -4342,21 +3681,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, long[] xs, long[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, long[] xs, long[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, long[] xs, long[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4372,15 +3701,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final float[] xs, final float[] ys, final int count, final int flags) {
-        nPlotStairsV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final float[] xs, final float[] ys, final int count, final int flags, final int offset) {
-        nPlotStairsV(labelId, xs, ys, count, flags, offset);
+    public static void plotStairsV(final String labelId, final float[] xs, final float[] ys, final int count, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, float[] xs, float[] ys, int count); /*MANUAL
@@ -4393,21 +3715,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, float[] xs, float[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, float[] xs, float[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, float[] xs, float[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4423,15 +3735,8 @@ public final class ImPlot {
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
-    public static void plotStairsV(final String labelId, final double[] xs, final double[] ys, final int count, final int flags) {
-        nPlotStairsV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
-     */
-    public static void plotStairsV(final String labelId, final double[] xs, final double[] ys, final int count, final int flags, final int offset) {
-        nPlotStairsV(labelId, xs, ys, count, flags, offset);
+    public static void plotStairsV(final String labelId, final double[] xs, final double[] ys, final int count, final ImPlotSpec spec) {
+        nPlotStairsV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotStairsV(String labelId, double[] xs, double[] ys, int count); /*MANUAL
@@ -4444,21 +3749,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStairsV(String labelId, double[] xs, double[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotStairsV(String labelId, double[] xs, double[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStairsV(String labelId, double[] xs, double[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotStairs(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -4497,15 +3792,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final short[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final short[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotShaded(final String labelId, final short[] values, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShaded(labelId, values, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, short[] values); /*MANUAL
@@ -4540,18 +3828,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, short[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, short[] values, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, short[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -4587,15 +3867,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final int[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final int[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotShaded(final String labelId, final int[] values, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShaded(labelId, values, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, int[] values); /*MANUAL
@@ -4630,18 +3903,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, int[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, int[] values, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, int[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -4677,15 +3942,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final long[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final long[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotShaded(final String labelId, final long[] values, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShaded(labelId, values, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, long[] values); /*MANUAL
@@ -4720,18 +3978,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, long[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, long[] values, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, long[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -4767,15 +4017,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final float[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final float[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotShaded(final String labelId, final float[] values, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShaded(labelId, values, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, float[] values); /*MANUAL
@@ -4810,18 +4053,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, float[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, float[] values, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, float[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -4857,15 +4092,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final double[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final double[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShaded(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotShaded(final String labelId, final double[] values, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShaded(labelId, values, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, double[] values); /*MANUAL
@@ -4900,18 +4128,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, double[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, double[] values, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, double[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], LEN(values), yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -4947,15 +4167,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final short[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final short[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags, offset);
+    public static void plotShadedV(final String labelId, final short[] values, final int count, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, short[] values, int count); /*MANUAL
@@ -4990,18 +4203,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, short[] values, int count, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, short[] values, int count, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, short[] values, int count, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -5037,15 +4242,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final int[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final int[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags, offset);
+    public static void plotShadedV(final String labelId, final int[] values, final int count, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, int[] values, int count); /*MANUAL
@@ -5080,18 +4278,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, int[] values, int count, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, int[] values, int count, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, int[] values, int count, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -5127,15 +4317,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final long[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final long[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags, offset);
+    public static void plotShadedV(final String labelId, final long[] values, final int count, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, long[] values, int count); /*MANUAL
@@ -5170,18 +4353,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, long[] values, int count, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, long[] values, int count, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, long[] values, int count, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -5217,15 +4392,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final float[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final float[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags, offset);
+    public static void plotShadedV(final String labelId, final float[] values, final int count, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, float[] values, int count); /*MANUAL
@@ -5260,18 +4428,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, float[] values, int count, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, float[] values, int count, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, float[] values, int count, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -5307,15 +4467,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final double[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final double[] values, final int count, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, flags, offset);
+    public static void plotShadedV(final String labelId, final double[] values, final int count, final double yRef, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, values, count, yRef, xscale, xstart, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, double[] values, int count); /*MANUAL
@@ -5350,18 +4503,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, double[] values, int count, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, double[] values, int count, double yRef, double xscale, double xstart, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, double[] values, int count, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotShaded(labelId, &values[0], count, yRef, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -5385,15 +4530,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final short[] xs, final short[] ys, final double yRef, final int flags) {
-        nPlotShaded(labelId, xs, ys, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final short[] xs, final short[] ys, final double yRef, final int flags, final int offset) {
-        nPlotShaded(labelId, xs, ys, yRef, flags, offset);
+    public static void plotShaded(final String labelId, final short[] xs, final short[] ys, final double yRef, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys, yRef, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -5416,21 +4554,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, short[] xs, short[] ys, double yRef, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, short[] xs, short[] ys, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, short[] xs, short[] ys, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5453,15 +4581,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final int[] xs, final int[] ys, final double yRef, final int flags) {
-        nPlotShaded(labelId, xs, ys, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final int[] xs, final int[] ys, final double yRef, final int flags, final int offset) {
-        nPlotShaded(labelId, xs, ys, yRef, flags, offset);
+    public static void plotShaded(final String labelId, final int[] xs, final int[] ys, final double yRef, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys, yRef, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -5484,21 +4605,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, int[] xs, int[] ys, double yRef, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, int[] xs, int[] ys, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, int[] xs, int[] ys, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5521,15 +4632,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final long[] xs, final long[] ys, final double yRef, final int flags) {
-        nPlotShaded(labelId, xs, ys, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final long[] xs, final long[] ys, final double yRef, final int flags, final int offset) {
-        nPlotShaded(labelId, xs, ys, yRef, flags, offset);
+    public static void plotShaded(final String labelId, final long[] xs, final long[] ys, final double yRef, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys, yRef, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -5552,21 +4656,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, long[] xs, long[] ys, double yRef, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, long[] xs, long[] ys, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, long[] xs, long[] ys, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5589,15 +4683,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final float[] xs, final float[] ys, final double yRef, final int flags) {
-        nPlotShaded(labelId, xs, ys, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final float[] xs, final float[] ys, final double yRef, final int flags, final int offset) {
-        nPlotShaded(labelId, xs, ys, yRef, flags, offset);
+    public static void plotShaded(final String labelId, final float[] xs, final float[] ys, final double yRef, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys, yRef, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -5620,21 +4707,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, float[] xs, float[] ys, double yRef, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, float[] xs, float[] ys, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, float[] xs, float[] ys, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5657,15 +4734,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final double[] xs, final double[] ys, final double yRef, final int flags) {
-        nPlotShaded(labelId, xs, ys, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShaded(final String labelId, final double[] xs, final double[] ys, final double yRef, final int flags, final int offset) {
-        nPlotShaded(labelId, xs, ys, yRef, flags, offset);
+    public static void plotShaded(final String labelId, final double[] xs, final double[] ys, final double yRef, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys, yRef, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -5688,21 +4758,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, double[] xs, double[] ys, double yRef, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, double[] xs, double[] ys, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShaded(String labelId, double[] xs, double[] ys, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], LEN(xs), yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5725,15 +4785,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef, final int flags) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotShadedV(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys, count, yRef, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, short[] xs, short[] ys, int count); /*MANUAL
@@ -5756,21 +4809,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, short[] xs, short[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, short[] xs, short[] ys, int count, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, short[] xs, short[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5793,15 +4836,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef, final int flags) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotShadedV(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys, count, yRef, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, int[] xs, int[] ys, int count); /*MANUAL
@@ -5824,21 +4860,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, int[] xs, int[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, int[] xs, int[] ys, int count, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, int[] xs, int[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5861,15 +4887,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef, final int flags) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotShadedV(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys, count, yRef, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, long[] xs, long[] ys, int count); /*MANUAL
@@ -5892,21 +4911,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, long[] xs, long[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, long[] xs, long[] ys, int count, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, long[] xs, long[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5929,15 +4938,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef, final int flags) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotShadedV(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys, count, yRef, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, float[] xs, float[] ys, int count); /*MANUAL
@@ -5960,21 +4962,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, float[] xs, float[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, float[] xs, float[] ys, int count, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, float[] xs, float[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -5997,15 +4989,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef, final int flags) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotShadedV(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys, count, yRef, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, double[] xs, double[] ys, int count); /*MANUAL
@@ -6028,21 +5013,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, double[] xs, double[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, double[] xs, double[] ys, int count, double yRef, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, double[] xs, double[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys[0], count, yRef, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -6060,8 +5035,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int flags) {
-        nPlotShaded(labelId, xs, ys1, ys2, flags);
+    public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys1, ys2, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, short[] xs, short[] ys1, short[] ys2); /*MANUAL
@@ -6076,12 +5051,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, short[] xs, short[] ys1, short[] ys2, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, short[] xs, short[] ys1, short[] ys2, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), flags);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6098,8 +5073,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final int[] xs, final int[] ys1, final int[] ys2, final int flags) {
-        nPlotShaded(labelId, xs, ys1, ys2, flags);
+    public static void plotShaded(final String labelId, final int[] xs, final int[] ys1, final int[] ys2, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys1, ys2, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, int[] xs, int[] ys1, int[] ys2); /*MANUAL
@@ -6114,12 +5089,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, int[] xs, int[] ys1, int[] ys2, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, int[] xs, int[] ys1, int[] ys2, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), flags);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6136,8 +5111,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final long[] xs, final long[] ys1, final long[] ys2, final int flags) {
-        nPlotShaded(labelId, xs, ys1, ys2, flags);
+    public static void plotShaded(final String labelId, final long[] xs, final long[] ys1, final long[] ys2, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys1, ys2, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, long[] xs, long[] ys1, long[] ys2); /*MANUAL
@@ -6152,12 +5127,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, long[] xs, long[] ys1, long[] ys2, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, long[] xs, long[] ys1, long[] ys2, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), flags);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6174,8 +5149,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final float[] xs, final float[] ys1, final float[] ys2, final int flags) {
-        nPlotShaded(labelId, xs, ys1, ys2, flags);
+    public static void plotShaded(final String labelId, final float[] xs, final float[] ys1, final float[] ys2, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys1, ys2, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, float[] xs, float[] ys1, float[] ys2); /*MANUAL
@@ -6190,12 +5165,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, float[] xs, float[] ys1, float[] ys2, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, float[] xs, float[] ys1, float[] ys2, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), flags);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6212,8 +5187,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShaded(final String labelId, final double[] xs, final double[] ys1, final double[] ys2, final int flags) {
-        nPlotShaded(labelId, xs, ys1, ys2, flags);
+    public static void plotShaded(final String labelId, final double[] xs, final double[] ys1, final double[] ys2, final ImPlotSpec spec) {
+        nPlotShaded(labelId, xs, ys1, ys2, spec.ptr);
     }
 
     private static native void nPlotShaded(String labelId, double[] xs, double[] ys1, double[] ys2); /*MANUAL
@@ -6228,12 +5203,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShaded(String labelId, double[] xs, double[] ys1, double[] ys2, int flags); /*MANUAL
+    private static native void nPlotShaded(String labelId, double[] xs, double[] ys1, double[] ys2, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), flags);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6250,15 +5225,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int count, final int flags) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int count, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags, offset);
+    public static void plotShadedV(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int count, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys1, ys2, count, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, short[] xs, short[] ys1, short[] ys2, int count); /*MANUAL
@@ -6273,24 +5241,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, short[] xs, short[] ys1, short[] ys2, int count, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, short[] xs, short[] ys1, short[] ys2, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, short[] xs, short[] ys1, short[] ys2, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6307,15 +5263,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final int[] xs, final int[] ys1, final int[] ys2, final int count, final int flags) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final int[] xs, final int[] ys1, final int[] ys2, final int count, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags, offset);
+    public static void plotShadedV(final String labelId, final int[] xs, final int[] ys1, final int[] ys2, final int count, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys1, ys2, count, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, int[] xs, int[] ys1, int[] ys2, int count); /*MANUAL
@@ -6330,24 +5279,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, int[] xs, int[] ys1, int[] ys2, int count, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, int[] xs, int[] ys1, int[] ys2, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, int[] xs, int[] ys1, int[] ys2, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6364,15 +5301,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final long[] xs, final long[] ys1, final long[] ys2, final int count, final int flags) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final long[] xs, final long[] ys1, final long[] ys2, final int count, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags, offset);
+    public static void plotShadedV(final String labelId, final long[] xs, final long[] ys1, final long[] ys2, final int count, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys1, ys2, count, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, long[] xs, long[] ys1, long[] ys2, int count); /*MANUAL
@@ -6387,24 +5317,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, long[] xs, long[] ys1, long[] ys2, int count, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, long[] xs, long[] ys1, long[] ys2, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, long[] xs, long[] ys1, long[] ys2, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6421,15 +5339,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final float[] xs, final float[] ys1, final float[] ys2, final int count, final int flags) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final float[] xs, final float[] ys1, final float[] ys2, final int count, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags, offset);
+    public static void plotShadedV(final String labelId, final float[] xs, final float[] ys1, final float[] ys2, final int count, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys1, ys2, count, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, float[] xs, float[] ys1, float[] ys2, int count); /*MANUAL
@@ -6444,24 +5355,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, float[] xs, float[] ys1, float[] ys2, int count, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, float[] xs, float[] ys1, float[] ys2, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, float[] xs, float[] ys1, float[] ys2, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6478,15 +5377,8 @@ public final class ImPlot {
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
-    public static void plotShadedV(final String labelId, final double[] xs, final double[] ys1, final double[] ys2, final int count, final int flags) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags);
-    }
-
-    /**
-     * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
-     */
-    public static void plotShadedV(final String labelId, final double[] xs, final double[] ys1, final double[] ys2, final int count, final int flags, final int offset) {
-        nPlotShadedV(labelId, xs, ys1, ys2, count, flags, offset);
+    public static void plotShadedV(final String labelId, final double[] xs, final double[] ys1, final double[] ys2, final int count, final ImPlotSpec spec) {
+        nPlotShadedV(labelId, xs, ys1, ys2, count, spec.ptr);
     }
 
     private static native void nPlotShadedV(String labelId, double[] xs, double[] ys1, double[] ys2, int count); /*MANUAL
@@ -6501,24 +5393,12 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    private static native void nPlotShadedV(String labelId, double[] xs, double[] ys1, double[] ys2, int count, int flags); /*MANUAL
+    private static native void nPlotShadedV(String labelId, double[] xs, double[] ys1, double[] ys2, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys1 = obj_ys1 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
         auto ys2 = obj_ys2 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
-        if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
-    */
-
-    private static native void nPlotShadedV(String labelId, double[] xs, double[] ys1, double[] ys2, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys1 = obj_ys1 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys1, JNI_FALSE);
-        auto ys2 = obj_ys2 == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys2, JNI_FALSE);
-        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, flags, offset);
+        ImPlot::PlotShaded(labelId, &xs[0], &ys1[0], &ys2[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys1 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys1, ys1, JNI_FALSE);
@@ -6528,38 +5408,31 @@ public final class ImPlot {
     // values
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBars(final String labelId, final short[] values) {
         nPlotBars(labelId, values);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final short[] values, final double barWidth) {
-        nPlotBars(labelId, values, barWidth);
+    public static void plotBars(final String labelId, final short[] values, final double barSize) {
+        nPlotBars(labelId, values, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final short[] values, final double barWidth, final double xstart) {
-        nPlotBars(labelId, values, barWidth, xstart);
+    public static void plotBars(final String labelId, final short[] values, final double barSize, final double shift) {
+        nPlotBars(labelId, values, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final short[] values, final double barWidth, final double xstart, final int flags) {
-        nPlotBars(labelId, values, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final short[] values, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBars(labelId, values, barWidth, xstart, flags, offset);
+    public static void plotBars(final String labelId, final short[] values, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBars(labelId, values, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, short[] values); /*MANUAL
@@ -6570,71 +5443,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, short[] values, double barWidth); /*MANUAL
+    private static native void nPlotBars(String labelId, short[] values, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, short[] values, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBars(String labelId, short[] values, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, short[] values, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, short[] values, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, short[] values, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBars(final String labelId, final int[] values) {
         nPlotBars(labelId, values);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final int[] values, final double barWidth) {
-        nPlotBars(labelId, values, barWidth);
+    public static void plotBars(final String labelId, final int[] values, final double barSize) {
+        nPlotBars(labelId, values, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final int[] values, final double barWidth, final double xstart) {
-        nPlotBars(labelId, values, barWidth, xstart);
+    public static void plotBars(final String labelId, final int[] values, final double barSize, final double shift) {
+        nPlotBars(labelId, values, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final int[] values, final double barWidth, final double xstart, final int flags) {
-        nPlotBars(labelId, values, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final int[] values, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBars(labelId, values, barWidth, xstart, flags, offset);
+    public static void plotBars(final String labelId, final int[] values, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBars(labelId, values, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, int[] values); /*MANUAL
@@ -6645,71 +5503,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, int[] values, double barWidth); /*MANUAL
+    private static native void nPlotBars(String labelId, int[] values, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, int[] values, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBars(String labelId, int[] values, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, int[] values, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, int[] values, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, int[] values, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBars(final String labelId, final long[] values) {
         nPlotBars(labelId, values);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final long[] values, final double barWidth) {
-        nPlotBars(labelId, values, barWidth);
+    public static void plotBars(final String labelId, final long[] values, final double barSize) {
+        nPlotBars(labelId, values, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final long[] values, final double barWidth, final double xstart) {
-        nPlotBars(labelId, values, barWidth, xstart);
+    public static void plotBars(final String labelId, final long[] values, final double barSize, final double shift) {
+        nPlotBars(labelId, values, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final long[] values, final double barWidth, final double xstart, final int flags) {
-        nPlotBars(labelId, values, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final long[] values, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBars(labelId, values, barWidth, xstart, flags, offset);
+    public static void plotBars(final String labelId, final long[] values, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBars(labelId, values, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, long[] values); /*MANUAL
@@ -6720,71 +5563,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, long[] values, double barWidth); /*MANUAL
+    private static native void nPlotBars(String labelId, long[] values, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, long[] values, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBars(String labelId, long[] values, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, long[] values, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, long[] values, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, long[] values, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBars(final String labelId, final float[] values) {
         nPlotBars(labelId, values);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final float[] values, final double barWidth) {
-        nPlotBars(labelId, values, barWidth);
+    public static void plotBars(final String labelId, final float[] values, final double barSize) {
+        nPlotBars(labelId, values, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final float[] values, final double barWidth, final double xstart) {
-        nPlotBars(labelId, values, barWidth, xstart);
+    public static void plotBars(final String labelId, final float[] values, final double barSize, final double shift) {
+        nPlotBars(labelId, values, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final float[] values, final double barWidth, final double xstart, final int flags) {
-        nPlotBars(labelId, values, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final float[] values, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBars(labelId, values, barWidth, xstart, flags, offset);
+    public static void plotBars(final String labelId, final float[] values, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBars(labelId, values, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, float[] values); /*MANUAL
@@ -6795,71 +5623,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, float[] values, double barWidth); /*MANUAL
+    private static native void nPlotBars(String labelId, float[] values, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, float[] values, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBars(String labelId, float[] values, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, float[] values, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, float[] values, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, float[] values, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBars(final String labelId, final double[] values) {
         nPlotBars(labelId, values);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final double[] values, final double barWidth) {
-        nPlotBars(labelId, values, barWidth);
+    public static void plotBars(final String labelId, final double[] values, final double barSize) {
+        nPlotBars(labelId, values, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final double[] values, final double barWidth, final double xstart) {
-        nPlotBars(labelId, values, barWidth, xstart);
+    public static void plotBars(final String labelId, final double[] values, final double barSize, final double shift) {
+        nPlotBars(labelId, values, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBars(final String labelId, final double[] values, final double barWidth, final double xstart, final int flags) {
-        nPlotBars(labelId, values, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final double[] values, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBars(labelId, values, barWidth, xstart, flags, offset);
+    public static void plotBars(final String labelId, final double[] values, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBars(labelId, values, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, double[] values); /*MANUAL
@@ -6870,71 +5683,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, double[] values, double barWidth); /*MANUAL
+    private static native void nPlotBars(String labelId, double[] values, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, double[] values, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBars(String labelId, double[] values, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, double[] values, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, double[] values, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, double[] values, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], LEN(values), barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], LEN(values), barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBarsV(final String labelId, final short[] values, final int count) {
         nPlotBarsV(labelId, values, count);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final short[] values, final int count, final double barWidth) {
-        nPlotBarsV(labelId, values, count, barWidth);
+    public static void plotBarsV(final String labelId, final short[] values, final int count, final double barSize) {
+        nPlotBarsV(labelId, values, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final short[] values, final int count, final double barWidth, final double xstart) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart);
+    public static void plotBarsV(final String labelId, final short[] values, final int count, final double barSize, final double shift) {
+        nPlotBarsV(labelId, values, count, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final short[] values, final int count, final double barWidth, final double xstart, final int flags) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final short[] values, final int count, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags, offset);
+    public static void plotBarsV(final String labelId, final short[] values, final int count, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, values, count, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarsV(String labelId, short[] values, int count); /*MANUAL
@@ -6945,71 +5743,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, short[] values, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, short[] values, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, short[] values, int count, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBarsV(String labelId, short[] values, int count, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, short[] values, int count, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, short[] values, int count, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, short[] values, int count, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBarsV(final String labelId, final int[] values, final int count) {
         nPlotBarsV(labelId, values, count);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final int[] values, final int count, final double barWidth) {
-        nPlotBarsV(labelId, values, count, barWidth);
+    public static void plotBarsV(final String labelId, final int[] values, final int count, final double barSize) {
+        nPlotBarsV(labelId, values, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final int[] values, final int count, final double barWidth, final double xstart) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart);
+    public static void plotBarsV(final String labelId, final int[] values, final int count, final double barSize, final double shift) {
+        nPlotBarsV(labelId, values, count, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final int[] values, final int count, final double barWidth, final double xstart, final int flags) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final int[] values, final int count, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags, offset);
+    public static void plotBarsV(final String labelId, final int[] values, final int count, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, values, count, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarsV(String labelId, int[] values, int count); /*MANUAL
@@ -7020,71 +5803,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, int[] values, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, int[] values, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, int[] values, int count, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBarsV(String labelId, int[] values, int count, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, int[] values, int count, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, int[] values, int count, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, int[] values, int count, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBarsV(final String labelId, final long[] values, final int count) {
         nPlotBarsV(labelId, values, count);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final long[] values, final int count, final double barWidth) {
-        nPlotBarsV(labelId, values, count, barWidth);
+    public static void plotBarsV(final String labelId, final long[] values, final int count, final double barSize) {
+        nPlotBarsV(labelId, values, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final long[] values, final int count, final double barWidth, final double xstart) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart);
+    public static void plotBarsV(final String labelId, final long[] values, final int count, final double barSize, final double shift) {
+        nPlotBarsV(labelId, values, count, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final long[] values, final int count, final double barWidth, final double xstart, final int flags) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final long[] values, final int count, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags, offset);
+    public static void plotBarsV(final String labelId, final long[] values, final int count, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, values, count, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarsV(String labelId, long[] values, int count); /*MANUAL
@@ -7095,71 +5863,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, long[] values, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, long[] values, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, long[] values, int count, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBarsV(String labelId, long[] values, int count, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, long[] values, int count, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, long[] values, int count, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, long[] values, int count, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBarsV(final String labelId, final float[] values, final int count) {
         nPlotBarsV(labelId, values, count);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final float[] values, final int count, final double barWidth) {
-        nPlotBarsV(labelId, values, count, barWidth);
+    public static void plotBarsV(final String labelId, final float[] values, final int count, final double barSize) {
+        nPlotBarsV(labelId, values, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final float[] values, final int count, final double barWidth, final double xstart) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart);
+    public static void plotBarsV(final String labelId, final float[] values, final int count, final double barSize, final double shift) {
+        nPlotBarsV(labelId, values, count, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final float[] values, final int count, final double barWidth, final double xstart, final int flags) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final float[] values, final int count, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags, offset);
+    public static void plotBarsV(final String labelId, final float[] values, final int count, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, values, count, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarsV(String labelId, float[] values, int count); /*MANUAL
@@ -7170,71 +5923,56 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, float[] values, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, float[] values, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, float[] values, int count, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBarsV(String labelId, float[] values, int count, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, float[] values, int count, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, float[] values, int count, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, float[] values, int count, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     public static void plotBarsV(final String labelId, final double[] values, final int count) {
         nPlotBarsV(labelId, values, count);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final double[] values, final int count, final double barWidth) {
-        nPlotBarsV(labelId, values, count, barWidth);
+    public static void plotBarsV(final String labelId, final double[] values, final int count, final double barSize) {
+        nPlotBarsV(labelId, values, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final double[] values, final int count, final double barWidth, final double xstart) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart);
+    public static void plotBarsV(final String labelId, final double[] values, final int count, final double barSize, final double shift) {
+        nPlotBarsV(labelId, values, count, barSize, shift);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
-    public static void plotBarsV(final String labelId, final double[] values, final int count, final double barWidth, final double xstart, final int flags) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final double[] values, final int count, final double barWidth, final double xstart, final int flags, final int offset) {
-        nPlotBarsV(labelId, values, count, barWidth, xstart, flags, offset);
+    public static void plotBarsV(final String labelId, final double[] values, final int count, final double barSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, values, count, barSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarsV(String labelId, double[] values, int count); /*MANUAL
@@ -7245,34 +5983,26 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, double[] values, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, double[] values, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, double[] values, int count, double barWidth, double xstart); /*MANUAL
+    private static native void nPlotBarsV(String labelId, double[] values, int count, double barSize, double shift); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, double[] values, int count, double barWidth, double xstart, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, double[] values, int count, double barSize, double shift, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, double[] values, int count, double barWidth, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &values[0], count, barWidth, xstart, flags, offset);
+        ImPlot::PlotBars(labelId, &values[0], count, barSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -7280,24 +6010,17 @@ public final class ImPlot {
     // xs,ys
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
     public static void plotBars(final String labelId, final short[] xs, final short[] ys) {
         nPlotBars(labelId, xs, ys);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBars(final String labelId, final short[] xs, final short[] ys, final int flags) {
-        nPlotBars(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final short[] xs, final short[] ys, final int flags, final int offset) {
-        nPlotBars(labelId, xs, ys, flags, offset);
+    public static void plotBars(final String labelId, final short[] xs, final short[] ys, final ImPlotSpec spec) {
+        nPlotBars(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -7310,45 +6033,28 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, short[] xs, short[] ys, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, short[] xs, short[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, short[] xs, short[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
     public static void plotBars(final String labelId, final int[] xs, final int[] ys) {
         nPlotBars(labelId, xs, ys);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBars(final String labelId, final int[] xs, final int[] ys, final int flags) {
-        nPlotBars(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final int[] xs, final int[] ys, final int flags, final int offset) {
-        nPlotBars(labelId, xs, ys, flags, offset);
+    public static void plotBars(final String labelId, final int[] xs, final int[] ys, final ImPlotSpec spec) {
+        nPlotBars(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -7361,45 +6067,28 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, int[] xs, int[] ys, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, int[] xs, int[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, int[] xs, int[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
     public static void plotBars(final String labelId, final long[] xs, final long[] ys) {
         nPlotBars(labelId, xs, ys);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBars(final String labelId, final long[] xs, final long[] ys, final int flags) {
-        nPlotBars(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final long[] xs, final long[] ys, final int flags, final int offset) {
-        nPlotBars(labelId, xs, ys, flags, offset);
+    public static void plotBars(final String labelId, final long[] xs, final long[] ys, final ImPlotSpec spec) {
+        nPlotBars(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -7412,45 +6101,28 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, long[] xs, long[] ys, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, long[] xs, long[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, long[] xs, long[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
     public static void plotBars(final String labelId, final float[] xs, final float[] ys) {
         nPlotBars(labelId, xs, ys);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBars(final String labelId, final float[] xs, final float[] ys, final int flags) {
-        nPlotBars(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final float[] xs, final float[] ys, final int flags, final int offset) {
-        nPlotBars(labelId, xs, ys, flags, offset);
+    public static void plotBars(final String labelId, final float[] xs, final float[] ys, final ImPlotSpec spec) {
+        nPlotBars(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -7463,45 +6135,28 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, float[] xs, float[] ys, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, float[] xs, float[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, float[] xs, float[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
     public static void plotBars(final String labelId, final double[] xs, final double[] ys) {
         nPlotBars(labelId, xs, ys);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBars(final String labelId, final double[] xs, final double[] ys, final int flags) {
-        nPlotBars(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBars(final String labelId, final double[] xs, final double[] ys, final int flags, final int offset) {
-        nPlotBars(labelId, xs, ys, flags, offset);
+    public static void plotBars(final String labelId, final double[] xs, final double[] ys, final ImPlotSpec spec) {
+        nPlotBars(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotBars(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -7514,531 +6169,351 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBars(String labelId, double[] xs, double[] ys, int flags); /*MANUAL
+    private static native void nPlotBars(String labelId, double[] xs, double[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBars(String labelId, double[] xs, double[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), 0.67, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, barWidth);
+    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags);
+    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, barSize, spec.ptr);
     }
 
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, double barWidth, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, double barSize, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, double barWidth, int flags, int offset); /*MANUAL
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, barSize);
+    }
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, barSize, spec.ptr);
+    }
+
+    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, double barSize); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, double barSize, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, barSize);
+    }
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, barSize, spec.ptr);
+    }
+
+    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, double barSize); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, double barSize, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, barSize);
+    }
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, barSize, spec.ptr);
+    }
+
+    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, double barSize); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, double barSize, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, barSize);
+    }
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, barSize, spec.ptr);
+    }
+
+    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, double barSize); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, double barSize, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barSize, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final int count, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, count, barSize);
+    }
+
+    /**
+     * Plots a vertical bar graph. #bar_size is in X units.
+     */
+    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final int count, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, count, barSize, spec.ptr);
+    }
+
+    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, barWidth);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, double barWidth); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, double barWidth, int flags); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, barWidth);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, double barWidth); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, double barWidth, int flags); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, barWidth);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, double barWidth); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, double barWidth, int flags); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, barWidth);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, double barWidth); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, double barWidth, int flags); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], LEN(xs), barWidth, flags, offset);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final int count, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final int count, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags);
-    }
-
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final int count, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, int count, double barSize, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, int count, double barWidth, int flags); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, short[] xs, short[] ys, int count, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final int count, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth);
+    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final int count, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final int count, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags);
+    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final int count, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, count, barSize, spec.ptr);
     }
 
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final int[] xs, final int[] ys, final int count, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, int count, double barWidth, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, int count, double barSize, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, int[] xs, int[] ys, int count, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final int count, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth);
+    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final int count, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final int count, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags);
+    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final int count, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, count, barSize, spec.ptr);
     }
 
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final long[] xs, final long[] ys, final int count, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, int count, double barWidth, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, int count, double barSize, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, long[] xs, long[] ys, int count, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final int count, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth);
+    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final int count, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final int count, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags);
+    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final int count, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, count, barSize, spec.ptr);
     }
 
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final float[] xs, final float[] ys, final int count, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, int count, double barWidth, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, int count, double barSize, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, float[] xs, float[] ys, int count, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final int count, final double barWidth) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth);
+    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final int count, final double barSize) {
+        nPlotBarsV(labelId, xs, ys, count, barSize);
     }
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
-    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final int count, final double barWidth, final int flags) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags);
+    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final int count, final double barSize, final ImPlotSpec spec) {
+        nPlotBarsV(labelId, xs, ys, count, barSize, spec.ptr);
     }
 
-    /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
-     */
-    public static void plotBarsV(final String labelId, final double[] xs, final double[] ys, final int count, final double barWidth, final int flags, final int offset) {
-        nPlotBarsV(labelId, xs, ys, count, barWidth, flags, offset);
-    }
-
-    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, int count, double barWidth); /*MANUAL
+    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, int count, double barSize); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, int count, double barWidth, int flags); /*MANUAL
+    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, int count, double barSize, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotBarsV(String labelId, double[] xs, double[] ys, int count, double barWidth, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barWidth, flags, offset);
+        ImPlot::PlotBars(labelId, &xs[0], &ys[0], count, barSize, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -8068,8 +6543,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroups(final String[] labelIds, final short[] values, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, flags);
+    public static void plotBarGroups(final String[] labelIds, final short[] values, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, short[] values, int groupCount); /*MANUAL
@@ -8120,7 +6595,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, short[] values, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, short[] values, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8128,7 +6603,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8160,8 +6635,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroups(final String[] labelIds, final int[] values, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, flags);
+    public static void plotBarGroups(final String[] labelIds, final int[] values, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, int[] values, int groupCount); /*MANUAL
@@ -8212,7 +6687,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, int[] values, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, int[] values, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8220,7 +6695,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8252,8 +6727,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroups(final String[] labelIds, final long[] values, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, flags);
+    public static void plotBarGroups(final String[] labelIds, final long[] values, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, long[] values, int groupCount); /*MANUAL
@@ -8304,7 +6779,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, long[] values, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, long[] values, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8312,7 +6787,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8344,8 +6819,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroups(final String[] labelIds, final float[] values, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, flags);
+    public static void plotBarGroups(final String[] labelIds, final float[] values, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, float[] values, int groupCount); /*MANUAL
@@ -8396,7 +6871,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, float[] values, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, float[] values, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8404,7 +6879,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8436,8 +6911,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroups(final String[] labelIds, final double[] values, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, flags);
+    public static void plotBarGroups(final String[] labelIds, final double[] values, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroups(labelIds, labelIds.length, values, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, double[] values, int groupCount); /*MANUAL
@@ -8488,7 +6963,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, double[] values, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroups(String[] obj_labelIds, int labelIdsCount, double[] values, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8496,7 +6971,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], LEN(values), groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8528,8 +7003,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroupsV(final String[] labelIds, final short[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, flags);
+    public static void plotBarGroupsV(final String[] labelIds, final short[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, short[] values, int itemCount, int groupCount); /*MANUAL
@@ -8580,7 +7055,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, short[] values, int itemCount, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, short[] values, int itemCount, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8588,7 +7063,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8620,8 +7095,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroupsV(final String[] labelIds, final int[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, flags);
+    public static void plotBarGroupsV(final String[] labelIds, final int[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, int[] values, int itemCount, int groupCount); /*MANUAL
@@ -8672,7 +7147,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, int[] values, int itemCount, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, int[] values, int itemCount, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8680,7 +7155,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8712,8 +7187,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroupsV(final String[] labelIds, final long[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, flags);
+    public static void plotBarGroupsV(final String[] labelIds, final long[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, long[] values, int itemCount, int groupCount); /*MANUAL
@@ -8764,7 +7239,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, long[] values, int itemCount, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, long[] values, int itemCount, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8772,7 +7247,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8804,8 +7279,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroupsV(final String[] labelIds, final float[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, flags);
+    public static void plotBarGroupsV(final String[] labelIds, final float[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, float[] values, int itemCount, int groupCount); /*MANUAL
@@ -8856,7 +7331,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, float[] values, int itemCount, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, float[] values, int itemCount, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8864,7 +7339,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8896,8 +7371,8 @@ public final class ImPlot {
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
-    public static void plotBarGroupsV(final String[] labelIds, final double[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final int flags) {
-        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, flags);
+    public static void plotBarGroupsV(final String[] labelIds, final double[] values, final int itemCount, final int groupCount, final double groupSize, final double shift, final ImPlotSpec spec) {
+        nPlotBarGroupsV(labelIds, labelIds.length, values, itemCount, groupCount, groupSize, shift, spec.ptr);
     }
 
     private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, double[] values, int itemCount, int groupCount); /*MANUAL
@@ -8948,7 +7423,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, double[] values, int itemCount, int groupCount, double groupSize, double shift, int flags); /*MANUAL
+    private static native void nPlotBarGroupsV(String[] obj_labelIds, int labelIdsCount, double[] values, int itemCount, int groupCount, double groupSize, double shift, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -8956,7 +7431,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, flags);
+        ImPlot::PlotBarGroups(labelIds, &values[0], itemCount, groupCount, groupSize, shift, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -8974,15 +7449,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, err, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, flags, offset);
+    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, err, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] err); /*MANUAL
@@ -8997,24 +7465,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] err, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] err, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] err, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9031,15 +7487,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] err, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, err, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] err, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, flags, offset);
+    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] err, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, err, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] err); /*MANUAL
@@ -9054,24 +7503,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] err, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] err, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] err, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9088,15 +7525,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] err, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, err, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] err, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, flags, offset);
+    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] err, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, err, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] err); /*MANUAL
@@ -9111,24 +7541,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] err, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] err, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] err, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9145,15 +7563,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] err, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, err, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] err, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, flags, offset);
+    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] err, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, err, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] err); /*MANUAL
@@ -9168,24 +7579,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] err, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] err, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] err, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9202,15 +7601,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] err, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, err, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] err, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, err, flags, offset);
+    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] err, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, err, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] err); /*MANUAL
@@ -9225,24 +7617,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] err, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] err, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] err, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9259,15 +7639,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, err, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, short[] xs, short[] ys, short[] err, int count); /*MANUAL
@@ -9282,24 +7655,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, short[] xs, short[] ys, short[] err, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, short[] xs, short[] ys, short[] err, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, short[] xs, short[] ys, short[] err, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9316,15 +7677,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final int[] xs, final int[] ys, final int[] err, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final int[] xs, final int[] ys, final int[] err, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final int[] xs, final int[] ys, final int[] err, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, err, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, int[] xs, int[] ys, int[] err, int count); /*MANUAL
@@ -9339,24 +7693,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, int[] xs, int[] ys, int[] err, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, int[] xs, int[] ys, int[] err, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, int[] xs, int[] ys, int[] err, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9373,15 +7715,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final long[] xs, final long[] ys, final long[] err, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final long[] xs, final long[] ys, final long[] err, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final long[] xs, final long[] ys, final long[] err, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, err, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, long[] xs, long[] ys, long[] err, int count); /*MANUAL
@@ -9396,24 +7731,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, long[] xs, long[] ys, long[] err, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, long[] xs, long[] ys, long[] err, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, long[] xs, long[] ys, long[] err, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9430,15 +7753,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final float[] xs, final float[] ys, final float[] err, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final float[] xs, final float[] ys, final float[] err, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final float[] xs, final float[] ys, final float[] err, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, err, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, float[] xs, float[] ys, float[] err, int count); /*MANUAL
@@ -9453,24 +7769,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, float[] xs, float[] ys, float[] err, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, float[] xs, float[] ys, float[] err, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, float[] xs, float[] ys, float[] err, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9487,15 +7791,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final double[] xs, final double[] ys, final double[] err, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final double[] xs, final double[] ys, final double[] err, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, err, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final double[] xs, final double[] ys, final double[] err, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, err, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, double[] xs, double[] ys, double[] err, int count); /*MANUAL
@@ -9510,24 +7807,12 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, double[] xs, double[] ys, double[] err, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, double[] xs, double[] ys, double[] err, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, double[] xs, double[] ys, double[] err, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto err = obj_err == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_err, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &err[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9544,15 +7829,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags, offset);
+    public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos); /*MANUAL
@@ -9569,27 +7847,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9607,15 +7871,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags, offset);
+    public static void plotErrorBars(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos); /*MANUAL
@@ -9632,27 +7889,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9670,15 +7913,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags, offset);
+    public static void plotErrorBars(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos); /*MANUAL
@@ -9695,27 +7931,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9733,15 +7955,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags, offset);
+    public static void plotErrorBars(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos); /*MANUAL
@@ -9758,27 +7973,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9796,15 +7997,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int flags) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int flags, final int offset) {
-        nPlotErrorBars(labelId, xs, ys, neg, pos, flags, offset);
+    public static void plotErrorBars(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final ImPlotSpec spec) {
+        nPlotErrorBars(labelId, xs, ys, neg, pos, spec.ptr);
     }
 
     private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos); /*MANUAL
@@ -9821,27 +8015,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int flags); /*MANUAL
+    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBars(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9859,15 +8039,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int count); /*MANUAL
@@ -9884,27 +8057,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, short[] xs, short[] ys, short[] neg, short[] pos, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9922,15 +8081,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final int[] xs, final int[] ys, final int[] neg, final int[] pos, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int count); /*MANUAL
@@ -9947,27 +8099,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, int[] xs, int[] ys, int[] neg, int[] pos, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -9985,15 +8123,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final long[] xs, final long[] ys, final long[] neg, final long[] pos, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int count); /*MANUAL
@@ -10010,27 +8141,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, long[] xs, long[] ys, long[] neg, long[] pos, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -10048,15 +8165,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final float[] xs, final float[] ys, final float[] neg, final float[] pos, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int count); /*MANUAL
@@ -10073,27 +8183,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, float[] xs, float[] ys, float[] neg, float[] pos, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -10111,15 +8207,8 @@ public final class ImPlot {
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
-    public static void plotErrorBarsV(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int count, final int flags) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags);
-    }
-
-    /**
-     * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-     */
-    public static void plotErrorBarsV(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int count, final int flags, final int offset) {
-        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, flags, offset);
+    public static void plotErrorBarsV(final String labelId, final double[] xs, final double[] ys, final double[] neg, final double[] pos, final int count, final ImPlotSpec spec) {
+        nPlotErrorBarsV(labelId, xs, ys, neg, pos, count, spec.ptr);
     }
 
     private static native void nPlotErrorBarsV(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int count); /*MANUAL
@@ -10136,27 +8225,13 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    private static native void nPlotErrorBarsV(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int count, int flags); /*MANUAL
+    private static native void nPlotErrorBarsV(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
         auto neg = obj_neg == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
         auto pos = obj_pos == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-        if (neg != NULL) env->ReleasePrimitiveArrayCritical(obj_neg, neg, JNI_FALSE);
-        if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
-    */
-
-    private static native void nPlotErrorBarsV(String labelId, double[] xs, double[] ys, double[] neg, double[] pos, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto neg = obj_neg == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_neg, JNI_FALSE);
-        auto pos = obj_pos == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_pos, JNI_FALSE);
-        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, flags, offset);
+        ImPlot::PlotErrorBars(labelId, &xs[0], &ys[0], &neg[0], &pos[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -10176,36 +8251,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final short[] values, final double yRef) {
-        nPlotStems(labelId, values, yRef);
+    public static void plotStems(final String labelId, final short[] values, final double ref) {
+        nPlotStems(labelId, values, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final short[] values, final double yRef, final double xscale) {
-        nPlotStems(labelId, values, yRef, xscale);
+    public static void plotStems(final String labelId, final short[] values, final double ref, final double scale) {
+        nPlotStems(labelId, values, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final short[] values, final double yRef, final double xscale, final double xstart) {
-        nPlotStems(labelId, values, yRef, xscale, xstart);
+    public static void plotStems(final String labelId, final short[] values, final double ref, final double scale, final double start) {
+        nPlotStems(labelId, values, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final short[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final short[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotStems(final String labelId, final short[] values, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStems(labelId, values, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, short[] values); /*MANUAL
@@ -10216,42 +8284,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, short[] values, double yRef); /*MANUAL
+    private static native void nPlotStems(String labelId, short[] values, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, short[] values, double yRef, double xscale); /*MANUAL
+    private static native void nPlotStems(String labelId, short[] values, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, short[] values, double yRef, double xscale, double xstart); /*MANUAL
+    private static native void nPlotStems(String labelId, short[] values, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, short[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, short[] values, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, short[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10266,36 +8326,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final int[] values, final double yRef) {
-        nPlotStems(labelId, values, yRef);
+    public static void plotStems(final String labelId, final int[] values, final double ref) {
+        nPlotStems(labelId, values, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final int[] values, final double yRef, final double xscale) {
-        nPlotStems(labelId, values, yRef, xscale);
+    public static void plotStems(final String labelId, final int[] values, final double ref, final double scale) {
+        nPlotStems(labelId, values, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final int[] values, final double yRef, final double xscale, final double xstart) {
-        nPlotStems(labelId, values, yRef, xscale, xstart);
+    public static void plotStems(final String labelId, final int[] values, final double ref, final double scale, final double start) {
+        nPlotStems(labelId, values, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final int[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final int[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotStems(final String labelId, final int[] values, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStems(labelId, values, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, int[] values); /*MANUAL
@@ -10306,42 +8359,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, int[] values, double yRef); /*MANUAL
+    private static native void nPlotStems(String labelId, int[] values, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, int[] values, double yRef, double xscale); /*MANUAL
+    private static native void nPlotStems(String labelId, int[] values, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, int[] values, double yRef, double xscale, double xstart); /*MANUAL
+    private static native void nPlotStems(String labelId, int[] values, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, int[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, int[] values, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, int[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10356,36 +8401,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final long[] values, final double yRef) {
-        nPlotStems(labelId, values, yRef);
+    public static void plotStems(final String labelId, final long[] values, final double ref) {
+        nPlotStems(labelId, values, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final long[] values, final double yRef, final double xscale) {
-        nPlotStems(labelId, values, yRef, xscale);
+    public static void plotStems(final String labelId, final long[] values, final double ref, final double scale) {
+        nPlotStems(labelId, values, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final long[] values, final double yRef, final double xscale, final double xstart) {
-        nPlotStems(labelId, values, yRef, xscale, xstart);
+    public static void plotStems(final String labelId, final long[] values, final double ref, final double scale, final double start) {
+        nPlotStems(labelId, values, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final long[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final long[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotStems(final String labelId, final long[] values, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStems(labelId, values, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, long[] values); /*MANUAL
@@ -10396,42 +8434,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, long[] values, double yRef); /*MANUAL
+    private static native void nPlotStems(String labelId, long[] values, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, long[] values, double yRef, double xscale); /*MANUAL
+    private static native void nPlotStems(String labelId, long[] values, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, long[] values, double yRef, double xscale, double xstart); /*MANUAL
+    private static native void nPlotStems(String labelId, long[] values, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, long[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, long[] values, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, long[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10446,36 +8476,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final float[] values, final double yRef) {
-        nPlotStems(labelId, values, yRef);
+    public static void plotStems(final String labelId, final float[] values, final double ref) {
+        nPlotStems(labelId, values, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final float[] values, final double yRef, final double xscale) {
-        nPlotStems(labelId, values, yRef, xscale);
+    public static void plotStems(final String labelId, final float[] values, final double ref, final double scale) {
+        nPlotStems(labelId, values, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final float[] values, final double yRef, final double xscale, final double xstart) {
-        nPlotStems(labelId, values, yRef, xscale, xstart);
+    public static void plotStems(final String labelId, final float[] values, final double ref, final double scale, final double start) {
+        nPlotStems(labelId, values, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final float[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final float[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotStems(final String labelId, final float[] values, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStems(labelId, values, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, float[] values); /*MANUAL
@@ -10486,42 +8509,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, float[] values, double yRef); /*MANUAL
+    private static native void nPlotStems(String labelId, float[] values, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, float[] values, double yRef, double xscale); /*MANUAL
+    private static native void nPlotStems(String labelId, float[] values, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, float[] values, double yRef, double xscale, double xstart); /*MANUAL
+    private static native void nPlotStems(String labelId, float[] values, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, float[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, float[] values, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, float[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10536,36 +8551,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final double[] values, final double yRef) {
-        nPlotStems(labelId, values, yRef);
+    public static void plotStems(final String labelId, final double[] values, final double ref) {
+        nPlotStems(labelId, values, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final double[] values, final double yRef, final double xscale) {
-        nPlotStems(labelId, values, yRef, xscale);
+    public static void plotStems(final String labelId, final double[] values, final double ref, final double scale) {
+        nPlotStems(labelId, values, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final double[] values, final double yRef, final double xscale, final double xstart) {
-        nPlotStems(labelId, values, yRef, xscale, xstart);
+    public static void plotStems(final String labelId, final double[] values, final double ref, final double scale, final double start) {
+        nPlotStems(labelId, values, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final double[] values, final double yRef, final double xscale, final double xstart, final int flags) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final double[] values, final double yRef, final double xscale, final double xstart, final int flags, final int offset) {
-        nPlotStems(labelId, values, yRef, xscale, xstart, flags, offset);
+    public static void plotStems(final String labelId, final double[] values, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStems(labelId, values, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, double[] values); /*MANUAL
@@ -10576,42 +8584,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, double[] values, double yRef); /*MANUAL
+    private static native void nPlotStems(String labelId, double[] values, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, double[] values, double yRef, double xscale); /*MANUAL
+    private static native void nPlotStems(String labelId, double[] values, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, double[] values, double yRef, double xscale, double xstart); /*MANUAL
+    private static native void nPlotStems(String labelId, double[] values, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, double[] values, double yRef, double xscale, double xstart, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, double[] values, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, double[] values, double yRef, double xscale, double xstart, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], LEN(values), yRef, xscale, xstart, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], LEN(values), ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10626,36 +8626,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final short[] values, final int count, final double yRef) {
-        nPlotStemsV(labelId, values, count, yRef);
+    public static void plotStemsV(final String labelId, final short[] values, final int count, final double ref) {
+        nPlotStemsV(labelId, values, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final short[] values, final int count, final double yRef, final double scale) {
-        nPlotStemsV(labelId, values, count, yRef, scale);
+    public static void plotStemsV(final String labelId, final short[] values, final int count, final double ref, final double scale) {
+        nPlotStemsV(labelId, values, count, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final short[] values, final int count, final double yRef, final double scale, final double start) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start);
+    public static void plotStemsV(final String labelId, final short[] values, final int count, final double ref, final double scale, final double start) {
+        nPlotStemsV(labelId, values, count, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final short[] values, final int count, final double yRef, final double scale, final double start, final int flags) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final short[] values, final int count, final double yRef, final double scale, final double start, final int flags, final int offset) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags, offset);
+    public static void plotStemsV(final String labelId, final short[] values, final int count, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, values, count, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, short[] values, int count); /*MANUAL
@@ -10666,42 +8659,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, short[] values, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, short[] values, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        ImPlot::PlotStems(labelId, &values[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, short[] values, int count, double yRef, double scale); /*MANUAL
+    private static native void nPlotStemsV(String labelId, short[] values, int count, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, short[] values, int count, double yRef, double scale, double start); /*MANUAL
+    private static native void nPlotStemsV(String labelId, short[] values, int count, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, short[] values, int count, double yRef, double scale, double start, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, short[] values, int count, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, short[] values, int count, double yRef, double scale, double start, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10716,36 +8701,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final int[] values, final int count, final double yRef) {
-        nPlotStemsV(labelId, values, count, yRef);
+    public static void plotStemsV(final String labelId, final int[] values, final int count, final double ref) {
+        nPlotStemsV(labelId, values, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final int[] values, final int count, final double yRef, final double scale) {
-        nPlotStemsV(labelId, values, count, yRef, scale);
+    public static void plotStemsV(final String labelId, final int[] values, final int count, final double ref, final double scale) {
+        nPlotStemsV(labelId, values, count, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final int[] values, final int count, final double yRef, final double scale, final double start) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start);
+    public static void plotStemsV(final String labelId, final int[] values, final int count, final double ref, final double scale, final double start) {
+        nPlotStemsV(labelId, values, count, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final int[] values, final int count, final double yRef, final double scale, final double start, final int flags) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final int[] values, final int count, final double yRef, final double scale, final double start, final int flags, final int offset) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags, offset);
+    public static void plotStemsV(final String labelId, final int[] values, final int count, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, values, count, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, int[] values, int count); /*MANUAL
@@ -10756,42 +8734,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, int[] values, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, int[] values, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        ImPlot::PlotStems(labelId, &values[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, int[] values, int count, double yRef, double scale); /*MANUAL
+    private static native void nPlotStemsV(String labelId, int[] values, int count, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, int[] values, int count, double yRef, double scale, double start); /*MANUAL
+    private static native void nPlotStemsV(String labelId, int[] values, int count, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, int[] values, int count, double yRef, double scale, double start, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, int[] values, int count, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, int[] values, int count, double yRef, double scale, double start, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10806,36 +8776,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final long[] values, final int count, final double yRef) {
-        nPlotStemsV(labelId, values, count, yRef);
+    public static void plotStemsV(final String labelId, final long[] values, final int count, final double ref) {
+        nPlotStemsV(labelId, values, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final long[] values, final int count, final double yRef, final double scale) {
-        nPlotStemsV(labelId, values, count, yRef, scale);
+    public static void plotStemsV(final String labelId, final long[] values, final int count, final double ref, final double scale) {
+        nPlotStemsV(labelId, values, count, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final long[] values, final int count, final double yRef, final double scale, final double start) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start);
+    public static void plotStemsV(final String labelId, final long[] values, final int count, final double ref, final double scale, final double start) {
+        nPlotStemsV(labelId, values, count, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final long[] values, final int count, final double yRef, final double scale, final double start, final int flags) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final long[] values, final int count, final double yRef, final double scale, final double start, final int flags, final int offset) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags, offset);
+    public static void plotStemsV(final String labelId, final long[] values, final int count, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, values, count, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, long[] values, int count); /*MANUAL
@@ -10846,42 +8809,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, long[] values, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, long[] values, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        ImPlot::PlotStems(labelId, &values[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, long[] values, int count, double yRef, double scale); /*MANUAL
+    private static native void nPlotStemsV(String labelId, long[] values, int count, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, long[] values, int count, double yRef, double scale, double start); /*MANUAL
+    private static native void nPlotStemsV(String labelId, long[] values, int count, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, long[] values, int count, double yRef, double scale, double start, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, long[] values, int count, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, long[] values, int count, double yRef, double scale, double start, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10896,36 +8851,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final float[] values, final int count, final double yRef) {
-        nPlotStemsV(labelId, values, count, yRef);
+    public static void plotStemsV(final String labelId, final float[] values, final int count, final double ref) {
+        nPlotStemsV(labelId, values, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final float[] values, final int count, final double yRef, final double scale) {
-        nPlotStemsV(labelId, values, count, yRef, scale);
+    public static void plotStemsV(final String labelId, final float[] values, final int count, final double ref, final double scale) {
+        nPlotStemsV(labelId, values, count, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final float[] values, final int count, final double yRef, final double scale, final double start) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start);
+    public static void plotStemsV(final String labelId, final float[] values, final int count, final double ref, final double scale, final double start) {
+        nPlotStemsV(labelId, values, count, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final float[] values, final int count, final double yRef, final double scale, final double start, final int flags) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final float[] values, final int count, final double yRef, final double scale, final double start, final int flags, final int offset) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags, offset);
+    public static void plotStemsV(final String labelId, final float[] values, final int count, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, values, count, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, float[] values, int count); /*MANUAL
@@ -10936,42 +8884,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, float[] values, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, float[] values, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        ImPlot::PlotStems(labelId, &values[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, float[] values, int count, double yRef, double scale); /*MANUAL
+    private static native void nPlotStemsV(String labelId, float[] values, int count, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, float[] values, int count, double yRef, double scale, double start); /*MANUAL
+    private static native void nPlotStemsV(String labelId, float[] values, int count, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, float[] values, int count, double yRef, double scale, double start, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, float[] values, int count, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, float[] values, int count, double yRef, double scale, double start, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -10986,36 +8926,29 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final double[] values, final int count, final double yRef) {
-        nPlotStemsV(labelId, values, count, yRef);
+    public static void plotStemsV(final String labelId, final double[] values, final int count, final double ref) {
+        nPlotStemsV(labelId, values, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final double[] values, final int count, final double yRef, final double scale) {
-        nPlotStemsV(labelId, values, count, yRef, scale);
+    public static void plotStemsV(final String labelId, final double[] values, final int count, final double ref, final double scale) {
+        nPlotStemsV(labelId, values, count, ref, scale);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final double[] values, final int count, final double yRef, final double scale, final double start) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start);
+    public static void plotStemsV(final String labelId, final double[] values, final int count, final double ref, final double scale, final double start) {
+        nPlotStemsV(labelId, values, count, ref, scale, start);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final double[] values, final int count, final double yRef, final double scale, final double start, final int flags) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final double[] values, final int count, final double yRef, final double scale, final double start, final int flags, final int offset) {
-        nPlotStemsV(labelId, values, count, yRef, scale, start, flags, offset);
+    public static void plotStemsV(final String labelId, final double[] values, final int count, final double ref, final double scale, final double start, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, values, count, ref, scale, start, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, double[] values, int count); /*MANUAL
@@ -11026,42 +8959,34 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, double[] values, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, double[] values, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef);
+        ImPlot::PlotStems(labelId, &values[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, double[] values, int count, double yRef, double scale); /*MANUAL
+    private static native void nPlotStemsV(String labelId, double[] values, int count, double ref, double scale); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, double[] values, int count, double yRef, double scale, double start); /*MANUAL
+    private static native void nPlotStemsV(String labelId, double[] values, int count, double ref, double scale, double start); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, double[] values, int count, double yRef, double scale, double start, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, double[] values, int count, double ref, double scale, double start, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, double[] values, int count, double yRef, double scale, double start, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &values[0], count, yRef, scale, start, flags, offset);
+        ImPlot::PlotStems(labelId, &values[0], count, ref, scale, start, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -11085,15 +9010,8 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final short[] xs, final short[] ys, final double ref, final int flags) {
-        nPlotStems(labelId, xs, ys, ref, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final short[] xs, final short[] ys, final double ref, final int flags, final int offset) {
-        nPlotStems(labelId, xs, ys, ref, flags, offset);
+    public static void plotStems(final String labelId, final short[] xs, final short[] ys, final double ref, final ImPlotSpec spec) {
+        nPlotStems(labelId, xs, ys, ref, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -11116,21 +9034,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, short[] xs, short[] ys, double ref, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, short[] xs, short[] ys, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, short[] xs, short[] ys, double ref, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11153,15 +9061,8 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final int[] xs, final int[] ys, final double ref, final int flags) {
-        nPlotStems(labelId, xs, ys, ref, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final int[] xs, final int[] ys, final double ref, final int flags, final int offset) {
-        nPlotStems(labelId, xs, ys, ref, flags, offset);
+    public static void plotStems(final String labelId, final int[] xs, final int[] ys, final double ref, final ImPlotSpec spec) {
+        nPlotStems(labelId, xs, ys, ref, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -11184,21 +9085,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, int[] xs, int[] ys, double ref, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, int[] xs, int[] ys, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, int[] xs, int[] ys, double ref, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11221,15 +9112,8 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final long[] xs, final long[] ys, final double ref, final int flags) {
-        nPlotStems(labelId, xs, ys, ref, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final long[] xs, final long[] ys, final double ref, final int flags, final int offset) {
-        nPlotStems(labelId, xs, ys, ref, flags, offset);
+    public static void plotStems(final String labelId, final long[] xs, final long[] ys, final double ref, final ImPlotSpec spec) {
+        nPlotStems(labelId, xs, ys, ref, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -11252,21 +9136,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, long[] xs, long[] ys, double ref, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, long[] xs, long[] ys, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, long[] xs, long[] ys, double ref, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11289,15 +9163,8 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final float[] xs, final float[] ys, final double ref, final int flags) {
-        nPlotStems(labelId, xs, ys, ref, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final float[] xs, final float[] ys, final double ref, final int flags, final int offset) {
-        nPlotStems(labelId, xs, ys, ref, flags, offset);
+    public static void plotStems(final String labelId, final float[] xs, final float[] ys, final double ref, final ImPlotSpec spec) {
+        nPlotStems(labelId, xs, ys, ref, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -11320,21 +9187,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, float[] xs, float[] ys, double ref, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, float[] xs, float[] ys, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, float[] xs, float[] ys, double ref, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11357,15 +9214,8 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStems(final String labelId, final double[] xs, final double[] ys, final double ref, final int flags) {
-        nPlotStems(labelId, xs, ys, ref, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStems(final String labelId, final double[] xs, final double[] ys, final double ref, final int flags, final int offset) {
-        nPlotStems(labelId, xs, ys, ref, flags, offset);
+    public static void plotStems(final String labelId, final double[] xs, final double[] ys, final double ref, final ImPlotSpec spec) {
+        nPlotStems(labelId, xs, ys, ref, spec.ptr);
     }
 
     private static native void nPlotStems(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -11388,21 +9238,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStems(String labelId, double[] xs, double[] ys, double ref, int flags); /*MANUAL
+    private static native void nPlotStems(String labelId, double[] xs, double[] ys, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStems(String labelId, double[] xs, double[] ys, double ref, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], LEN(xs), ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11418,22 +9258,15 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef) {
-        nPlotStemsV(labelId, xs, ys, count, yRef);
+    public static void plotStemsV(final String labelId, final short[] xs, final short[] ys, final int count, final double ref) {
+        nPlotStemsV(labelId, xs, ys, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef, final int flags) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final short[] xs, final short[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotStemsV(final String labelId, final short[] xs, final short[] ys, final int count, final double ref, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, xs, ys, count, ref, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, short[] xs, short[] ys, int count); /*MANUAL
@@ -11446,31 +9279,21 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, short[] xs, short[] ys, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, short[] xs, short[] ys, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, short[] xs, short[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, short[] xs, short[] ys, int count, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, short[] xs, short[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11486,22 +9309,15 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef) {
-        nPlotStemsV(labelId, xs, ys, count, yRef);
+    public static void plotStemsV(final String labelId, final int[] xs, final int[] ys, final int count, final double ref) {
+        nPlotStemsV(labelId, xs, ys, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef, final int flags) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final int[] xs, final int[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotStemsV(final String labelId, final int[] xs, final int[] ys, final int count, final double ref, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, xs, ys, count, ref, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, int[] xs, int[] ys, int count); /*MANUAL
@@ -11514,31 +9330,21 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, int[] xs, int[] ys, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, int[] xs, int[] ys, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, int[] xs, int[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, int[] xs, int[] ys, int count, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, int[] xs, int[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11554,22 +9360,15 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef) {
-        nPlotStemsV(labelId, xs, ys, count, yRef);
+    public static void plotStemsV(final String labelId, final long[] xs, final long[] ys, final int count, final double ref) {
+        nPlotStemsV(labelId, xs, ys, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef, final int flags) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final long[] xs, final long[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotStemsV(final String labelId, final long[] xs, final long[] ys, final int count, final double ref, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, xs, ys, count, ref, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, long[] xs, long[] ys, int count); /*MANUAL
@@ -11582,31 +9381,21 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, long[] xs, long[] ys, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, long[] xs, long[] ys, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, long[] xs, long[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, long[] xs, long[] ys, int count, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, long[] xs, long[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11622,22 +9411,15 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef) {
-        nPlotStemsV(labelId, xs, ys, count, yRef);
+    public static void plotStemsV(final String labelId, final float[] xs, final float[] ys, final int count, final double ref) {
+        nPlotStemsV(labelId, xs, ys, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef, final int flags) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final float[] xs, final float[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotStemsV(final String labelId, final float[] xs, final float[] ys, final int count, final double ref, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, xs, ys, count, ref, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, float[] xs, float[] ys, int count); /*MANUAL
@@ -11650,31 +9432,21 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, float[] xs, float[] ys, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, float[] xs, float[] ys, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, float[] xs, float[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, float[] xs, float[] ys, int count, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, float[] xs, float[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11690,22 +9462,15 @@ public final class ImPlot {
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef) {
-        nPlotStemsV(labelId, xs, ys, count, yRef);
+    public static void plotStemsV(final String labelId, final double[] xs, final double[] ys, final int count, final double ref) {
+        nPlotStemsV(labelId, xs, ys, count, ref);
     }
 
     /**
      * Plots vertical stems.
      */
-    public static void plotStemsV(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef, final int flags) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags);
-    }
-
-    /**
-     * Plots vertical stems.
-     */
-    public static void plotStemsV(final String labelId, final double[] xs, final double[] ys, final int count, final double yRef, final int flags, final int offset) {
-        nPlotStemsV(labelId, xs, ys, count, yRef, flags, offset);
+    public static void plotStemsV(final String labelId, final double[] xs, final double[] ys, final int count, final double ref, final ImPlotSpec spec) {
+        nPlotStemsV(labelId, xs, ys, count, ref, spec.ptr);
     }
 
     private static native void nPlotStemsV(String labelId, double[] xs, double[] ys, int count); /*MANUAL
@@ -11718,31 +9483,21 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, double[] xs, double[] ys, int count, double yRef); /*MANUAL
+    private static native void nPlotStemsV(String labelId, double[] xs, double[] ys, int count, double ref); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref);
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotStemsV(String labelId, double[] xs, double[] ys, int count, double yRef, int flags); /*MANUAL
+    private static native void nPlotStemsV(String labelId, double[] xs, double[] ys, int count, double ref, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotStemsV(String labelId, double[] xs, double[] ys, int count, double yRef, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, yRef, flags, offset);
+        ImPlot::PlotStems(labelId, &xs[0], &ys[0], count, ref, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -11758,15 +9513,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLines(final String labelId, final short[] values, final int flags) {
-        nPlotInfLines(labelId, values, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLines(final String labelId, final short[] values, final int flags, final int offset) {
-        nPlotInfLines(labelId, values, flags, offset);
+    public static void plotInfLines(final String labelId, final short[] values, final ImPlotSpec spec) {
+        nPlotInfLines(labelId, values, spec.ptr);
     }
 
     private static native void nPlotInfLines(String labelId, short[] values); /*MANUAL
@@ -11777,18 +9525,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLines(String labelId, short[] values, int flags); /*MANUAL
+    private static native void nPlotInfLines(String labelId, short[] values, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLines(String labelId, short[] values, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -11803,15 +9543,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLines(final String labelId, final int[] values, final int flags) {
-        nPlotInfLines(labelId, values, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLines(final String labelId, final int[] values, final int flags, final int offset) {
-        nPlotInfLines(labelId, values, flags, offset);
+    public static void plotInfLines(final String labelId, final int[] values, final ImPlotSpec spec) {
+        nPlotInfLines(labelId, values, spec.ptr);
     }
 
     private static native void nPlotInfLines(String labelId, int[] values); /*MANUAL
@@ -11822,18 +9555,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLines(String labelId, int[] values, int flags); /*MANUAL
+    private static native void nPlotInfLines(String labelId, int[] values, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLines(String labelId, int[] values, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -11848,15 +9573,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLines(final String labelId, final long[] values, final int flags) {
-        nPlotInfLines(labelId, values, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLines(final String labelId, final long[] values, final int flags, final int offset) {
-        nPlotInfLines(labelId, values, flags, offset);
+    public static void plotInfLines(final String labelId, final long[] values, final ImPlotSpec spec) {
+        nPlotInfLines(labelId, values, spec.ptr);
     }
 
     private static native void nPlotInfLines(String labelId, long[] values); /*MANUAL
@@ -11867,18 +9585,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLines(String labelId, long[] values, int flags); /*MANUAL
+    private static native void nPlotInfLines(String labelId, long[] values, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLines(String labelId, long[] values, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -11893,15 +9603,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLines(final String labelId, final float[] values, final int flags) {
-        nPlotInfLines(labelId, values, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLines(final String labelId, final float[] values, final int flags, final int offset) {
-        nPlotInfLines(labelId, values, flags, offset);
+    public static void plotInfLines(final String labelId, final float[] values, final ImPlotSpec spec) {
+        nPlotInfLines(labelId, values, spec.ptr);
     }
 
     private static native void nPlotInfLines(String labelId, float[] values); /*MANUAL
@@ -11912,18 +9615,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLines(String labelId, float[] values, int flags); /*MANUAL
+    private static native void nPlotInfLines(String labelId, float[] values, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLines(String labelId, float[] values, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -11938,15 +9633,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLines(final String labelId, final double[] values, final int flags) {
-        nPlotInfLines(labelId, values, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLines(final String labelId, final double[] values, final int flags, final int offset) {
-        nPlotInfLines(labelId, values, flags, offset);
+    public static void plotInfLines(final String labelId, final double[] values, final ImPlotSpec spec) {
+        nPlotInfLines(labelId, values, spec.ptr);
     }
 
     private static native void nPlotInfLines(String labelId, double[] values); /*MANUAL
@@ -11957,18 +9645,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLines(String labelId, double[] values, int flags); /*MANUAL
+    private static native void nPlotInfLines(String labelId, double[] values, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLines(String labelId, double[] values, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], LEN(values), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -11983,15 +9663,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLinesV(final String labelId, final short[] values, final int count, final int flags) {
-        nPlotInfLinesV(labelId, values, count, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLinesV(final String labelId, final short[] values, final int count, final int flags, final int offset) {
-        nPlotInfLinesV(labelId, values, count, flags, offset);
+    public static void plotInfLinesV(final String labelId, final short[] values, final int count, final ImPlotSpec spec) {
+        nPlotInfLinesV(labelId, values, count, spec.ptr);
     }
 
     private static native void nPlotInfLinesV(String labelId, short[] values, int count); /*MANUAL
@@ -12002,18 +9675,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLinesV(String labelId, short[] values, int count, int flags); /*MANUAL
+    private static native void nPlotInfLinesV(String labelId, short[] values, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLinesV(String labelId, short[] values, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -12028,15 +9693,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLinesV(final String labelId, final int[] values, final int count, final int flags) {
-        nPlotInfLinesV(labelId, values, count, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLinesV(final String labelId, final int[] values, final int count, final int flags, final int offset) {
-        nPlotInfLinesV(labelId, values, count, flags, offset);
+    public static void plotInfLinesV(final String labelId, final int[] values, final int count, final ImPlotSpec spec) {
+        nPlotInfLinesV(labelId, values, count, spec.ptr);
     }
 
     private static native void nPlotInfLinesV(String labelId, int[] values, int count); /*MANUAL
@@ -12047,18 +9705,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLinesV(String labelId, int[] values, int count, int flags); /*MANUAL
+    private static native void nPlotInfLinesV(String labelId, int[] values, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLinesV(String labelId, int[] values, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -12073,15 +9723,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLinesV(final String labelId, final long[] values, final int count, final int flags) {
-        nPlotInfLinesV(labelId, values, count, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLinesV(final String labelId, final long[] values, final int count, final int flags, final int offset) {
-        nPlotInfLinesV(labelId, values, count, flags, offset);
+    public static void plotInfLinesV(final String labelId, final long[] values, final int count, final ImPlotSpec spec) {
+        nPlotInfLinesV(labelId, values, count, spec.ptr);
     }
 
     private static native void nPlotInfLinesV(String labelId, long[] values, int count); /*MANUAL
@@ -12092,18 +9735,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLinesV(String labelId, long[] values, int count, int flags); /*MANUAL
+    private static native void nPlotInfLinesV(String labelId, long[] values, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLinesV(String labelId, long[] values, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -12118,15 +9753,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLinesV(final String labelId, final float[] values, final int count, final int flags) {
-        nPlotInfLinesV(labelId, values, count, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLinesV(final String labelId, final float[] values, final int count, final int flags, final int offset) {
-        nPlotInfLinesV(labelId, values, count, flags, offset);
+    public static void plotInfLinesV(final String labelId, final float[] values, final int count, final ImPlotSpec spec) {
+        nPlotInfLinesV(labelId, values, count, spec.ptr);
     }
 
     private static native void nPlotInfLinesV(String labelId, float[] values, int count); /*MANUAL
@@ -12137,18 +9765,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLinesV(String labelId, float[] values, int count, int flags); /*MANUAL
+    private static native void nPlotInfLinesV(String labelId, float[] values, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLinesV(String labelId, float[] values, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -12163,15 +9783,8 @@ public final class ImPlot {
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
-    public static void plotInfLinesV(final String labelId, final double[] values, final int count, final int flags) {
-        nPlotInfLinesV(labelId, values, count, flags);
-    }
-
-    /**
-     * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-     */
-    public static void plotInfLinesV(final String labelId, final double[] values, final int count, final int flags, final int offset) {
-        nPlotInfLinesV(labelId, values, count, flags, offset);
+    public static void plotInfLinesV(final String labelId, final double[] values, final int count, final ImPlotSpec spec) {
+        nPlotInfLinesV(labelId, values, count, spec.ptr);
     }
 
     private static native void nPlotInfLinesV(String labelId, double[] values, int count); /*MANUAL
@@ -12182,18 +9795,10 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    private static native void nPlotInfLinesV(String labelId, double[] values, int count, int flags); /*MANUAL
+    private static native void nPlotInfLinesV(String labelId, double[] values, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
-    */
-
-    private static native void nPlotInfLinesV(String labelId, double[] values, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotInfLines(labelId, &values[0], count, flags, offset);
+        ImPlot::PlotInfLines(labelId, &values[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -12222,15 +9827,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final short[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final short[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final short[] values, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final short[] values, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, double x, double y, double radius); /*MANUAL
@@ -12285,7 +9890,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12294,7 +9899,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12303,7 +9908,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, short[] values, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12311,7 +9916,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12343,15 +9948,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final int[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final int[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final int[] values, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final int[] values, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, double x, double y, double radius); /*MANUAL
@@ -12406,7 +10011,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12415,7 +10020,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12424,7 +10029,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, int[] values, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12432,7 +10037,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12464,15 +10069,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final long[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final long[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final long[] values, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final long[] values, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, double x, double y, double radius); /*MANUAL
@@ -12527,7 +10132,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12536,7 +10141,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12545,7 +10150,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, long[] values, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12553,7 +10158,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12585,15 +10190,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final float[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final float[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final float[] values, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final float[] values, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, double x, double y, double radius); /*MANUAL
@@ -12648,7 +10253,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12657,7 +10262,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12666,7 +10271,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, float[] values, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12674,7 +10279,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12706,15 +10311,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final double[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final double[] values, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChart(final String[] labelIds, final double[] values, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, flags);
+    public static void plotPieChart(final String[] labelIds, final double[] values, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChart(labelIds, labelIds.length, values, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, double x, double y, double radius); /*MANUAL
@@ -12769,7 +10374,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12778,7 +10383,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12787,7 +10392,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChart(String[] obj_labelIds, int labelIdsCount, double[] values, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12795,7 +10400,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], LEN(values), x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12827,15 +10432,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius); /*MANUAL
@@ -12890,7 +10495,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12899,7 +10504,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12908,7 +10513,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, short[] values, int count, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -12916,7 +10521,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -12948,15 +10553,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final int[] values, final int count, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius); /*MANUAL
@@ -13011,7 +10616,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -13020,7 +10625,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -13029,7 +10634,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, int[] values, int count, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -13037,7 +10642,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -13069,15 +10674,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final long[] values, final int count, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius); /*MANUAL
@@ -13132,7 +10737,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -13141,7 +10746,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -13150,7 +10755,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, long[] values, int count, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -13158,7 +10763,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -13190,15 +10795,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final float[] values, final int count, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius); /*MANUAL
@@ -13253,7 +10858,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -13262,7 +10867,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -13271,7 +10876,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, float[] values, int count, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -13279,7 +10884,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -13311,15 +10916,15 @@ public final class ImPlot {
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final String labelFmt, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, labelFmt, angle0, spec.ptr);
     }
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotPieChartV(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final double angle0, final int flags) {
-        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, flags);
+    public static void plotPieChartV(final String[] labelIds, final double[] values, final int count, final double x, final double y, final double radius, final double angle0, final ImPlotSpec spec) {
+        nPlotPieChartV(labelIds, labelIds.length, values, count, x, y, radius, angle0, spec.ptr);
     }
 
     private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius); /*MANUAL
@@ -13374,7 +10979,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, String labelFmt, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, String labelFmt, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -13383,7 +10988,7 @@ public final class ImPlot {
         };
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, labelFmt, angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -13392,7 +10997,7 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, double angle0, int flags); /*MANUAL
+    private static native void nPlotPieChartV(String[] obj_labelIds, int labelIdsCount, double[] values, int count, double x, double y, double radius, double angle0, long spec); /*MANUAL
         const char* labelIds[labelIdsCount];
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
@@ -13400,7 +11005,7 @@ public final class ImPlot {
             labelIds[i] = rawStr;
         };
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, flags);
+        ImPlot::PlotPieChart(labelIds, &values[0], count, x, y, radius, "%.1f", angle0, *reinterpret_cast<ImPlotSpec*>(spec));
         for (int i = 0; i < labelIdsCount; i++) {
             const jstring str = (jstring)env->GetObjectArrayElement(obj_labelIds, i);
             env->ReleaseStringUTFChars(str, labelIds[i]);
@@ -13467,29 +11072,29 @@ public final class ImPlot {
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     private static native void nPlotHeatmap(String labelId, short[] values, int rows, int cols); /*MANUAL
@@ -13546,20 +11151,20 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, short[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, short[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, short[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, short[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -13623,29 +11228,29 @@ public final class ImPlot {
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final int[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final int[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final int[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final int[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final int[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final int[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final int[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final int[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     private static native void nPlotHeatmap(String labelId, int[] values, int rows, int cols); /*MANUAL
@@ -13702,20 +11307,20 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, int[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, int[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, int[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, int[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -13779,29 +11384,29 @@ public final class ImPlot {
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final long[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final long[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final long[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final long[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final long[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final long[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final long[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final long[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     private static native void nPlotHeatmap(String labelId, long[] values, int rows, int cols); /*MANUAL
@@ -13858,20 +11463,20 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, long[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, long[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, long[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, long[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -13935,29 +11540,29 @@ public final class ImPlot {
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final float[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final float[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final float[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final float[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final float[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final float[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final float[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final float[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     private static native void nPlotHeatmap(String labelId, float[] values, int rows, int cols); /*MANUAL
@@ -14014,20 +11619,20 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, float[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, float[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, float[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, float[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -14091,29 +11696,29 @@ public final class ImPlot {
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final double[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final double[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final double[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final double[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final String labelFmt, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, labelFmt, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final double[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, flags);
+    public static void plotHeatmap(final String labelId, final double[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, spec.ptr);
     }
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
-    public static void plotHeatmap(final String labelId, final double[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final int flags) {
-        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, flags);
+    public static void plotHeatmap(final String labelId, final double[] values, final int rows, final int cols, final double scaleMin, final double scaleMax, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImPlotSpec spec) {
+        nPlotHeatmap(labelId, values, rows, cols, scaleMin, scaleMax, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, spec.ptr);
     }
 
     private static native void nPlotHeatmap(String labelId, double[] values, int rows, int cols); /*MANUAL
@@ -14170,20 +11775,20 @@ public final class ImPlot {
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, double[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, double[] values, int rows, int cols, double scaleMin, double scaleMax, String labelFmt, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
         auto labelFmt = obj_labelFmt == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelFmt, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, labelFmt, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         if (labelFmt != NULL) env->ReleaseStringUTFChars(obj_labelFmt, labelFmt);
     */
 
-    private static native void nPlotHeatmap(String labelId, double[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, int flags); /*MANUAL
+    private static native void nPlotHeatmap(String labelId, double[] values, int rows, int cols, double scaleMin, double scaleMax, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), flags);
+        ImPlot::PlotHeatmap(labelId, &values[0], rows, cols, scaleMin, scaleMax, "%.1f", ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
@@ -14238,8 +11843,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final short[] values, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final short[] values, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14247,8 +11852,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final short[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final short[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14256,8 +11861,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final short[] values, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final short[] values, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14265,8 +11870,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final short[] values, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final short[] values, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14274,8 +11879,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final short[] values, final int bins, final double barScale, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, flags);
+    public static double plotHistogram(final String labelId, final short[] values, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogram(String obj_labelId, short[] obj_values); /*MANUAL
@@ -14314,28 +11919,28 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, short[] obj_values, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -14391,8 +11996,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final int[] values, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final int[] values, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14400,8 +12005,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final int[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final int[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14409,8 +12014,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final int[] values, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final int[] values, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14418,8 +12023,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final int[] values, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final int[] values, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14427,8 +12032,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final int[] values, final int bins, final double barScale, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, flags);
+    public static double plotHistogram(final String labelId, final int[] values, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogram(String obj_labelId, int[] obj_values); /*MANUAL
@@ -14467,28 +12072,28 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, int[] obj_values, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -14544,8 +12149,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final long[] values, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final long[] values, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14553,8 +12158,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final long[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final long[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14562,8 +12167,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final long[] values, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final long[] values, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14571,8 +12176,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final long[] values, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final long[] values, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14580,8 +12185,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final long[] values, final int bins, final double barScale, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, flags);
+    public static double plotHistogram(final String labelId, final long[] values, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogram(String obj_labelId, long[] obj_values); /*MANUAL
@@ -14620,28 +12225,28 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, long[] obj_values, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -14697,8 +12302,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final float[] values, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final float[] values, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14706,8 +12311,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final float[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final float[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14715,8 +12320,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final float[] values, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final float[] values, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14724,8 +12329,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final float[] values, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final float[] values, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14733,8 +12338,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final float[] values, final int bins, final double barScale, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, flags);
+    public static double plotHistogram(final String labelId, final float[] values, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogram(String obj_labelId, float[] obj_values); /*MANUAL
@@ -14773,28 +12378,28 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, float[] obj_values, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -14850,8 +12455,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final double[] values, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final double[] values, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14859,8 +12464,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final double[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final double[] values, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14868,8 +12473,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final double[] values, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, range.min, range.max, flags);
+    public static double plotHistogram(final String labelId, final double[] values, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -14877,8 +12482,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final double[] values, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogram(final String labelId, final double[] values, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -14886,8 +12491,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram(final String labelId, final double[] values, final int bins, final double barScale, final int flags) {
-        return nPlotHistogram(labelId, values, bins, barScale, flags);
+    public static double plotHistogram(final String labelId, final double[] values, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogram(labelId, values, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogram(String obj_labelId, double[] obj_values); /*MANUAL
@@ -14926,28 +12531,28 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), ImPlotBin_Sturges, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogram(String obj_labelId, double[] obj_values, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], LEN(values), bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -15003,8 +12608,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final short[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogramV(final String labelId, final short[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -15012,8 +12617,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final short[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogramV(final String labelId, final short[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -15021,8 +12626,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final short[] values, final int count, final int bins, final double barScale, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, flags);
+    public static double plotHistogramV(final String labelId, final short[] values, final int count, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogramV(String obj_labelId, short[] obj_values, int count); /*MANUAL
@@ -15061,19 +12666,19 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, short[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, short[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, short[] obj_values, int count, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, short[] obj_values, int count, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -15129,8 +12734,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final int[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogramV(final String labelId, final int[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -15138,8 +12743,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final int[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogramV(final String labelId, final int[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -15147,8 +12752,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final int[] values, final int count, final int bins, final double barScale, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, flags);
+    public static double plotHistogramV(final String labelId, final int[] values, final int count, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogramV(String obj_labelId, int[] obj_values, int count); /*MANUAL
@@ -15187,19 +12792,19 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, int[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, int[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, int[] obj_values, int count, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, int[] obj_values, int count, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -15255,8 +12860,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final long[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogramV(final String labelId, final long[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -15264,8 +12869,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final long[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogramV(final String labelId, final long[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -15273,8 +12878,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final long[] values, final int count, final int bins, final double barScale, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, flags);
+    public static double plotHistogramV(final String labelId, final long[] values, final int count, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogramV(String obj_labelId, long[] obj_values, int count); /*MANUAL
@@ -15313,19 +12918,19 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, long[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, long[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, long[] obj_values, int count, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, long[] obj_values, int count, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -15381,8 +12986,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final float[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogramV(final String labelId, final float[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -15390,8 +12995,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final float[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogramV(final String labelId, final float[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -15399,8 +13004,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final float[] values, final int count, final int bins, final double barScale, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, flags);
+    public static double plotHistogramV(final String labelId, final float[] values, final int count, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogramV(String obj_labelId, float[] obj_values, int count); /*MANUAL
@@ -15439,19 +13044,19 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, float[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, float[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, float[] obj_values, int count, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, float[] obj_values, int count, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -15507,8 +13112,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final double[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, flags);
+    public static double plotHistogramV(final String labelId, final double[] values, final int count, final int bins, final double barScale, final ImPlotRange range, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, range.min, range.max, spec.ptr);
     }
 
     /**
@@ -15516,8 +13121,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final double[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, flags);
+    public static double plotHistogramV(final String labelId, final double[] values, final int count, final int bins, final double barScale, final double rangeMin, final double rangeMax, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, rangeMin, rangeMax, spec.ptr);
     }
 
     /**
@@ -15525,8 +13130,8 @@ public final class ImPlot {
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogramV(final String labelId, final double[] values, final int count, final int bins, final double barScale, final int flags) {
-        return nPlotHistogramV(labelId, values, count, bins, barScale, flags);
+    public static double plotHistogramV(final String labelId, final double[] values, final int count, final int bins, final double barScale, final ImPlotSpec spec) {
+        return nPlotHistogramV(labelId, values, count, bins, barScale, spec.ptr);
     }
 
     private static native double nPlotHistogramV(String obj_labelId, double[] obj_values, int count); /*MANUAL
@@ -15565,19 +13170,19 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, double[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, double[] obj_values, int count, int bins, double barScale, double rangeMin, double rangeMax, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(rangeMin, rangeMax), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogramV(String obj_labelId, double[] obj_values, int count, int bins, double barScale, int flags); /*MANUAL
+    private static native double nPlotHistogramV(String obj_labelId, double[] obj_values, int count, int bins, double barScale, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), flags);
+        auto _result = ImPlot::PlotHistogram(labelId, &values[0], count, bins, barScale, ImPlotRange(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
         return _result;
@@ -15633,8 +13238,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -15642,8 +13247,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -15651,8 +13256,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, flags);
+    public static double plotHistogram2D(final String labelId, final short[] xs, final short[] ys, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys); /*MANUAL
@@ -15699,22 +13304,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, short[] obj_xs, short[] obj_ys, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -15771,8 +13376,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -15780,8 +13385,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -15789,8 +13394,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, flags);
+    public static double plotHistogram2D(final String labelId, final int[] xs, final int[] ys, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys); /*MANUAL
@@ -15837,22 +13442,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, int[] obj_xs, int[] obj_ys, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -15909,8 +13514,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -15918,8 +13523,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -15927,8 +13532,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, flags);
+    public static double plotHistogram2D(final String labelId, final long[] xs, final long[] ys, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys); /*MANUAL
@@ -15975,22 +13580,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, long[] obj_xs, long[] obj_ys, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -16047,8 +13652,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -16056,8 +13661,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -16065,8 +13670,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, flags);
+    public static double plotHistogram2D(final String labelId, final float[] xs, final float[] ys, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys); /*MANUAL
@@ -16113,22 +13718,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, float[] obj_xs, float[] obj_ys, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -16185,8 +13790,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -16194,8 +13799,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -16203,8 +13808,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, flags);
+    public static double plotHistogram2D(final String labelId, final double[] xs, final double[] ys, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2D(labelId, xs, ys, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys); /*MANUAL
@@ -16251,22 +13856,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2D(String obj_labelId, double[] obj_xs, double[] obj_ys, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], LEN(xs), xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -16323,8 +13928,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2DV(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -16332,8 +13937,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2DV(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -16341,8 +13946,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, flags);
+    public static double plotHistogram2DV(final String labelId, final short[] xs, final short[] ys, final int count, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2DV(String obj_labelId, short[] obj_xs, short[] obj_ys, int count); /*MANUAL
@@ -16389,22 +13994,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, short[] obj_xs, short[] obj_ys, int count, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -16461,8 +14066,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2DV(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -16470,8 +14075,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2DV(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -16479,8 +14084,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, flags);
+    public static double plotHistogram2DV(final String labelId, final int[] xs, final int[] ys, final int count, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2DV(String obj_labelId, int[] obj_xs, int[] obj_ys, int count); /*MANUAL
@@ -16527,22 +14132,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, int[] obj_xs, int[] obj_ys, int count, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -16599,8 +14204,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2DV(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -16608,8 +14213,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2DV(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -16617,8 +14222,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, flags);
+    public static double plotHistogram2DV(final String labelId, final long[] xs, final long[] ys, final int count, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2DV(String obj_labelId, long[] obj_xs, long[] obj_ys, int count); /*MANUAL
@@ -16665,22 +14270,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, long[] obj_xs, long[] obj_ys, int count, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -16737,8 +14342,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2DV(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -16746,8 +14351,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2DV(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -16755,8 +14360,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, flags);
+    public static double plotHistogram2DV(final String labelId, final float[] xs, final float[] ys, final int count, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2DV(String obj_labelId, float[] obj_xs, float[] obj_ys, int count); /*MANUAL
@@ -16803,22 +14408,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, float[] obj_xs, float[] obj_ys, int count, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -16875,8 +14480,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, flags);
+    public static double plotHistogram2DV(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final ImPlotRect range, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, range.x.min, range.y.min, range.x.max, range.y.max, spec.ptr);
     }
 
     /**
@@ -16884,8 +14489,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, flags);
+    public static double plotHistogram2DV(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final double rangeMinX, final double rangeMinY, final double rangeMaxX, final double rangeMaxY, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, rangeMinX, rangeMinY, rangeMaxX, rangeMaxY, spec.ptr);
     }
 
     /**
@@ -16893,8 +14498,8 @@ public final class ImPlot {
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
      */
-    public static double plotHistogram2DV(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final int flags) {
-        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, flags);
+    public static double plotHistogram2DV(final String labelId, final double[] xs, final double[] ys, final int count, final int xBins, final int yBins, final ImPlotSpec spec) {
+        return nPlotHistogram2DV(labelId, xs, ys, count, xBins, yBins, spec.ptr);
     }
 
     private static native double nPlotHistogram2DV(String obj_labelId, double[] obj_xs, double[] obj_ys, int count); /*MANUAL
@@ -16941,22 +14546,22 @@ public final class ImPlot {
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, double rangeMinX, double rangeMinY, double rangeMaxX, double rangeMaxY, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(rangeMinX, rangeMinY, rangeMaxX, rangeMaxY), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
         return _result;
     */
 
-    private static native double nPlotHistogram2DV(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, int flags); /*MANUAL
+    private static native double nPlotHistogram2DV(String obj_labelId, double[] obj_xs, double[] obj_ys, int count, int xBins, int yBins, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), flags);
+        auto _result = ImPlot::PlotHistogram2D(labelId, &xs[0], &ys[0], count, xBins, yBins, ImPlotRect(), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -16973,15 +14578,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigital(final String labelId, final short[] xs, final short[] ys, final int flags) {
-        nPlotDigital(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final short[] xs, final short[] ys, final int flags, final int offset) {
-        nPlotDigital(labelId, xs, ys, flags, offset);
+    public static void plotDigital(final String labelId, final short[] xs, final short[] ys, final ImPlotSpec spec) {
+        nPlotDigital(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotDigital(String labelId, short[] xs, short[] ys); /*MANUAL
@@ -16994,21 +14592,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, short[] xs, short[] ys, int flags); /*MANUAL
+    private static native void nPlotDigital(String labelId, short[] xs, short[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigital(String labelId, short[] xs, short[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17024,15 +14612,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigital(final String labelId, final int[] xs, final int[] ys, final int flags) {
-        nPlotDigital(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final int[] xs, final int[] ys, final int flags, final int offset) {
-        nPlotDigital(labelId, xs, ys, flags, offset);
+    public static void plotDigital(final String labelId, final int[] xs, final int[] ys, final ImPlotSpec spec) {
+        nPlotDigital(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotDigital(String labelId, int[] xs, int[] ys); /*MANUAL
@@ -17045,21 +14626,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, int[] xs, int[] ys, int flags); /*MANUAL
+    private static native void nPlotDigital(String labelId, int[] xs, int[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigital(String labelId, int[] xs, int[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17075,15 +14646,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigital(final String labelId, final long[] xs, final long[] ys, final int flags) {
-        nPlotDigital(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final long[] xs, final long[] ys, final int flags, final int offset) {
-        nPlotDigital(labelId, xs, ys, flags, offset);
+    public static void plotDigital(final String labelId, final long[] xs, final long[] ys, final ImPlotSpec spec) {
+        nPlotDigital(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotDigital(String labelId, long[] xs, long[] ys); /*MANUAL
@@ -17096,21 +14660,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, long[] xs, long[] ys, int flags); /*MANUAL
+    private static native void nPlotDigital(String labelId, long[] xs, long[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigital(String labelId, long[] xs, long[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17126,15 +14680,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigital(final String labelId, final float[] xs, final float[] ys, final int flags) {
-        nPlotDigital(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final float[] xs, final float[] ys, final int flags, final int offset) {
-        nPlotDigital(labelId, xs, ys, flags, offset);
+    public static void plotDigital(final String labelId, final float[] xs, final float[] ys, final ImPlotSpec spec) {
+        nPlotDigital(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotDigital(String labelId, float[] xs, float[] ys); /*MANUAL
@@ -17147,21 +14694,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, float[] xs, float[] ys, int flags); /*MANUAL
+    private static native void nPlotDigital(String labelId, float[] xs, float[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigital(String labelId, float[] xs, float[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17177,15 +14714,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigital(final String labelId, final double[] xs, final double[] ys, final int flags) {
-        nPlotDigital(labelId, xs, ys, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigital(final String labelId, final double[] xs, final double[] ys, final int flags, final int offset) {
-        nPlotDigital(labelId, xs, ys, flags, offset);
+    public static void plotDigital(final String labelId, final double[] xs, final double[] ys, final ImPlotSpec spec) {
+        nPlotDigital(labelId, xs, ys, spec.ptr);
     }
 
     private static native void nPlotDigital(String labelId, double[] xs, double[] ys); /*MANUAL
@@ -17198,21 +14728,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigital(String labelId, double[] xs, double[] ys, int flags); /*MANUAL
+    private static native void nPlotDigital(String labelId, double[] xs, double[] ys, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigital(String labelId, double[] xs, double[] ys, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17228,15 +14748,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigitalV(final String labelId, final short[] xs, final short[] ys, final int count, final int flags) {
-        nPlotDigitalV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigitalV(final String labelId, final short[] xs, final short[] ys, final int count, final int flags, final int offset) {
-        nPlotDigitalV(labelId, xs, ys, count, flags, offset);
+    public static void plotDigitalV(final String labelId, final short[] xs, final short[] ys, final int count, final ImPlotSpec spec) {
+        nPlotDigitalV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotDigitalV(String labelId, short[] xs, short[] ys, int count); /*MANUAL
@@ -17249,21 +14762,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigitalV(String labelId, short[] xs, short[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotDigitalV(String labelId, short[] xs, short[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigitalV(String labelId, short[] xs, short[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17279,15 +14782,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigitalV(final String labelId, final int[] xs, final int[] ys, final int count, final int flags) {
-        nPlotDigitalV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigitalV(final String labelId, final int[] xs, final int[] ys, final int count, final int flags, final int offset) {
-        nPlotDigitalV(labelId, xs, ys, count, flags, offset);
+    public static void plotDigitalV(final String labelId, final int[] xs, final int[] ys, final int count, final ImPlotSpec spec) {
+        nPlotDigitalV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotDigitalV(String labelId, int[] xs, int[] ys, int count); /*MANUAL
@@ -17300,21 +14796,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigitalV(String labelId, int[] xs, int[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotDigitalV(String labelId, int[] xs, int[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigitalV(String labelId, int[] xs, int[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17330,15 +14816,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigitalV(final String labelId, final long[] xs, final long[] ys, final int count, final int flags) {
-        nPlotDigitalV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigitalV(final String labelId, final long[] xs, final long[] ys, final int count, final int flags, final int offset) {
-        nPlotDigitalV(labelId, xs, ys, count, flags, offset);
+    public static void plotDigitalV(final String labelId, final long[] xs, final long[] ys, final int count, final ImPlotSpec spec) {
+        nPlotDigitalV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotDigitalV(String labelId, long[] xs, long[] ys, int count); /*MANUAL
@@ -17351,21 +14830,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigitalV(String labelId, long[] xs, long[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotDigitalV(String labelId, long[] xs, long[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigitalV(String labelId, long[] xs, long[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17381,15 +14850,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigitalV(final String labelId, final float[] xs, final float[] ys, final int count, final int flags) {
-        nPlotDigitalV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigitalV(final String labelId, final float[] xs, final float[] ys, final int count, final int flags, final int offset) {
-        nPlotDigitalV(labelId, xs, ys, count, flags, offset);
+    public static void plotDigitalV(final String labelId, final float[] xs, final float[] ys, final int count, final ImPlotSpec spec) {
+        nPlotDigitalV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotDigitalV(String labelId, float[] xs, float[] ys, int count); /*MANUAL
@@ -17402,21 +14864,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigitalV(String labelId, float[] xs, float[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotDigitalV(String labelId, float[] xs, float[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigitalV(String labelId, float[] xs, float[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17432,15 +14884,8 @@ public final class ImPlot {
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
-    public static void plotDigitalV(final String labelId, final double[] xs, final double[] ys, final int count, final int flags) {
-        nPlotDigitalV(labelId, xs, ys, count, flags);
-    }
-
-    /**
-     * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-     */
-    public static void plotDigitalV(final String labelId, final double[] xs, final double[] ys, final int count, final int flags, final int offset) {
-        nPlotDigitalV(labelId, xs, ys, count, flags, offset);
+    public static void plotDigitalV(final String labelId, final double[] xs, final double[] ys, final int count, final ImPlotSpec spec) {
+        nPlotDigitalV(labelId, xs, ys, count, spec.ptr);
     }
 
     private static native void nPlotDigitalV(String labelId, double[] xs, double[] ys, int count); /*MANUAL
@@ -17453,21 +14898,11 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    private static native void nPlotDigitalV(String labelId, double[] xs, double[] ys, int count, int flags); /*MANUAL
+    private static native void nPlotDigitalV(String labelId, double[] xs, double[] ys, int count, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
         auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags);
-        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
-        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
-        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
-    */
-
-    private static native void nPlotDigitalV(String labelId, double[] xs, double[] ys, int count, int flags, int offset); /*MANUAL
-        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
-        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
-        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
-        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, flags, offset);
+        ImPlot::PlotDigital(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
         if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
@@ -17553,22 +14988,22 @@ public final class ImPlot {
     /**
      * Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
      */
-    public static void plotImage(final String labelId, final long userTextureId, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImVec2 uv0, final ImVec2 uv1, final ImVec4 tintCol, final int flags) {
-        nPlotImage(labelId, userTextureId, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, uv0.x, uv0.y, uv1.x, uv1.y, tintCol.x, tintCol.y, tintCol.z, tintCol.w, flags);
+    public static void plotImage(final String labelId, final long userTextureId, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final ImVec2 uv0, final ImVec2 uv1, final ImVec4 tintCol, final ImPlotSpec spec) {
+        nPlotImage(labelId, userTextureId, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, uv0.x, uv0.y, uv1.x, uv1.y, tintCol.x, tintCol.y, tintCol.z, tintCol.w, spec.ptr);
     }
 
     /**
      * Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
      */
-    public static void plotImage(final String labelId, final long userTextureId, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final float uv0X, final float uv0Y, final float uv1X, final float uv1Y, final float tintColX, final float tintColY, final float tintColZ, final float tintColW, final int flags) {
-        nPlotImage(labelId, userTextureId, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, uv0X, uv0Y, uv1X, uv1Y, tintColX, tintColY, tintColZ, tintColW, flags);
+    public static void plotImage(final String labelId, final long userTextureId, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax, final float uv0X, final float uv0Y, final float uv1X, final float uv1Y, final float tintColX, final float tintColY, final float tintColZ, final float tintColW, final ImPlotSpec spec) {
+        nPlotImage(labelId, userTextureId, boundsMin.x, boundsMin.y, boundsMax.x, boundsMax.y, uv0X, uv0Y, uv1X, uv1Y, tintColX, tintColY, tintColZ, tintColW, spec.ptr);
     }
 
     /**
      * Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
      */
-    public static void plotImage(final String labelId, final long userTextureId, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImVec2 uv0, final ImVec2 uv1, final ImVec4 tintCol, final int flags) {
-        nPlotImage(labelId, userTextureId, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, uv0.x, uv0.y, uv1.x, uv1.y, tintCol.x, tintCol.y, tintCol.z, tintCol.w, flags);
+    public static void plotImage(final String labelId, final long userTextureId, final double boundsMinX, final double boundsMinY, final double boundsMaxX, final double boundsMaxY, final ImVec2 uv0, final ImVec2 uv1, final ImVec4 tintCol, final ImPlotSpec spec) {
+        nPlotImage(labelId, userTextureId, boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, uv0.x, uv0.y, uv1.x, uv1.y, tintCol.x, tintCol.y, tintCol.z, tintCol.w, spec.ptr);
     }
 
     private static native void nPlotImage(String labelId, long userTextureId, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY); /*MANUAL
@@ -17601,12 +15036,12 @@ public final class ImPlot {
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
     */
 
-    private static native void nPlotImage(String labelId, long userTextureId, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, float uv0X, float uv0Y, float uv1X, float uv1Y, float tintColX, float tintColY, float tintColZ, float tintColW, int flags); /*MANUAL
+    private static native void nPlotImage(String labelId, long userTextureId, double boundsMinX, double boundsMinY, double boundsMaxX, double boundsMaxY, float uv0X, float uv0Y, float uv1X, float uv1Y, float tintColX, float tintColY, float tintColZ, float tintColW, long spec); /*MANUAL
         auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
         ImVec2 uv0 = ImVec2(uv0X, uv0Y);
         ImVec2 uv1 = ImVec2(uv1X, uv1Y);
         ImVec4 tintCol = ImVec4(tintColX, tintColY, tintColZ, tintColW);
-        ImPlot::PlotImage(labelId, (ImTextureID)(uintptr_t)userTextureId, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), uv0, uv1, tintCol, flags);
+        ImPlot::PlotImage(labelId, (ImTextureID)(uintptr_t)userTextureId, ImPlotPoint(boundsMinX, boundsMinY), ImPlotPoint(boundsMaxX, boundsMaxY), uv0, uv1, tintCol, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
     */
 
@@ -17634,22 +15069,22 @@ public final class ImPlot {
     /**
      * Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
      */
-    public static void plotText(final String text, final double x, final double y, final ImVec2 pixOffset, final int flags) {
-        nPlotText(text, x, y, pixOffset.x, pixOffset.y, flags);
+    public static void plotText(final String text, final double x, final double y, final ImVec2 pixOffset, final ImPlotSpec spec) {
+        nPlotText(text, x, y, pixOffset.x, pixOffset.y, spec.ptr);
     }
 
     /**
      * Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
      */
-    public static void plotText(final String text, final double x, final double y, final float pixOffsetX, final float pixOffsetY, final int flags) {
-        nPlotText(text, x, y, pixOffsetX, pixOffsetY, flags);
+    public static void plotText(final String text, final double x, final double y, final float pixOffsetX, final float pixOffsetY, final ImPlotSpec spec) {
+        nPlotText(text, x, y, pixOffsetX, pixOffsetY, spec.ptr);
     }
 
     /**
      * Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
      */
-    public static void plotText(final String text, final double x, final double y, final int flags) {
-        nPlotText(text, x, y, flags);
+    public static void plotText(final String text, final double x, final double y, final ImPlotSpec spec) {
+        nPlotText(text, x, y, spec.ptr);
     }
 
     private static native void nPlotText(String text, double x, double y); /*MANUAL
@@ -17665,16 +15100,16 @@ public final class ImPlot {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    private static native void nPlotText(String text, double x, double y, float pixOffsetX, float pixOffsetY, int flags); /*MANUAL
+    private static native void nPlotText(String text, double x, double y, float pixOffsetX, float pixOffsetY, long spec); /*MANUAL
         auto text = obj_text == NULL ? NULL : (char*)env->GetStringUTFChars(obj_text, JNI_FALSE);
         ImVec2 pixOffset = ImVec2(pixOffsetX, pixOffsetY);
-        ImPlot::PlotText(text, x, y, pixOffset, flags);
+        ImPlot::PlotText(text, x, y, pixOffset, *reinterpret_cast<ImPlotSpec*>(spec));
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    private static native void nPlotText(String text, double x, double y, int flags); /*MANUAL
+    private static native void nPlotText(String text, double x, double y, long spec); /*MANUAL
         auto text = obj_text == NULL ? NULL : (char*)env->GetStringUTFChars(obj_text, JNI_FALSE);
-        ImPlot::PlotText(text, x, y, ImVec2(0,0), flags);
+        ImPlot::PlotText(text, x, y, ImVec2(0,0), *reinterpret_cast<ImPlotSpec*>(spec));
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
@@ -17688,8 +15123,8 @@ public final class ImPlot {
     /**
      * Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)
      */
-    public static void plotDummy(final String labelID, final int flags) {
-        nPlotDummy(labelID, flags);
+    public static void plotDummy(final String labelID, final ImPlotSpec spec) {
+        nPlotDummy(labelID, spec.ptr);
     }
 
     private static native void nPlotDummy(String labelID); /*MANUAL
@@ -17698,10 +15133,1414 @@ public final class ImPlot {
         if (labelID != NULL) env->ReleaseStringUTFChars(obj_labelID, labelID);
     */
 
-    private static native void nPlotDummy(String labelID, int flags); /*MANUAL
+    private static native void nPlotDummy(String labelID, long spec); /*MANUAL
         auto labelID = obj_labelID == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelID, JNI_FALSE);
-        ImPlot::PlotDummy(labelID, flags);
+        ImPlot::PlotDummy(labelID, *reinterpret_cast<ImPlotSpec*>(spec));
         if (labelID != NULL) env->ReleaseStringUTFChars(obj_labelID, labelID);
+    */
+
+    // values
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final short[] values, final short[] szs) {
+        nPlotBubbles(labelId, values, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final short[] values, final short[] szs, final double xscale) {
+        nPlotBubbles(labelId, values, szs, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final short[] values, final short[] szs, final double xscale, final double xstart) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final short[] values, final short[] szs, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, short[] values, short[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, short[] values, short[] szs, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, short[] values, short[] szs, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, short[] values, short[] szs, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final int[] values, final int[] szs) {
+        nPlotBubbles(labelId, values, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final int[] values, final int[] szs, final double xscale) {
+        nPlotBubbles(labelId, values, szs, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final int[] values, final int[] szs, final double xscale, final double xstart) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final int[] values, final int[] szs, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, int[] values, int[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, int[] values, int[] szs, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, int[] values, int[] szs, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, int[] values, int[] szs, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final long[] values, final long[] szs) {
+        nPlotBubbles(labelId, values, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final long[] values, final long[] szs, final double xscale) {
+        nPlotBubbles(labelId, values, szs, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final long[] values, final long[] szs, final double xscale, final double xstart) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final long[] values, final long[] szs, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, long[] values, long[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, long[] values, long[] szs, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, long[] values, long[] szs, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, long[] values, long[] szs, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final float[] values, final float[] szs) {
+        nPlotBubbles(labelId, values, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final float[] values, final float[] szs, final double xscale) {
+        nPlotBubbles(labelId, values, szs, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final float[] values, final float[] szs, final double xscale, final double xstart) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final float[] values, final float[] szs, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, float[] values, float[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, float[] values, float[] szs, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, float[] values, float[] szs, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, float[] values, float[] szs, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final double[] values, final double[] szs) {
+        nPlotBubbles(labelId, values, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final double[] values, final double[] szs, final double xscale) {
+        nPlotBubbles(labelId, values, szs, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final double[] values, final double[] szs, final double xscale, final double xstart) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final double[] values, final double[] szs, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, values, szs, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, double[] values, double[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, double[] values, double[] szs, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, double[] values, double[] szs, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, double[] values, double[] szs, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], LEN(values), xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final short[] values, final short[] szs, final int count) {
+        nPlotBubblesV(labelId, values, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final short[] values, final short[] szs, final int count, final double xscale) {
+        nPlotBubblesV(labelId, values, szs, count, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final short[] values, final short[] szs, final int count, final double xscale, final double xstart) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final short[] values, final short[] szs, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, short[] values, short[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, short[] values, short[] szs, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, short[] values, short[] szs, int count, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, short[] values, short[] szs, int count, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final int[] values, final int[] szs, final int count) {
+        nPlotBubblesV(labelId, values, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final int[] values, final int[] szs, final int count, final double xscale) {
+        nPlotBubblesV(labelId, values, szs, count, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final int[] values, final int[] szs, final int count, final double xscale, final double xstart) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final int[] values, final int[] szs, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, int[] values, int[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, int[] values, int[] szs, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, int[] values, int[] szs, int count, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, int[] values, int[] szs, int count, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final long[] values, final long[] szs, final int count) {
+        nPlotBubblesV(labelId, values, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final long[] values, final long[] szs, final int count, final double xscale) {
+        nPlotBubblesV(labelId, values, szs, count, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final long[] values, final long[] szs, final int count, final double xscale, final double xstart) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final long[] values, final long[] szs, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, long[] values, long[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, long[] values, long[] szs, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, long[] values, long[] szs, int count, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, long[] values, long[] szs, int count, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final float[] values, final float[] szs, final int count) {
+        nPlotBubblesV(labelId, values, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final float[] values, final float[] szs, final int count, final double xscale) {
+        nPlotBubblesV(labelId, values, szs, count, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final float[] values, final float[] szs, final int count, final double xscale, final double xstart) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final float[] values, final float[] szs, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, float[] values, float[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, float[] values, float[] szs, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, float[] values, float[] szs, int count, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, float[] values, float[] szs, int count, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final double[] values, final double[] szs, final int count) {
+        nPlotBubblesV(labelId, values, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final double[] values, final double[] szs, final int count, final double xscale) {
+        nPlotBubblesV(labelId, values, szs, count, xscale);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final double[] values, final double[] szs, final int count, final double xscale, final double xstart) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final double[] values, final double[] szs, final int count, final double xscale, final double xstart, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, values, szs, count, xscale, xstart, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, double[] values, double[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, double[] values, double[] szs, int count, double xscale); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, double[] values, double[] szs, int count, double xscale, double xstart); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, double[] values, double[] szs, int count, double xscale, double xstart, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto values = obj_values == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_values, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &values[0], &szs[0], count, xscale, xstart, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    // xs,ys,szs
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final short[] xs, final short[] ys, final short[] szs) {
+        nPlotBubbles(labelId, xs, ys, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final short[] xs, final short[] ys, final short[] szs, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, xs, ys, szs, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, short[] xs, short[] ys, short[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, short[] xs, short[] ys, short[] szs, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final int[] xs, final int[] ys, final int[] szs) {
+        nPlotBubbles(labelId, xs, ys, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final int[] xs, final int[] ys, final int[] szs, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, xs, ys, szs, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, int[] xs, int[] ys, int[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, int[] xs, int[] ys, int[] szs, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final long[] xs, final long[] ys, final long[] szs) {
+        nPlotBubbles(labelId, xs, ys, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final long[] xs, final long[] ys, final long[] szs, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, xs, ys, szs, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, long[] xs, long[] ys, long[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, long[] xs, long[] ys, long[] szs, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final float[] xs, final float[] ys, final float[] szs) {
+        nPlotBubbles(labelId, xs, ys, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final float[] xs, final float[] ys, final float[] szs, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, xs, ys, szs, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, float[] xs, float[] ys, float[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, float[] xs, float[] ys, float[] szs, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final double[] xs, final double[] ys, final double[] szs) {
+        nPlotBubbles(labelId, xs, ys, szs);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubbles(final String labelId, final double[] xs, final double[] ys, final double[] szs, final ImPlotSpec spec) {
+        nPlotBubbles(labelId, xs, ys, szs, spec.ptr);
+    }
+
+    private static native void nPlotBubbles(String labelId, double[] xs, double[] ys, double[] szs); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubbles(String labelId, double[] xs, double[] ys, double[] szs, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final short[] xs, final short[] ys, final short[] szs, final int count) {
+        nPlotBubblesV(labelId, xs, ys, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final short[] xs, final short[] ys, final short[] szs, final int count, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, xs, ys, szs, count, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, short[] xs, short[] ys, short[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, short[] xs, short[] ys, short[] szs, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final int[] xs, final int[] ys, final int[] szs, final int count) {
+        nPlotBubblesV(labelId, xs, ys, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final int[] xs, final int[] ys, final int[] szs, final int count, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, xs, ys, szs, count, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, int[] xs, int[] ys, int[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, int[] xs, int[] ys, int[] szs, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final long[] xs, final long[] ys, final long[] szs, final int count) {
+        nPlotBubblesV(labelId, xs, ys, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final long[] xs, final long[] ys, final long[] szs, final int count, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, xs, ys, szs, count, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, long[] xs, long[] ys, long[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, long[] xs, long[] ys, long[] szs, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final float[] xs, final float[] ys, final float[] szs, final int count) {
+        nPlotBubblesV(labelId, xs, ys, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final float[] xs, final float[] ys, final float[] szs, final int count, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, xs, ys, szs, count, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, float[] xs, float[] ys, float[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, float[] xs, float[] ys, float[] szs, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final double[] xs, final double[] ys, final double[] szs, final int count) {
+        nPlotBubblesV(labelId, xs, ys, szs, count);
+    }
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    public static void plotBubblesV(final String labelId, final double[] xs, final double[] ys, final double[] szs, final int count, final ImPlotSpec spec) {
+        nPlotBubblesV(labelId, xs, ys, szs, count, spec.ptr);
+    }
+
+    private static native void nPlotBubblesV(String labelId, double[] xs, double[] ys, double[] szs, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    private static native void nPlotBubblesV(String labelId, double[] xs, double[] ys, double[] szs, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        auto szs = obj_szs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_szs, JNI_FALSE);
+        ImPlot::PlotBubbles(labelId, &xs[0], &ys[0], &szs[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+        if (szs != NULL) env->ReleasePrimitiveArrayCritical(obj_szs, szs, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final short[] xs, final short[] ys) {
+        nPlotPolygon(labelId, xs, ys);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final short[] xs, final short[] ys, final ImPlotSpec spec) {
+        nPlotPolygon(labelId, xs, ys, spec.ptr);
+    }
+
+    private static native void nPlotPolygon(String labelId, short[] xs, short[] ys); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygon(String labelId, short[] xs, short[] ys, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final int[] xs, final int[] ys) {
+        nPlotPolygon(labelId, xs, ys);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final int[] xs, final int[] ys, final ImPlotSpec spec) {
+        nPlotPolygon(labelId, xs, ys, spec.ptr);
+    }
+
+    private static native void nPlotPolygon(String labelId, int[] xs, int[] ys); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygon(String labelId, int[] xs, int[] ys, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final long[] xs, final long[] ys) {
+        nPlotPolygon(labelId, xs, ys);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final long[] xs, final long[] ys, final ImPlotSpec spec) {
+        nPlotPolygon(labelId, xs, ys, spec.ptr);
+    }
+
+    private static native void nPlotPolygon(String labelId, long[] xs, long[] ys); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygon(String labelId, long[] xs, long[] ys, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final float[] xs, final float[] ys) {
+        nPlotPolygon(labelId, xs, ys);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final float[] xs, final float[] ys, final ImPlotSpec spec) {
+        nPlotPolygon(labelId, xs, ys, spec.ptr);
+    }
+
+    private static native void nPlotPolygon(String labelId, float[] xs, float[] ys); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygon(String labelId, float[] xs, float[] ys, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final double[] xs, final double[] ys) {
+        nPlotPolygon(labelId, xs, ys);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygon(final String labelId, final double[] xs, final double[] ys, final ImPlotSpec spec) {
+        nPlotPolygon(labelId, xs, ys, spec.ptr);
+    }
+
+    private static native void nPlotPolygon(String labelId, double[] xs, double[] ys); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygon(String labelId, double[] xs, double[] ys, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], LEN(xs), *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final short[] xs, final short[] ys, final int count) {
+        nPlotPolygonV(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final short[] xs, final short[] ys, final int count, final ImPlotSpec spec) {
+        nPlotPolygonV(labelId, xs, ys, count, spec.ptr);
+    }
+
+    private static native void nPlotPolygonV(String labelId, short[] xs, short[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygonV(String labelId, short[] xs, short[] ys, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (short*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final int[] xs, final int[] ys, final int count) {
+        nPlotPolygonV(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final int[] xs, final int[] ys, final int count, final ImPlotSpec spec) {
+        nPlotPolygonV(labelId, xs, ys, count, spec.ptr);
+    }
+
+    private static native void nPlotPolygonV(String labelId, int[] xs, int[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygonV(String labelId, int[] xs, int[] ys, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (int*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final long[] xs, final long[] ys, final int count) {
+        nPlotPolygonV(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final long[] xs, final long[] ys, final int count, final ImPlotSpec spec) {
+        nPlotPolygonV(labelId, xs, ys, count, spec.ptr);
+    }
+
+    private static native void nPlotPolygonV(String labelId, long[] xs, long[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygonV(String labelId, long[] xs, long[] ys, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (long*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final float[] xs, final float[] ys, final int count) {
+        nPlotPolygonV(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final float[] xs, final float[] ys, final int count, final ImPlotSpec spec) {
+        nPlotPolygonV(labelId, xs, ys, count, spec.ptr);
+    }
+
+    private static native void nPlotPolygonV(String labelId, float[] xs, float[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygonV(String labelId, float[] xs, float[] ys, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (float*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final double[] xs, final double[] ys, final int count) {
+        nPlotPolygonV(labelId, xs, ys, count);
+    }
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    public static void plotPolygonV(final String labelId, final double[] xs, final double[] ys, final int count, final ImPlotSpec spec) {
+        nPlotPolygonV(labelId, xs, ys, count, spec.ptr);
+    }
+
+    private static native void nPlotPolygonV(String labelId, double[] xs, double[] ys, int count); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count);
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
+    */
+
+    private static native void nPlotPolygonV(String labelId, double[] xs, double[] ys, int count, long spec); /*MANUAL
+        auto labelId = obj_labelId == NULL ? NULL : (char*)env->GetStringUTFChars(obj_labelId, JNI_FALSE);
+        auto xs = obj_xs == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_xs, JNI_FALSE);
+        auto ys = obj_ys == NULL ? NULL : (double*)env->GetPrimitiveArrayCritical(obj_ys, JNI_FALSE);
+        ImPlot::PlotPolygon(labelId, &xs[0], &ys[0], count, *reinterpret_cast<ImPlotSpec*>(spec));
+        if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
+        if (xs != NULL) env->ReleasePrimitiveArrayCritical(obj_xs, xs, JNI_FALSE);
+        if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
     /*JNI
@@ -19453,313 +18292,15 @@ public final class ImPlot {
     */
 
     /**
-     * Set the line color and weight for the next item only.
+     * Returns the next automatic marker (in the order ImPlot cycles markers for auto-style items).
+     * Replaces SetNextMarkerStyle in v1.0; to style the next item, populate an ImPlotSpec instead (LineColor, FillColor, Marker, MarkerSize, LineWeight, MarkerLineColor, Size, ErrorBar style, etc.) and pass it to the Plot* call. The SetNextLineStyle/SetNextFillStyle/SetNextErrorBarStyle helpers were removed for the same reason.
      */
-    public static void setNextLineStyle() {
-        nSetNextLineStyle();
+    public static int nextMarker() {
+        return nNextMarker();
     }
 
-    /**
-     * Set the line color and weight for the next item only.
-     */
-    public static void setNextLineStyle(final ImVec4 col) {
-        nSetNextLineStyle(col.x, col.y, col.z, col.w);
-    }
-
-    /**
-     * Set the line color and weight for the next item only.
-     */
-    public static void setNextLineStyle(final float colX, final float colY, final float colZ, final float colW) {
-        nSetNextLineStyle(colX, colY, colZ, colW);
-    }
-
-    /**
-     * Set the line color and weight for the next item only.
-     */
-    public static void setNextLineStyle(final ImVec4 col, final float weight) {
-        nSetNextLineStyle(col.x, col.y, col.z, col.w, weight);
-    }
-
-    /**
-     * Set the line color and weight for the next item only.
-     */
-    public static void setNextLineStyle(final float colX, final float colY, final float colZ, final float colW, final float weight) {
-        nSetNextLineStyle(colX, colY, colZ, colW, weight);
-    }
-
-    /**
-     * Set the line color and weight for the next item only.
-     */
-    public static void setNextLineStyle(final float weight) {
-        nSetNextLineStyle(weight);
-    }
-
-    private static native void nSetNextLineStyle(); /*
-        ImPlot::SetNextLineStyle();
-    */
-
-    private static native void nSetNextLineStyle(float colX, float colY, float colZ, float colW); /*MANUAL
-        ImVec4 col = ImVec4(colX, colY, colZ, colW);
-        ImPlot::SetNextLineStyle(col);
-    */
-
-    private static native void nSetNextLineStyle(float colX, float colY, float colZ, float colW, float weight); /*MANUAL
-        ImVec4 col = ImVec4(colX, colY, colZ, colW);
-        ImPlot::SetNextLineStyle(col, weight);
-    */
-
-    private static native void nSetNextLineStyle(float weight); /*
-        ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, weight);
-    */
-
-    /**
-     * Set the fill color for the next item only.
-     */
-    public static void setNextFillStyle() {
-        nSetNextFillStyle();
-    }
-
-    /**
-     * Set the fill color for the next item only.
-     */
-    public static void setNextFillStyle(final ImVec4 col) {
-        nSetNextFillStyle(col.x, col.y, col.z, col.w);
-    }
-
-    /**
-     * Set the fill color for the next item only.
-     */
-    public static void setNextFillStyle(final float colX, final float colY, final float colZ, final float colW) {
-        nSetNextFillStyle(colX, colY, colZ, colW);
-    }
-
-    /**
-     * Set the fill color for the next item only.
-     */
-    public static void setNextFillStyle(final ImVec4 col, final float alphaMod) {
-        nSetNextFillStyle(col.x, col.y, col.z, col.w, alphaMod);
-    }
-
-    /**
-     * Set the fill color for the next item only.
-     */
-    public static void setNextFillStyle(final float colX, final float colY, final float colZ, final float colW, final float alphaMod) {
-        nSetNextFillStyle(colX, colY, colZ, colW, alphaMod);
-    }
-
-    /**
-     * Set the fill color for the next item only.
-     */
-    public static void setNextFillStyle(final float alphaMod) {
-        nSetNextFillStyle(alphaMod);
-    }
-
-    private static native void nSetNextFillStyle(); /*
-        ImPlot::SetNextFillStyle();
-    */
-
-    private static native void nSetNextFillStyle(float colX, float colY, float colZ, float colW); /*MANUAL
-        ImVec4 col = ImVec4(colX, colY, colZ, colW);
-        ImPlot::SetNextFillStyle(col);
-    */
-
-    private static native void nSetNextFillStyle(float colX, float colY, float colZ, float colW, float alphaMod); /*MANUAL
-        ImVec4 col = ImVec4(colX, colY, colZ, colW);
-        ImPlot::SetNextFillStyle(col, alphaMod);
-    */
-
-    private static native void nSetNextFillStyle(float alphaMod); /*
-        ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, alphaMod);
-    */
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle() {
-        nSetNextMarkerStyle();
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker) {
-        nSetNextMarkerStyle(marker);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size) {
-        nSetNextMarkerStyle(marker, size);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size, final ImVec4 fill) {
-        nSetNextMarkerStyle(marker, size, fill.x, fill.y, fill.z, fill.w);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size, final float fillX, final float fillY, final float fillZ, final float fillW) {
-        nSetNextMarkerStyle(marker, size, fillX, fillY, fillZ, fillW);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size, final ImVec4 fill, final float weight) {
-        nSetNextMarkerStyle(marker, size, fill.x, fill.y, fill.z, fill.w, weight);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size, final float fillX, final float fillY, final float fillZ, final float fillW, final float weight) {
-        nSetNextMarkerStyle(marker, size, fillX, fillY, fillZ, fillW, weight);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size, final ImVec4 fill, final float weight, final ImVec4 outline) {
-        nSetNextMarkerStyle(marker, size, fill.x, fill.y, fill.z, fill.w, weight, outline.x, outline.y, outline.z, outline.w);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size, final float fillX, final float fillY, final float fillZ, final float fillW, final float weight, final float outlineX, final float outlineY, final float outlineZ, final float outlineW) {
-        nSetNextMarkerStyle(marker, size, fillX, fillY, fillZ, fillW, weight, outlineX, outlineY, outlineZ, outlineW);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size, final ImVec4 fill, final ImVec4 outline) {
-        nSetNextMarkerStyle(marker, size, fill.x, fill.y, fill.z, fill.w, outline.x, outline.y, outline.z, outline.w);
-    }
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    public static void setNextMarkerStyle(final int marker, final float size, final float fillX, final float fillY, final float fillZ, final float fillW, final float outlineX, final float outlineY, final float outlineZ, final float outlineW) {
-        nSetNextMarkerStyle(marker, size, fillX, fillY, fillZ, fillW, outlineX, outlineY, outlineZ, outlineW);
-    }
-
-    private static native void nSetNextMarkerStyle(); /*
-        ImPlot::SetNextMarkerStyle();
-    */
-
-    private static native void nSetNextMarkerStyle(int marker); /*
-        ImPlot::SetNextMarkerStyle(marker);
-    */
-
-    private static native void nSetNextMarkerStyle(int marker, float size); /*
-        ImPlot::SetNextMarkerStyle(marker, size);
-    */
-
-    private static native void nSetNextMarkerStyle(int marker, float size, float fillX, float fillY, float fillZ, float fillW); /*MANUAL
-        ImVec4 fill = ImVec4(fillX, fillY, fillZ, fillW);
-        ImPlot::SetNextMarkerStyle(marker, size, fill);
-    */
-
-    private static native void nSetNextMarkerStyle(int marker, float size, float fillX, float fillY, float fillZ, float fillW, float weight); /*MANUAL
-        ImVec4 fill = ImVec4(fillX, fillY, fillZ, fillW);
-        ImPlot::SetNextMarkerStyle(marker, size, fill, weight);
-    */
-
-    private static native void nSetNextMarkerStyle(int marker, float size, float fillX, float fillY, float fillZ, float fillW, float weight, float outlineX, float outlineY, float outlineZ, float outlineW); /*MANUAL
-        ImVec4 fill = ImVec4(fillX, fillY, fillZ, fillW);
-        ImVec4 outline = ImVec4(outlineX, outlineY, outlineZ, outlineW);
-        ImPlot::SetNextMarkerStyle(marker, size, fill, weight, outline);
-    */
-
-    private static native void nSetNextMarkerStyle(int marker, float size, float fillX, float fillY, float fillZ, float fillW, float outlineX, float outlineY, float outlineZ, float outlineW); /*MANUAL
-        ImVec4 fill = ImVec4(fillX, fillY, fillZ, fillW);
-        ImVec4 outline = ImVec4(outlineX, outlineY, outlineZ, outlineW);
-        ImPlot::SetNextMarkerStyle(marker, size, fill, IMPLOT_AUTO, outline);
-    */
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    public static void setNextErrorBarStyle() {
-        nSetNextErrorBarStyle();
-    }
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    public static void setNextErrorBarStyle(final ImVec4 col) {
-        nSetNextErrorBarStyle(col.x, col.y, col.z, col.w);
-    }
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    public static void setNextErrorBarStyle(final float colX, final float colY, final float colZ, final float colW) {
-        nSetNextErrorBarStyle(colX, colY, colZ, colW);
-    }
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    public static void setNextErrorBarStyle(final ImVec4 col, final float size) {
-        nSetNextErrorBarStyle(col.x, col.y, col.z, col.w, size);
-    }
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    public static void setNextErrorBarStyle(final float colX, final float colY, final float colZ, final float colW, final float size) {
-        nSetNextErrorBarStyle(colX, colY, colZ, colW, size);
-    }
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    public static void setNextErrorBarStyle(final ImVec4 col, final float size, final float weight) {
-        nSetNextErrorBarStyle(col.x, col.y, col.z, col.w, size, weight);
-    }
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    public static void setNextErrorBarStyle(final float colX, final float colY, final float colZ, final float colW, final float size, final float weight) {
-        nSetNextErrorBarStyle(colX, colY, colZ, colW, size, weight);
-    }
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    public static void setNextErrorBarStyle(final float size, final float weight) {
-        nSetNextErrorBarStyle(size, weight);
-    }
-
-    private static native void nSetNextErrorBarStyle(); /*
-        ImPlot::SetNextErrorBarStyle();
-    */
-
-    private static native void nSetNextErrorBarStyle(float colX, float colY, float colZ, float colW); /*MANUAL
-        ImVec4 col = ImVec4(colX, colY, colZ, colW);
-        ImPlot::SetNextErrorBarStyle(col);
-    */
-
-    private static native void nSetNextErrorBarStyle(float colX, float colY, float colZ, float colW, float size); /*MANUAL
-        ImVec4 col = ImVec4(colX, colY, colZ, colW);
-        ImPlot::SetNextErrorBarStyle(col, size);
-    */
-
-    private static native void nSetNextErrorBarStyle(float colX, float colY, float colZ, float colW, float size, float weight); /*MANUAL
-        ImVec4 col = ImVec4(colX, colY, colZ, colW);
-        ImPlot::SetNextErrorBarStyle(col, size, weight);
-    */
-
-    private static native void nSetNextErrorBarStyle(float size, float weight); /*
-        ImPlot::SetNextErrorBarStyle(IMPLOT_AUTO_COL, size, weight);
+    private static native int nNextMarker(); /*
+        return ImPlot::NextMarker();
     */
 
     /**

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotSpec.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotSpec.java
@@ -1,0 +1,481 @@
+package imgui.extension.implot;
+
+import imgui.ImVec4;
+import imgui.binding.ImGuiStructDestroyable;
+
+public final class ImPlotSpec extends ImGuiStructDestroyable {
+    public ImPlotSpec() {
+        super();
+    }
+
+    public ImPlotSpec(final long ptr) {
+        super(ptr);
+    }
+
+    @Override
+    protected long create() {
+        return nCreate();
+    }
+
+    @Override
+    public void destroy() {
+        nFreeArrays(ptr);
+        super.destroy();
+    }
+
+    /*JNI
+        #include "_implot.h"
+        #define THIS ((ImPlotSpec*)STRUCT_PTR)
+     */
+
+    private native long nCreate(); /*
+        return (uintptr_t)(new ImPlotSpec());
+    */
+
+    // Frees any array backing buffers currently held by this spec. Called from destroy()
+    // before the struct itself is deleted.
+    private native void nFreeArrays(long specPtr); /*
+        ImPlotSpec* spec = (ImPlotSpec*)specPtr;
+        if (spec->LineColors)       { ImGui::MemFree(spec->LineColors);       spec->LineColors       = NULL; }
+        if (spec->FillColors)       { ImGui::MemFree(spec->FillColors);       spec->FillColors       = NULL; }
+        if (spec->MarkerSizes)      { ImGui::MemFree(spec->MarkerSizes);      spec->MarkerSizes      = NULL; }
+        if (spec->MarkerLineColors) { ImGui::MemFree(spec->MarkerLineColors); spec->MarkerLineColors = NULL; }
+        if (spec->MarkerFillColors) { ImGui::MemFree(spec->MarkerFillColors); spec->MarkerFillColors = NULL; }
+    */
+
+    public ImVec4 getLineColor() {
+        final ImVec4 dst = new ImVec4();
+        nGetLineColor(dst);
+        return dst;
+    }
+
+    public float getLineColorX() {
+        return nGetLineColorX();
+    }
+
+    public float getLineColorY() {
+        return nGetLineColorY();
+    }
+
+    public float getLineColorZ() {
+        return nGetLineColorZ();
+    }
+
+    public float getLineColorW() {
+        return nGetLineColorW();
+    }
+
+    public void getLineColor(final ImVec4 dst) {
+        nGetLineColor(dst);
+    }
+
+    public void setLineColor(final ImVec4 value) {
+        nSetLineColor(value.x, value.y, value.z, value.w);
+    }
+
+    public void setLineColor(final float valueX, final float valueY, final float valueZ, final float valueW) {
+        nSetLineColor(valueX, valueY, valueZ, valueW);
+    }
+
+    private native void nGetLineColor(ImVec4 dst); /*
+        Jni::ImVec4Cpy(env, THIS->LineColor, dst);
+    */
+
+    private native float nGetLineColorX(); /*
+        return THIS->LineColor.x;
+    */
+
+    private native float nGetLineColorY(); /*
+        return THIS->LineColor.y;
+    */
+
+    private native float nGetLineColorZ(); /*
+        return THIS->LineColor.z;
+    */
+
+    private native float nGetLineColorW(); /*
+        return THIS->LineColor.w;
+    */
+
+    private native void nSetLineColor(float valueX, float valueY, float valueZ, float valueW); /*MANUAL
+        ImVec4 value = ImVec4(valueX, valueY, valueZ, valueW);
+        THIS->LineColor = value;
+    */
+
+    public float getLineWeight() {
+        return nGetLineWeight();
+    }
+
+    public void setLineWeight(final float value) {
+        nSetLineWeight(value);
+    }
+
+    private native float nGetLineWeight(); /*
+        return THIS->LineWeight;
+    */
+
+    private native void nSetLineWeight(float value); /*
+        THIS->LineWeight = value;
+    */
+
+    public ImVec4 getFillColor() {
+        final ImVec4 dst = new ImVec4();
+        nGetFillColor(dst);
+        return dst;
+    }
+
+    public float getFillColorX() {
+        return nGetFillColorX();
+    }
+
+    public float getFillColorY() {
+        return nGetFillColorY();
+    }
+
+    public float getFillColorZ() {
+        return nGetFillColorZ();
+    }
+
+    public float getFillColorW() {
+        return nGetFillColorW();
+    }
+
+    public void getFillColor(final ImVec4 dst) {
+        nGetFillColor(dst);
+    }
+
+    public void setFillColor(final ImVec4 value) {
+        nSetFillColor(value.x, value.y, value.z, value.w);
+    }
+
+    public void setFillColor(final float valueX, final float valueY, final float valueZ, final float valueW) {
+        nSetFillColor(valueX, valueY, valueZ, valueW);
+    }
+
+    private native void nGetFillColor(ImVec4 dst); /*
+        Jni::ImVec4Cpy(env, THIS->FillColor, dst);
+    */
+
+    private native float nGetFillColorX(); /*
+        return THIS->FillColor.x;
+    */
+
+    private native float nGetFillColorY(); /*
+        return THIS->FillColor.y;
+    */
+
+    private native float nGetFillColorZ(); /*
+        return THIS->FillColor.z;
+    */
+
+    private native float nGetFillColorW(); /*
+        return THIS->FillColor.w;
+    */
+
+    private native void nSetFillColor(float valueX, float valueY, float valueZ, float valueW); /*MANUAL
+        ImVec4 value = ImVec4(valueX, valueY, valueZ, valueW);
+        THIS->FillColor = value;
+    */
+
+    public float getFillAlpha() {
+        return nGetFillAlpha();
+    }
+
+    public void setFillAlpha(final float value) {
+        nSetFillAlpha(value);
+    }
+
+    private native float nGetFillAlpha(); /*
+        return THIS->FillAlpha;
+    */
+
+    private native void nSetFillAlpha(float value); /*
+        THIS->FillAlpha = value;
+    */
+
+    public int getMarker() {
+        return nGetMarker();
+    }
+
+    public void setMarker(final int value) {
+        nSetMarker(value);
+    }
+
+    private native int nGetMarker(); /*
+        return THIS->Marker;
+    */
+
+    private native void nSetMarker(int value); /*
+        THIS->Marker = value;
+    */
+
+    public float getMarkerSize() {
+        return nGetMarkerSize();
+    }
+
+    public void setMarkerSize(final float value) {
+        nSetMarkerSize(value);
+    }
+
+    private native float nGetMarkerSize(); /*
+        return THIS->MarkerSize;
+    */
+
+    private native void nSetMarkerSize(float value); /*
+        THIS->MarkerSize = value;
+    */
+
+    public ImVec4 getMarkerLineColor() {
+        final ImVec4 dst = new ImVec4();
+        nGetMarkerLineColor(dst);
+        return dst;
+    }
+
+    public float getMarkerLineColorX() {
+        return nGetMarkerLineColorX();
+    }
+
+    public float getMarkerLineColorY() {
+        return nGetMarkerLineColorY();
+    }
+
+    public float getMarkerLineColorZ() {
+        return nGetMarkerLineColorZ();
+    }
+
+    public float getMarkerLineColorW() {
+        return nGetMarkerLineColorW();
+    }
+
+    public void getMarkerLineColor(final ImVec4 dst) {
+        nGetMarkerLineColor(dst);
+    }
+
+    public void setMarkerLineColor(final ImVec4 value) {
+        nSetMarkerLineColor(value.x, value.y, value.z, value.w);
+    }
+
+    public void setMarkerLineColor(final float valueX, final float valueY, final float valueZ, final float valueW) {
+        nSetMarkerLineColor(valueX, valueY, valueZ, valueW);
+    }
+
+    private native void nGetMarkerLineColor(ImVec4 dst); /*
+        Jni::ImVec4Cpy(env, THIS->MarkerLineColor, dst);
+    */
+
+    private native float nGetMarkerLineColorX(); /*
+        return THIS->MarkerLineColor.x;
+    */
+
+    private native float nGetMarkerLineColorY(); /*
+        return THIS->MarkerLineColor.y;
+    */
+
+    private native float nGetMarkerLineColorZ(); /*
+        return THIS->MarkerLineColor.z;
+    */
+
+    private native float nGetMarkerLineColorW(); /*
+        return THIS->MarkerLineColor.w;
+    */
+
+    private native void nSetMarkerLineColor(float valueX, float valueY, float valueZ, float valueW); /*MANUAL
+        ImVec4 value = ImVec4(valueX, valueY, valueZ, valueW);
+        THIS->MarkerLineColor = value;
+    */
+
+    public ImVec4 getMarkerFillColor() {
+        final ImVec4 dst = new ImVec4();
+        nGetMarkerFillColor(dst);
+        return dst;
+    }
+
+    public float getMarkerFillColorX() {
+        return nGetMarkerFillColorX();
+    }
+
+    public float getMarkerFillColorY() {
+        return nGetMarkerFillColorY();
+    }
+
+    public float getMarkerFillColorZ() {
+        return nGetMarkerFillColorZ();
+    }
+
+    public float getMarkerFillColorW() {
+        return nGetMarkerFillColorW();
+    }
+
+    public void getMarkerFillColor(final ImVec4 dst) {
+        nGetMarkerFillColor(dst);
+    }
+
+    public void setMarkerFillColor(final ImVec4 value) {
+        nSetMarkerFillColor(value.x, value.y, value.z, value.w);
+    }
+
+    public void setMarkerFillColor(final float valueX, final float valueY, final float valueZ, final float valueW) {
+        nSetMarkerFillColor(valueX, valueY, valueZ, valueW);
+    }
+
+    private native void nGetMarkerFillColor(ImVec4 dst); /*
+        Jni::ImVec4Cpy(env, THIS->MarkerFillColor, dst);
+    */
+
+    private native float nGetMarkerFillColorX(); /*
+        return THIS->MarkerFillColor.x;
+    */
+
+    private native float nGetMarkerFillColorY(); /*
+        return THIS->MarkerFillColor.y;
+    */
+
+    private native float nGetMarkerFillColorZ(); /*
+        return THIS->MarkerFillColor.z;
+    */
+
+    private native float nGetMarkerFillColorW(); /*
+        return THIS->MarkerFillColor.w;
+    */
+
+    private native void nSetMarkerFillColor(float valueX, float valueY, float valueZ, float valueW); /*MANUAL
+        ImVec4 value = ImVec4(valueX, valueY, valueZ, valueW);
+        THIS->MarkerFillColor = value;
+    */
+
+    public float getSize() {
+        return nGetSize();
+    }
+
+    public void setSize(final float value) {
+        nSetSize(value);
+    }
+
+    private native float nGetSize(); /*
+        return THIS->Size;
+    */
+
+    private native void nSetSize(float value); /*
+        THIS->Size = value;
+    */
+
+    public int getOffset() {
+        return nGetOffset();
+    }
+
+    public void setOffset(final int value) {
+        nSetOffset(value);
+    }
+
+    private native int nGetOffset(); /*
+        return THIS->Offset;
+    */
+
+    private native void nSetOffset(int value); /*
+        THIS->Offset = value;
+    */
+
+    public int getStride() {
+        return nGetStride();
+    }
+
+    public void setStride(final int value) {
+        nSetStride(value);
+    }
+
+    private native int nGetStride(); /*
+        return THIS->Stride;
+    */
+
+    private native void nSetStride(int value); /*
+        THIS->Stride = value;
+    */
+
+    public int getFlags() {
+        return nGetFlags();
+    }
+
+    public void setFlags(final int value) {
+        nSetFlags(value);
+    }
+
+    private native int nGetFlags(); /*
+        return THIS->Flags;
+    */
+
+    private native void nSetFlags(int value); /*
+        THIS->Flags = value;
+    */
+
+    // Per-index color array for lines (ImU32 packed RGBA). Pass null to clear.
+    // Ownership: the backing buffer is allocated in native memory and freed on destroy()
+    // or when reassigned.
+    public void setLineColors(final int[] colors) {
+        nSetLineColors(colors, colors != null ? colors.length : 0);
+    }
+
+    private native void nSetLineColors(int[] colors, int len); /*
+        if (THIS->LineColors) { ImGui::MemFree(THIS->LineColors); THIS->LineColors = NULL; }
+        if (colors != NULL && len > 0) {
+            ImU32* buf = (ImU32*)ImGui::MemAlloc(len * sizeof(ImU32));
+            for (int i = 0; i < len; i++) { buf[i] = (ImU32)colors[i]; }
+            THIS->LineColors = buf;
+        }
+    */
+
+    public void setFillColors(final int[] colors) {
+        nSetFillColors(colors, colors != null ? colors.length : 0);
+    }
+
+    private native void nSetFillColors(int[] colors, int len); /*
+        if (THIS->FillColors) { ImGui::MemFree(THIS->FillColors); THIS->FillColors = NULL; }
+        if (colors != NULL && len > 0) {
+            ImU32* buf = (ImU32*)ImGui::MemAlloc(len * sizeof(ImU32));
+            for (int i = 0; i < len; i++) { buf[i] = (ImU32)colors[i]; }
+            THIS->FillColors = buf;
+        }
+    */
+
+    public void setMarkerSizes(final float[] sizes) {
+        nSetMarkerSizes(sizes, sizes != null ? sizes.length : 0);
+    }
+
+    private native void nSetMarkerSizes(float[] sizes, int len); /*
+        if (THIS->MarkerSizes) { ImGui::MemFree(THIS->MarkerSizes); THIS->MarkerSizes = NULL; }
+        if (sizes != NULL && len > 0) {
+            float* buf = (float*)ImGui::MemAlloc(len * sizeof(float));
+            for (int i = 0; i < len; i++) { buf[i] = sizes[i]; }
+            THIS->MarkerSizes = buf;
+        }
+    */
+
+    public void setMarkerLineColors(final int[] colors) {
+        nSetMarkerLineColors(colors, colors != null ? colors.length : 0);
+    }
+
+    private native void nSetMarkerLineColors(int[] colors, int len); /*
+        if (THIS->MarkerLineColors) { ImGui::MemFree(THIS->MarkerLineColors); THIS->MarkerLineColors = NULL; }
+        if (colors != NULL && len > 0) {
+            ImU32* buf = (ImU32*)ImGui::MemAlloc(len * sizeof(ImU32));
+            for (int i = 0; i < len; i++) { buf[i] = (ImU32)colors[i]; }
+            THIS->MarkerLineColors = buf;
+        }
+    */
+
+    public void setMarkerFillColors(final int[] colors) {
+        nSetMarkerFillColors(colors, colors != null ? colors.length : 0);
+    }
+
+    private native void nSetMarkerFillColors(int[] colors, int len); /*
+        if (THIS->MarkerFillColors) { ImGui::MemFree(THIS->MarkerFillColors); THIS->MarkerFillColors = NULL; }
+        if (colors != NULL && len > 0) {
+            ImU32* buf = (ImU32*)ImGui::MemAlloc(len * sizeof(ImU32));
+            for (int i = 0; i < len; i++) { buf[i] = (ImU32)colors[i]; }
+            THIS->MarkerFillColors = buf;
+        }
+    */
+
+    /*JNI
+        #undef THIS
+     */
+}

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotSpec.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotSpec.java
@@ -409,9 +409,14 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
 
     // Per-index color array for lines (ImU32 packed RGBA). Pass null to clear.
     // Ownership: the backing buffer is allocated in native memory and freed on destroy()
-    // or when reassigned.
+    // or when reassigned. The (arr, len) overloads mirror the plot methods and let
+    // callers reuse a backing array larger than the logical count.
     public void setLineColors(final int[] colors) {
         nSetLineColors(colors, colors != null ? colors.length : 0);
+    }
+
+    public void setLineColors(final int[] colors, final int len) {
+        nSetLineColors(colors, len);
     }
 
     private native void nSetLineColors(int[] colors, int len); /*
@@ -427,6 +432,10 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
         nSetFillColors(colors, colors != null ? colors.length : 0);
     }
 
+    public void setFillColors(final int[] colors, final int len) {
+        nSetFillColors(colors, len);
+    }
+
     private native void nSetFillColors(int[] colors, int len); /*
         if (THIS->FillColors) { ImGui::MemFree(THIS->FillColors); THIS->FillColors = NULL; }
         if (colors != NULL && len > 0) {
@@ -438,6 +447,10 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
 
     public void setMarkerSizes(final float[] sizes) {
         nSetMarkerSizes(sizes, sizes != null ? sizes.length : 0);
+    }
+
+    public void setMarkerSizes(final float[] sizes, final int len) {
+        nSetMarkerSizes(sizes, len);
     }
 
     private native void nSetMarkerSizes(float[] sizes, int len); /*
@@ -453,6 +466,10 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
         nSetMarkerLineColors(colors, colors != null ? colors.length : 0);
     }
 
+    public void setMarkerLineColors(final int[] colors, final int len) {
+        nSetMarkerLineColors(colors, len);
+    }
+
     private native void nSetMarkerLineColors(int[] colors, int len); /*
         if (THIS->MarkerLineColors) { ImGui::MemFree(THIS->MarkerLineColors); THIS->MarkerLineColors = NULL; }
         if (colors != NULL && len > 0) {
@@ -464,6 +481,10 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
 
     public void setMarkerFillColors(final int[] colors) {
         nSetMarkerFillColors(colors, colors != null ? colors.length : 0);
+    }
+
+    public void setMarkerFillColors(final int[] colors, final int len) {
+        nSetMarkerFillColors(colors, len);
     }
 
     private native void nSetMarkerFillColors(int[] colors, int len); /*

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotStyle.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotStyle.java
@@ -27,150 +27,6 @@ public final class ImPlotStyle extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImPlotStyle());
     */
 
-    public float getLineWeight() {
-        return nGetLineWeight();
-    }
-
-    public void setLineWeight(final float value) {
-        nSetLineWeight(value);
-    }
-
-    private native float nGetLineWeight(); /*
-        return THIS->LineWeight;
-    */
-
-    private native void nSetLineWeight(float value); /*
-        THIS->LineWeight = value;
-    */
-
-    public int getMarker() {
-        return nGetMarker();
-    }
-
-    public void setMarker(final int value) {
-        nSetMarker(value);
-    }
-
-    private native int nGetMarker(); /*
-        return THIS->Marker;
-    */
-
-    private native void nSetMarker(int value); /*
-        THIS->Marker = value;
-    */
-
-    public float getMarkerSize() {
-        return nGetMarkerSize();
-    }
-
-    public void setMarkerSize(final float value) {
-        nSetMarkerSize(value);
-    }
-
-    private native float nGetMarkerSize(); /*
-        return THIS->MarkerSize;
-    */
-
-    private native void nSetMarkerSize(float value); /*
-        THIS->MarkerSize = value;
-    */
-
-    public float getMarkerWeight() {
-        return nGetMarkerWeight();
-    }
-
-    public void setMarkerWeight(final float value) {
-        nSetMarkerWeight(value);
-    }
-
-    private native float nGetMarkerWeight(); /*
-        return THIS->MarkerWeight;
-    */
-
-    private native void nSetMarkerWeight(float value); /*
-        THIS->MarkerWeight = value;
-    */
-
-    public float getFillAlpha() {
-        return nGetFillAlpha();
-    }
-
-    public void setFillAlpha(final float value) {
-        nSetFillAlpha(value);
-    }
-
-    private native float nGetFillAlpha(); /*
-        return THIS->FillAlpha;
-    */
-
-    private native void nSetFillAlpha(float value); /*
-        THIS->FillAlpha = value;
-    */
-
-    public float getErrorBarSize() {
-        return nGetErrorBarSize();
-    }
-
-    public void setErrorBarSize(final float value) {
-        nSetErrorBarSize(value);
-    }
-
-    private native float nGetErrorBarSize(); /*
-        return THIS->ErrorBarSize;
-    */
-
-    private native void nSetErrorBarSize(float value); /*
-        THIS->ErrorBarSize = value;
-    */
-
-    public float getErrorBarWeight() {
-        return nGetErrorBarWeight();
-    }
-
-    public void setErrorBarWeight(final float value) {
-        nSetErrorBarWeight(value);
-    }
-
-    private native float nGetErrorBarWeight(); /*
-        return THIS->ErrorBarWeight;
-    */
-
-    private native void nSetErrorBarWeight(float value); /*
-        THIS->ErrorBarWeight = value;
-    */
-
-    public float getDigitalBitHeight() {
-        return nGetDigitalBitHeight();
-    }
-
-    public void setDigitalBitHeight(final float value) {
-        nSetDigitalBitHeight(value);
-    }
-
-    private native float nGetDigitalBitHeight(); /*
-        return THIS->DigitalBitHeight;
-    */
-
-    private native void nSetDigitalBitHeight(float value); /*
-        THIS->DigitalBitHeight = value;
-    */
-
-    public float getDigitalBitGap() {
-        return nGetDigitalBitGap();
-    }
-
-    public void setDigitalBitGap(final float value) {
-        nSetDigitalBitGap(value);
-    }
-
-    private native float nGetDigitalBitGap(); /*
-        return THIS->DigitalBitGap;
-    */
-
-    private native void nSetDigitalBitGap(float value); /*
-        THIS->DigitalBitGap = value;
-    */
-
     public float getPlotBorderSize() {
         return nGetPlotBorderSize();
     }
@@ -889,6 +745,38 @@ public final class ImPlotStyle extends ImGuiStructDestroyable {
     private native void nSetPlotMinSize(float valueX, float valueY); /*MANUAL
         ImVec2 value = ImVec2(valueX, valueY);
         THIS->PlotMinSize = value;
+    */
+
+    public float getDigitalPadding() {
+        return nGetDigitalPadding();
+    }
+
+    public void setDigitalPadding(final float value) {
+        nSetDigitalPadding(value);
+    }
+
+    private native float nGetDigitalPadding(); /*
+        return THIS->DigitalPadding;
+    */
+
+    private native void nSetDigitalPadding(float value); /*
+        THIS->DigitalPadding = value;
+    */
+
+    public float getDigitalSpacing() {
+        return nGetDigitalSpacing();
+    }
+
+    public void setDigitalSpacing(final float value) {
+        nSetDigitalSpacing(value);
+    }
+
+    private native float nGetDigitalSpacing(); /*
+        return THIS->DigitalSpacing;
+    */
+
+    private native void nSetDigitalSpacing(float value); /*
+        THIS->DigitalSpacing = value;
     */
 
     public ImVec4[] getColors() {

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCol.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCol.java
@@ -6,109 +6,84 @@ public final class ImPlotCol {
     }
 
     /**
-     * plot line/outline color (defaults to next unused color in current colormap)
-     */
-    public static final int Line = 0;
-
-    /**
-     * plot fill color for bars (defaults to the current line color)
-     */
-    public static final int Fill = 1;
-
-    /**
-     * marker outline color (defaults to the current line color)
-     */
-    public static final int MarkerOutline = 2;
-
-    /**
-     * marker fill color (defaults to the current line color)
-     */
-    public static final int MarkerFill = 3;
-
-    /**
-     * error bar color (defaults to ImGuiCol_Text)
-     */
-    public static final int ErrorBar = 4;
-
-    /**
      * plot frame background color (defaults to ImGuiCol_FrameBg)
      */
-    public static final int FrameBg = 5;
+    public static final int FrameBg = 0;
 
     /**
      * plot area background color (defaults to ImGuiCol_WindowBg)
      */
-    public static final int PlotBg = 6;
+    public static final int PlotBg = 1;
 
     /**
      * plot area border color (defaults to ImGuiCol_Border)
      */
-    public static final int PlotBorder = 7;
+    public static final int PlotBorder = 2;
 
     /**
      * legend background color (defaults to ImGuiCol_PopupBg)
      */
-    public static final int LegendBg = 8;
+    public static final int LegendBg = 3;
 
     /**
      * legend border color (defaults to ImPlotCol_PlotBorder)
      */
-    public static final int LegendBorder = 9;
+    public static final int LegendBorder = 4;
 
     /**
      * legend text color (defaults to ImPlotCol_InlayText)
      */
-    public static final int LegendText = 10;
+    public static final int LegendText = 5;
 
     /**
      * plot title text color (defaults to ImGuiCol_Text)
      */
-    public static final int TitleText = 11;
+    public static final int TitleText = 6;
 
     /**
      * color of text appearing inside of plots (defaults to ImGuiCol_Text)
      */
-    public static final int InlayText = 12;
+    public static final int InlayText = 7;
 
     /**
      * axis label and tick labels color (defaults to ImGuiCol_Text)
      */
-    public static final int AxisText = 13;
+    public static final int AxisText = 8;
 
     /**
      * axis grid color (defaults to 25% ImPlotCol_AxisText)
      */
-    public static final int AxisGrid = 14;
+    public static final int AxisGrid = 9;
 
     /**
      * axis tick color (defaults to AxisGrid)
      */
-    public static final int AxisTick = 15;
+    public static final int AxisTick = 10;
 
     /**
      * background color of axis hover region (defaults to transparent)
      */
-    public static final int AxisBg = 16;
+    public static final int AxisBg = 11;
 
     /**
      * axis hover color (defaults to ImGuiCol_ButtonHovered)
      */
-    public static final int AxisBgHovered = 17;
+    public static final int AxisBgHovered = 12;
 
     /**
      * axis active color (defaults to ImGuiCol_ButtonActive)
      */
-    public static final int AxisBgActive = 18;
+    public static final int AxisBgActive = 13;
 
     /**
      * box-selection color (defaults to yellow)
      */
-    public static final int Selection = 19;
+    public static final int Selection = 14;
 
     /**
      * crosshairs color (defaults to ImPlotCol_PlotBorder)
      */
-    public static final int Crosshairs = 20;
+    public static final int Crosshairs = 15;
 
-    public static final int COUNT = 21;
+    public static final int COUNT = 16;
 }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMarker.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMarker.java
@@ -8,9 +8,16 @@ public final class ImPlotMarker {
     /**
      * no marker
      *
+     * <p>Definition: {@code -2}
+     */
+    public static final int None = -2;
+
+    /**
+     * automatic marker selection
+     *
      * <p>Definition: {@code -1}
      */
-    public static final int None = -1;
+    public static final int Auto = -1;
 
     /**
      * a circle marker (default)
@@ -48,17 +55,17 @@ public final class ImPlotMarker {
     public static final int Right = 6;
 
     /**
-     * a cross marker (not fillable)
+     * a cross marker (not fill-able)
      */
     public static final int Cross = 7;
 
     /**
-     * a plus marker (not fillable)
+     * a plus marker (not fill-able)
      */
     public static final int Plus = 8;
 
     /**
-     * a asterisk marker (not fillable)
+     * a asterisk marker (not fill-able)
      */
     public static final int Asterisk = 9;
 

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotPieChartFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotPieChartFlags.java
@@ -27,9 +27,16 @@ public final class ImPlotPieChartFlags {
     public static final int IgnoreHidden = 2048;
 
     /**
-     * Explode legend-hovered slice
+     * explode legend-hovered slice
      *
      * <p>Definition: {@code 1 << 12}
      */
     public static final int Exploding = 4096;
+
+    /**
+     * do not draw slice borders
+     *
+     * <p>Definition: {@code 1 << 13}
+     */
+    public static final int NoSliceBorder = 8192;
 }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStyleVar.java
@@ -6,139 +6,104 @@ public final class ImPlotStyleVar {
     }
 
     /**
-     * float,  plot item line weight in pixels
-     */
-    public static final int LineWeight = 0;
-
-    /**
-     * int,    marker specification
-     */
-    public static final int Marker = 1;
-
-    /**
-     * float,  marker size in pixels (roughly the marker's "radius")
-     */
-    public static final int MarkerSize = 2;
-
-    /**
-     * float,  plot outline weight of markers in pixels
-     */
-    public static final int MarkerWeight = 3;
-
-    /**
-     * float,  alpha modifier applied to all plot item fills
-     */
-    public static final int FillAlpha = 4;
-
-    /**
-     * float,  error bar whisker width in pixels
-     */
-    public static final int ErrorBarSize = 5;
-
-    /**
-     * float,  error bar whisker weight in pixels
-     */
-    public static final int ErrorBarWeight = 6;
-
-    /**
-     * float,  digital channels bit height (at 1) in pixels
-     */
-    public static final int DigitalBitHeight = 7;
-
-    /**
-     * float,  digital channels bit padding gap in pixels
-     */
-    public static final int DigitalBitGap = 8;
-
-    /**
-     * float,  thickness of border around plot area
-     */
-    public static final int PlotBorderSize = 9;
-
-    /**
-     * float,  alpha multiplier applied to minor axis grid lines
-     */
-    public static final int MinorAlpha = 10;
-
-    /**
-     * ImVec2, major tick lengths for X and Y axes
-     */
-    public static final int MajorTickLen = 11;
-
-    /**
-     * ImVec2, minor tick lengths for X and Y axes
-     */
-    public static final int MinorTickLen = 12;
-
-    /**
-     * ImVec2, line thickness of major ticks
-     */
-    public static final int MajorTickSize = 13;
-
-    /**
-     * ImVec2, line thickness of minor ticks
-     */
-    public static final int MinorTickSize = 14;
-
-    /**
-     * ImVec2, line thickness of major grid lines
-     */
-    public static final int MajorGridSize = 15;
-
-    /**
-     * ImVec2, line thickness of minor grid lines
-     */
-    public static final int MinorGridSize = 16;
-
-    /**
-     * ImVec2, padding between widget frame and plot area, labels, or outside legends (i.e. main padding)
-     */
-    public static final int PlotPadding = 17;
-
-    /**
-     * ImVec2, padding between axes labels, tick labels, and plot edge
-     */
-    public static final int LabelPadding = 18;
-
-    /**
-     * ImVec2, legend padding from plot edges
-     */
-    public static final int LegendPadding = 19;
-
-    /**
-     * ImVec2, legend inner padding from legend edges
-     */
-    public static final int LegendInnerPadding = 20;
-
-    /**
-     * ImVec2, spacing between legend entries
-     */
-    public static final int LegendSpacing = 21;
-
-    /**
-     * ImVec2, padding between plot edge and interior info text
-     */
-    public static final int MousePosPadding = 22;
-
-    /**
-     * ImVec2, text padding around annotation labels
-     */
-    public static final int AnnotationPadding = 23;
-
-    /**
-     * ImVec2, additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)
-     */
-    public static final int FitPadding = 24;
-
-    /**
      * ImVec2, default size used when ImVec2(0,0) is passed to BeginPlot
      */
-    public static final int PlotDefaultSize = 25;
+    public static final int PlotDefaultSize = 0;
 
     /**
      * ImVec2, minimum size plot frame can be when shrunk
      */
-    public static final int PlotMinSize = 26;
+    public static final int PlotMinSize = 1;
 
-    public static final int COUNT = 27;
+    /**
+     * float,  thickness of border around plot area
+     */
+    public static final int PlotBorderSize = 2;
+
+    /**
+     * float,  alpha multiplier applied to minor axis grid lines
+     */
+    public static final int MinorAlpha = 3;
+
+    /**
+     * ImVec2, major tick lengths for X and Y axes
+     */
+    public static final int MajorTickLen = 4;
+
+    /**
+     * ImVec2, minor tick lengths for X and Y axes
+     */
+    public static final int MinorTickLen = 5;
+
+    /**
+     * ImVec2, line thickness of major ticks
+     */
+    public static final int MajorTickSize = 6;
+
+    /**
+     * ImVec2, line thickness of minor ticks
+     */
+    public static final int MinorTickSize = 7;
+
+    /**
+     * ImVec2, line thickness of major grid lines
+     */
+    public static final int MajorGridSize = 8;
+
+    /**
+     * ImVec2, line thickness of minor grid lines
+     */
+    public static final int MinorGridSize = 9;
+
+    /**
+     * ImVec2, padding between widget frame and plot area, labels, or outside legends (i.e. main padding)
+     */
+    public static final int PlotPadding = 10;
+
+    /**
+     * ImVec2, padding between axes labels, tick labels, and plot edge
+     */
+    public static final int LabelPadding = 11;
+
+    /**
+     * ImVec2, legend padding from plot edges
+     */
+    public static final int LegendPadding = 12;
+
+    /**
+     * ImVec2, legend inner padding from legend edges
+     */
+    public static final int LegendInnerPadding = 13;
+
+    /**
+     * ImVec2, spacing between legend entries
+     */
+    public static final int LegendSpacing = 14;
+
+    /**
+     * ImVec2, padding between plot edge and interior info text
+     */
+    public static final int MousePosPadding = 15;
+
+    /**
+     * ImVec2, text padding around annotation labels
+     */
+    public static final int AnnotationPadding = 16;
+
+    /**
+     * ImVec2, additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)
+     */
+    public static final int FitPadding = 17;
+
+    /**
+     * float,  digital plot padding from bottom in pixels
+     */
+    public static final int DigitalPadding = 18;
+
+    /**
+     * float,  digital plot spacing gap in pixels
+     */
+    public static final int DigitalSpacing = 19;
+
+    public static final int COUNT = 20;
 }

--- a/imgui-binding/src/main/java/imgui/extension/implot/ImPlot.java
+++ b/imgui-binding/src/main/java/imgui/extension/implot/ImPlot.java
@@ -399,8 +399,7 @@ public final class ImPlot {
                                        @ArgValue(callValue = "LEN(values)") Void count,
                                        @OptArg double xscale,
                                        @OptArg double xstart,
-                                       @OptArg int flags,
-                                       @OptArg int offset);
+                                       @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a standard 2D line plot.
@@ -411,8 +410,7 @@ public final class ImPlot {
                                         int count,
                                         @OptArg double xscale,
                                         @OptArg double xstart,
-                                        @OptArg int flags,
-                                        @OptArg int offset);
+                                        @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // xs,ys
 
@@ -424,7 +422,7 @@ public final class ImPlot {
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                        @ArgValue(callValue = "LEN(xs)") Void count,
-                                       @OptArg int flags);
+                                       @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a standard 2D line plot.
@@ -434,8 +432,7 @@ public final class ImPlot {
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                         int count,
-                                        @OptArg int flags,
-                                        @OptArg int offset);
+                                        @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // values
 
@@ -448,8 +445,7 @@ public final class ImPlot {
                                           @ArgValue(callValue = "LEN(values)") Void count,
                                           @OptArg double xscale,
                                           @OptArg double xstart,
-                                          @OptArg int flags,
-                                          @OptArg int offset);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
@@ -460,8 +456,7 @@ public final class ImPlot {
                                            int count,
                                            @OptArg double xscale,
                                            @OptArg double xstart,
-                                           @OptArg int flags,
-                                           @OptArg int offset);
+                                           @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // xs,ys
 
@@ -473,7 +468,7 @@ public final class ImPlot {
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                           @ArgValue(callValue = "LEN(xs)") Void count,
-                                          @OptArg int flags);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
@@ -483,8 +478,7 @@ public final class ImPlot {
                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                            int count,
-                                           @OptArg int flags,
-                                           @OptArg int offset);
+                                           @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // values
 
@@ -497,8 +491,7 @@ public final class ImPlot {
                                          @ArgValue(callValue = "LEN(values)") Void count,
                                          @OptArg double xscale,
                                          @OptArg double xstart,
-                                         @OptArg int flags,
-                                         @OptArg int offset);
+                                         @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
@@ -509,8 +502,7 @@ public final class ImPlot {
                                           int count,
                                           @OptArg double xscale,
                                           @OptArg double xstart,
-                                          @OptArg int flags,
-                                          @OptArg int offset);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // xs,ys
 
@@ -522,7 +514,7 @@ public final class ImPlot {
                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                          @ArgValue(callValue = "LEN(xs)") Void count,
-                                         @OptArg int flags);
+                                         @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
@@ -532,8 +524,7 @@ public final class ImPlot {
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                           int count,
-                                          @OptArg int flags,
-                                          @OptArg int offset);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // values
 
@@ -547,8 +538,7 @@ public final class ImPlot {
                                          @OptArg double yRef,
                                          @OptArg double xscale,
                                          @OptArg double xstart,
-                                         @OptArg int flags,
-                                         @OptArg int offset);
+                                         @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
@@ -560,8 +550,7 @@ public final class ImPlot {
                                           @OptArg double yRef,
                                           @OptArg double xscale,
                                           @OptArg double xstart,
-                                          @OptArg int flags,
-                                          @OptArg int offset);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // xs,ys
 
@@ -574,8 +563,7 @@ public final class ImPlot {
                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                          @ArgValue(callValue = "LEN(xs)") Void count,
                                          @OptArg double yRef,
-                                         @OptArg int flags,
-                                         @OptArg int offset);
+                                         @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
@@ -586,8 +574,7 @@ public final class ImPlot {
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                           int count,
                                           @OptArg double yRef,
-                                          @OptArg int flags,
-                                          @OptArg int offset);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // xs,ys1,ys2
 
@@ -600,7 +587,7 @@ public final class ImPlot {
                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys1,
                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys2,
                                          @ArgValue(callValue = "LEN(xs)") Void count,
-                                         @OptArg int flags);
+                                         @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
@@ -611,72 +598,66 @@ public final class ImPlot {
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys1,
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys2,
                                           int count,
-                                          @OptArg int flags,
-                                          @OptArg int offset);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // values
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     @BindingMethod
     public static native void PlotBars(String labelId,
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                        @ArgValue(callValue = "LEN(values)") Void count,
-                                       @OptArg double barWidth,
-                                       @OptArg double xstart,
-                                       @OptArg int flags,
-                                       @OptArg int offset);
+                                       @OptArg double barSize,
+                                       @OptArg double shift,
+                                       @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size and #shift are in X units.
      */
     @BindingMethod(callName = "PlotBars")
     public static native void PlotBarsV(String labelId,
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                         int count,
-                                        @OptArg double barWidth,
-                                        @OptArg double xstart,
-                                        @OptArg int flags,
-                                        @OptArg int offset);
+                                        @OptArg double barSize,
+                                        @OptArg double shift,
+                                        @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // xs,ys
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
     @BindingMethod
     public static native void PlotBars(String labelId,
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                        @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                        @ArgValue(callValue = "LEN(xs)") Void count,
-                                       @ArgValue(callValue = "0.67") Void barWidth,
-                                       @OptArg int flags,
-                                       @OptArg int offset);
+                                       @ArgValue(callValue = "0.67") Void barSize,
+                                       @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
     @BindingMethod(callName = "PlotBars")
     public static native void PlotBarsV(String labelId,
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                         @ArgValue(callValue = "LEN(xs)") Void count,
-                                        double barWidth,
-                                        @OptArg int flags,
-                                        @OptArg int offset);
+                                        double barSize,
+                                        @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
-     * Plots a vertical bar graph. #bar_width and #xstart are in X units.
+     * Plots a vertical bar graph. #bar_size is in X units.
      */
     @BindingMethod(callName = "PlotBars")
     public static native void PlotBarsV(String labelId,
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                         int count,
-                                        double barWidth,
-                                        @OptArg int flags,
-                                        @OptArg int offset);
+                                        double barSize,
+                                        @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
@@ -688,7 +669,7 @@ public final class ImPlot {
                                             int groupCount,
                                             @OptArg double groupSize,
                                             @OptArg double shift,
-                                            @OptArg int flags);
+                                            @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
@@ -700,7 +681,7 @@ public final class ImPlot {
                                              int groupCount,
                                              @OptArg double groupSize,
                                              @OptArg double shift,
-                                             @OptArg int flags);
+                                             @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
@@ -711,8 +692,7 @@ public final class ImPlot {
                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void err,
                                             @ArgValue(callValue = "LEN(xs)") Void count,
-                                            @OptArg int flags,
-                                            @OptArg int offset);
+                                            @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
@@ -723,8 +703,7 @@ public final class ImPlot {
                                              @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                              @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void err,
                                              int count,
-                                             @OptArg int flags,
-                                             @OptArg int offset);
+                                             @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
@@ -736,8 +715,7 @@ public final class ImPlot {
                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void neg,
                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void pos,
                                             @ArgValue(callValue = "LEN(xs)") Void count,
-                                            @OptArg int flags,
-                                            @OptArg int offset);
+                                            @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
@@ -749,8 +727,7 @@ public final class ImPlot {
                                              @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void neg,
                                              @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void pos,
                                              int count,
-                                             @OptArg int flags,
-                                             @OptArg int offset);
+                                             @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // values
 
@@ -761,11 +738,10 @@ public final class ImPlot {
     public static native void PlotStems(String labelId,
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                         @ArgValue(callValue = "LEN(values)") Void count,
-                                        @OptArg double yRef,
-                                        @OptArg double xscale,
-                                        @OptArg double xstart,
-                                        @OptArg int flags,
-                                        @OptArg int offset);
+                                        @OptArg double ref,
+                                        @OptArg double scale,
+                                        @OptArg double start,
+                                        @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots vertical stems.
@@ -774,11 +750,10 @@ public final class ImPlot {
     public static native void PlotStemsV(String labelId,
                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                          int count,
-                                         @OptArg double yRef,
+                                         @OptArg double ref,
                                          @OptArg double scale,
                                          @OptArg double start,
-                                         @OptArg int flags,
-                                         @OptArg int offset);
+                                         @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     // xs,ys
 
@@ -791,8 +766,7 @@ public final class ImPlot {
                                         @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                         @ArgValue(callValue = "LEN(xs)") Void count,
                                         @OptArg double ref,
-                                        @OptArg int flags,
-                                        @OptArg int offset);
+                                        @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots vertical stems.
@@ -802,9 +776,8 @@ public final class ImPlot {
                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                          int count,
-                                         @OptArg double yRef,
-                                         @OptArg int flags,
-                                         @OptArg int offset);
+                                         @OptArg double ref,
+                                         @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
@@ -813,8 +786,7 @@ public final class ImPlot {
     public static native void PlotInfLines(String labelId,
                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                            @ArgValue(callValue = "LEN(values)") Void count,
-                                           @OptArg int flags,
-                                           @OptArg int offset);
+                                           @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
@@ -823,8 +795,7 @@ public final class ImPlot {
     public static native void PlotInfLinesV(String labelId,
                                             @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
                                             int count,
-                                            @OptArg int flags,
-                                            @OptArg int offset);
+                                            @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
@@ -838,7 +809,7 @@ public final class ImPlot {
                                            double radius,
                                            @OptArg(callValue = "\"%.1f\"") String labelFmt,
                                            @OptArg double angle0,
-                                           @OptArg int flags);
+                                           @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
@@ -852,7 +823,7 @@ public final class ImPlot {
                                             double radius,
                                             @OptArg(callValue = "\"%.1f\"") String labelFmt,
                                             @OptArg double angle0,
-                                            @OptArg int flags);
+                                            @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
@@ -867,7 +838,7 @@ public final class ImPlot {
                                           @OptArg(callValue = "\"%.1f\"") String labelFmt,
                                           @OptArg ImPlotPoint boundsMin,
                                           @OptArg ImPlotPoint boundsMax,
-                                          @OptArg int flags);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
@@ -881,7 +852,7 @@ public final class ImPlot {
                                               @OptArg(callValue = "ImPlotBin_Sturges") int bins,
                                               @OptArg double barScale,
                                               @OptArg(callValue = "ImPlotRange()") ImPlotRange range,
-                                              @OptArg int flags);
+                                              @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
@@ -895,7 +866,7 @@ public final class ImPlot {
                                                @OptArg int bins,
                                                @OptArg double barScale,
                                                @OptArg(callValue = "ImPlotRange()") ImPlotRange range,
-                                               @OptArg int flags);
+                                               @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
@@ -910,7 +881,7 @@ public final class ImPlot {
                                                 @OptArg int xBins,
                                                 @OptArg int yBins,
                                                 @OptArg(callValue = "ImPlotRect()") ImPlotRect range,
-                                                @OptArg int flags);
+                                                @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
@@ -925,7 +896,7 @@ public final class ImPlot {
                                                  @OptArg int xBins,
                                                  @OptArg int yBins,
                                                  @OptArg(callValue = "ImPlotRect()") ImPlotRect range,
-                                                 @OptArg int flags);
+                                                 @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
@@ -935,8 +906,7 @@ public final class ImPlot {
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                           @ArgValue(callValue = "LEN(xs)") Void count,
-                                          @OptArg int flags,
-                                          @OptArg int offset);
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
@@ -946,8 +916,7 @@ public final class ImPlot {
                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
                                            @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
                                            int count,
-                                           @OptArg int flags,
-                                           @OptArg int offset);
+                                           @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
@@ -960,7 +929,7 @@ public final class ImPlot {
                                         @OptArg ImVec2 uv0,
                                         @OptArg ImVec2 uv1,
                                         @OptArg ImVec4 tintCol,
-                                        @OptArg int flags);
+                                        @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
@@ -970,13 +939,83 @@ public final class ImPlot {
                                        double x,
                                        double y,
                                        @OptArg(callValue = "ImVec2(0,0)") ImVec2 pixOffset,
-                                       @OptArg int flags);
+                                       @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /**
      * Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)
      */
     @BindingMethod
-    public static native void PlotDummy(String labelID, @OptArg int flags);
+    public static native void PlotDummy(String labelID, @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
+
+    // values
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    @BindingMethod
+    public static native void PlotBubbles(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void szs,
+                                          @ArgValue(callValue = "LEN(values)") Void count,
+                                          @OptArg double xscale,
+                                          @OptArg double xstart,
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    @BindingMethod(callName = "PlotBubbles")
+    public static native void PlotBubblesV(String labelId,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void values,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void szs,
+                                           int count,
+                                           @OptArg double xscale,
+                                           @OptArg double xstart,
+                                           @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
+
+    // xs,ys,szs
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    @BindingMethod
+    public static native void PlotBubbles(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void szs,
+                                          @ArgValue(callValue = "LEN(xs)") Void count,
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
+
+    /**
+     * Plots bubble markers with per-index sizes. #szs provides a size for each marker.
+     */
+    @BindingMethod(callName = "PlotBubbles")
+    public static native void PlotBubblesV(String labelId,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void szs,
+                                           int count,
+                                           @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    @BindingMethod
+    public static native void PlotPolygon(String labelId,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                          @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                          @ArgValue(callValue = "LEN(xs)") Void count,
+                                          @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
+
+    /**
+     * Plots a polygon (open, closed or loop) using the spec Flags (e.g. ImPlotPolygonFlags_Concave for concave shapes).
+     */
+    @BindingMethod(callName = "PlotPolygon")
+    public static native void PlotPolygonV(String labelId,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void xs,
+                                           @ArgVariant(type = {"short[]", "int[]", "long[]", "float[]", "double[]"}) Void ys,
+                                           int count,
+                                           @OptArg @ArgValue(callPrefix = "*") ImPlotSpec spec);
 
     /*JNI
         #undef LEN
@@ -1368,28 +1407,11 @@ public final class ImPlot {
     public static native void PopStyleVar(@OptArg int count);
 
     /**
-     * Set the line color and weight for the next item only.
+     * Returns the next automatic marker (in the order ImPlot cycles markers for auto-style items).
+     * Replaces SetNextMarkerStyle in v1.0; to style the next item, populate an ImPlotSpec instead (LineColor, FillColor, Marker, MarkerSize, LineWeight, MarkerLineColor, Size, ErrorBar style, etc.) and pass it to the Plot* call. The SetNextLineStyle/SetNextFillStyle/SetNextErrorBarStyle helpers were removed for the same reason.
      */
     @BindingMethod
-    public static native void SetNextLineStyle(@OptArg(callValue = "IMPLOT_AUTO_COL") ImVec4 col, @OptArg float weight);
-
-    /**
-     * Set the fill color for the next item only.
-     */
-    @BindingMethod
-    public static native void SetNextFillStyle(@OptArg(callValue = "IMPLOT_AUTO_COL") ImVec4 col, @OptArg float alphaMod);
-
-    /**
-     * Set the marker style for the next item only.
-     */
-    @BindingMethod
-    public static native void SetNextMarkerStyle(@OptArg int marker, @OptArg float size, @OptArg ImVec4 fill, @OptArg(callValue = "IMPLOT_AUTO") float weight, @OptArg ImVec4 outline);
-
-    /**
-     * Set the error bar style for the next item only.
-     */
-    @BindingMethod
-    public static native void SetNextErrorBarStyle(@OptArg(callValue = "IMPLOT_AUTO_COL") ImVec4 col, @OptArg float size, @OptArg float weight);
+    public static native int NextMarker();
 
     /**
      * Gets the last item primary color (i.e. its legend icon color)

--- a/imgui-binding/src/main/java/imgui/extension/implot/ImPlotSpec.java
+++ b/imgui-binding/src/main/java/imgui/extension/implot/ImPlotSpec.java
@@ -1,0 +1,156 @@
+package imgui.extension.implot;
+
+import imgui.ImVec4;
+import imgui.binding.ImGuiStructDestroyable;
+import imgui.binding.annotation.BindingField;
+import imgui.binding.annotation.BindingSource;
+
+@BindingSource
+public final class ImPlotSpec extends ImGuiStructDestroyable {
+    public ImPlotSpec() {
+        super();
+    }
+
+    public ImPlotSpec(final long ptr) {
+        super(ptr);
+    }
+
+    @Override
+    protected long create() {
+        return nCreate();
+    }
+
+    @Override
+    public void destroy() {
+        nFreeArrays(ptr);
+        super.destroy();
+    }
+
+    /*JNI
+        #include "_implot.h"
+        #define THIS ((ImPlotSpec*)STRUCT_PTR)
+     */
+
+    private native long nCreate(); /*
+        return (uintptr_t)(new ImPlotSpec());
+    */
+
+    // Frees any array backing buffers currently held by this spec. Called from destroy()
+    // before the struct itself is deleted.
+    private native void nFreeArrays(long specPtr); /*
+        ImPlotSpec* spec = (ImPlotSpec*)specPtr;
+        if (spec->LineColors)       { ImGui::MemFree(spec->LineColors);       spec->LineColors       = NULL; }
+        if (spec->FillColors)       { ImGui::MemFree(spec->FillColors);       spec->FillColors       = NULL; }
+        if (spec->MarkerSizes)      { ImGui::MemFree(spec->MarkerSizes);      spec->MarkerSizes      = NULL; }
+        if (spec->MarkerLineColors) { ImGui::MemFree(spec->MarkerLineColors); spec->MarkerLineColors = NULL; }
+        if (spec->MarkerFillColors) { ImGui::MemFree(spec->MarkerFillColors); spec->MarkerFillColors = NULL; }
+    */
+
+    @BindingField
+    public ImVec4 LineColor;
+
+    @BindingField
+    public float LineWeight;
+
+    @BindingField
+    public ImVec4 FillColor;
+
+    @BindingField
+    public float FillAlpha;
+
+    @BindingField
+    public int Marker;
+
+    @BindingField
+    public float MarkerSize;
+
+    @BindingField
+    public ImVec4 MarkerLineColor;
+
+    @BindingField
+    public ImVec4 MarkerFillColor;
+
+    @BindingField
+    public float Size;
+
+    @BindingField
+    public int Offset;
+
+    @BindingField
+    public int Stride;
+
+    @BindingField
+    public int Flags;
+
+    // Per-index color array for lines (ImU32 packed RGBA). Pass null to clear.
+    // Ownership: the backing buffer is allocated in native memory and freed on destroy()
+    // or when reassigned.
+    public void setLineColors(final int[] colors) {
+        nSetLineColors(colors, colors != null ? colors.length : 0);
+    }
+
+    private native void nSetLineColors(int[] colors, int len); /*
+        if (THIS->LineColors) { ImGui::MemFree(THIS->LineColors); THIS->LineColors = NULL; }
+        if (colors != NULL && len > 0) {
+            ImU32* buf = (ImU32*)ImGui::MemAlloc(len * sizeof(ImU32));
+            for (int i = 0; i < len; i++) { buf[i] = (ImU32)colors[i]; }
+            THIS->LineColors = buf;
+        }
+    */
+
+    public void setFillColors(final int[] colors) {
+        nSetFillColors(colors, colors != null ? colors.length : 0);
+    }
+
+    private native void nSetFillColors(int[] colors, int len); /*
+        if (THIS->FillColors) { ImGui::MemFree(THIS->FillColors); THIS->FillColors = NULL; }
+        if (colors != NULL && len > 0) {
+            ImU32* buf = (ImU32*)ImGui::MemAlloc(len * sizeof(ImU32));
+            for (int i = 0; i < len; i++) { buf[i] = (ImU32)colors[i]; }
+            THIS->FillColors = buf;
+        }
+    */
+
+    public void setMarkerSizes(final float[] sizes) {
+        nSetMarkerSizes(sizes, sizes != null ? sizes.length : 0);
+    }
+
+    private native void nSetMarkerSizes(float[] sizes, int len); /*
+        if (THIS->MarkerSizes) { ImGui::MemFree(THIS->MarkerSizes); THIS->MarkerSizes = NULL; }
+        if (sizes != NULL && len > 0) {
+            float* buf = (float*)ImGui::MemAlloc(len * sizeof(float));
+            for (int i = 0; i < len; i++) { buf[i] = sizes[i]; }
+            THIS->MarkerSizes = buf;
+        }
+    */
+
+    public void setMarkerLineColors(final int[] colors) {
+        nSetMarkerLineColors(colors, colors != null ? colors.length : 0);
+    }
+
+    private native void nSetMarkerLineColors(int[] colors, int len); /*
+        if (THIS->MarkerLineColors) { ImGui::MemFree(THIS->MarkerLineColors); THIS->MarkerLineColors = NULL; }
+        if (colors != NULL && len > 0) {
+            ImU32* buf = (ImU32*)ImGui::MemAlloc(len * sizeof(ImU32));
+            for (int i = 0; i < len; i++) { buf[i] = (ImU32)colors[i]; }
+            THIS->MarkerLineColors = buf;
+        }
+    */
+
+    public void setMarkerFillColors(final int[] colors) {
+        nSetMarkerFillColors(colors, colors != null ? colors.length : 0);
+    }
+
+    private native void nSetMarkerFillColors(int[] colors, int len); /*
+        if (THIS->MarkerFillColors) { ImGui::MemFree(THIS->MarkerFillColors); THIS->MarkerFillColors = NULL; }
+        if (colors != NULL && len > 0) {
+            ImU32* buf = (ImU32*)ImGui::MemAlloc(len * sizeof(ImU32));
+            for (int i = 0; i < len; i++) { buf[i] = (ImU32)colors[i]; }
+            THIS->MarkerFillColors = buf;
+        }
+    */
+
+    /*JNI
+        #undef THIS
+     */
+}

--- a/imgui-binding/src/main/java/imgui/extension/implot/ImPlotSpec.java
+++ b/imgui-binding/src/main/java/imgui/extension/implot/ImPlotSpec.java
@@ -84,9 +84,14 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
 
     // Per-index color array for lines (ImU32 packed RGBA). Pass null to clear.
     // Ownership: the backing buffer is allocated in native memory and freed on destroy()
-    // or when reassigned.
+    // or when reassigned. The (arr, len) overloads mirror the plot methods and let
+    // callers reuse a backing array larger than the logical count.
     public void setLineColors(final int[] colors) {
         nSetLineColors(colors, colors != null ? colors.length : 0);
+    }
+
+    public void setLineColors(final int[] colors, final int len) {
+        nSetLineColors(colors, len);
     }
 
     private native void nSetLineColors(int[] colors, int len); /*
@@ -102,6 +107,10 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
         nSetFillColors(colors, colors != null ? colors.length : 0);
     }
 
+    public void setFillColors(final int[] colors, final int len) {
+        nSetFillColors(colors, len);
+    }
+
     private native void nSetFillColors(int[] colors, int len); /*
         if (THIS->FillColors) { ImGui::MemFree(THIS->FillColors); THIS->FillColors = NULL; }
         if (colors != NULL && len > 0) {
@@ -113,6 +122,10 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
 
     public void setMarkerSizes(final float[] sizes) {
         nSetMarkerSizes(sizes, sizes != null ? sizes.length : 0);
+    }
+
+    public void setMarkerSizes(final float[] sizes, final int len) {
+        nSetMarkerSizes(sizes, len);
     }
 
     private native void nSetMarkerSizes(float[] sizes, int len); /*
@@ -128,6 +141,10 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
         nSetMarkerLineColors(colors, colors != null ? colors.length : 0);
     }
 
+    public void setMarkerLineColors(final int[] colors, final int len) {
+        nSetMarkerLineColors(colors, len);
+    }
+
     private native void nSetMarkerLineColors(int[] colors, int len); /*
         if (THIS->MarkerLineColors) { ImGui::MemFree(THIS->MarkerLineColors); THIS->MarkerLineColors = NULL; }
         if (colors != NULL && len > 0) {
@@ -139,6 +156,10 @@ public final class ImPlotSpec extends ImGuiStructDestroyable {
 
     public void setMarkerFillColors(final int[] colors) {
         nSetMarkerFillColors(colors, colors != null ? colors.length : 0);
+    }
+
+    public void setMarkerFillColors(final int[] colors, final int len) {
+        nSetMarkerFillColors(colors, len);
     }
 
     private native void nSetMarkerFillColors(int[] colors, int len); /*

--- a/imgui-binding/src/main/java/imgui/extension/implot/ImPlotStyle.java
+++ b/imgui-binding/src/main/java/imgui/extension/implot/ImPlotStyle.java
@@ -32,33 +32,6 @@ public final class ImPlotStyle extends ImGuiStructDestroyable {
     */
 
     @BindingField
-    public float LineWeight;
-
-    @BindingField
-    public int Marker;
-
-    @BindingField
-    public float MarkerSize;
-
-    @BindingField
-    public float MarkerWeight;
-
-    @BindingField
-    public float FillAlpha;
-
-    @BindingField
-    public float ErrorBarSize;
-
-    @BindingField
-    public float ErrorBarWeight;
-
-    @BindingField
-    public float DigitalBitHeight;
-
-    @BindingField
-    public float DigitalBitGap;
-
-    @BindingField
     public float PlotBorderSize;
 
     @BindingField
@@ -111,6 +84,12 @@ public final class ImPlotStyle extends ImGuiStructDestroyable {
 
     @BindingField
     public ImVec2 PlotMinSize;
+
+    @BindingField
+    public float DigitalPadding;
+
+    @BindingField
+    public float DigitalSpacing;
 
     @BindingField
     @TypeArray(type = "ImVec4", size = "ImPlotCol_COUNT")


### PR DESCRIPTION

Upstream implot v1.0 (https://github.com/epezent/implot/releases/tag/v1.0) is a breaking release that replaces per-call (flags, offset, stride) args on every Plot* function with a single ImPlotSpec value-type, and removes the SetNextX-style helpers. The headline new feature is per-index colors and marker sizes via ImPlotSpec arrays (PR epezent/implot#672).

Binding changes:
- Advance include/implot submodule 1f7a8c0 -> v1.0 (524f9fc)
- Regenerate ast-implot.json
- Add ImPlotSpec: scalar @BindingField props plus hand-written native setters for the 5 array-pointer fields (LineColors, FillColors, MarkerSizes, MarkerLineColors, MarkerFillColors). Backing buffers are owned in native memory (ImGui::MemAlloc) and freed on destroy() or on reassignment.
- Rewrite every Plot* signature: the (flags, offset, stride) tail is replaced by `@OptArg @ArgValue(callPrefix="*") ImPlotSpec spec`, which marshals to `*reinterpret_cast<ImPlotSpec*>(spec.ptr)` at the C++ call site. Progressive-cutoff overloads still expose spec-less variants (relying on C++ default `= ImPlotSpec()`).
- Add PlotPolygon, PlotBubbles, NextMarker (new in v1.0)
- Remove SetNextLineStyle / SetNextFillStyle / SetNextMarkerStyle / SetNextErrorBarStyle (obsoleted in v1.0 -- configure ImPlotSpec instead)
- Trim ImPlotStyle: drop LineWeight/Marker/MarkerSize/MarkerWeight/ FillAlpha/ErrorBarSize/ErrorBarWeight/DigitalBitHeight/ DigitalBitGap (all moved into ImPlotSpec); add new DigitalPadding/DigitalSpacing
- Flag enums shift accordingly: ImPlotMarker_None is now -2 (ImPlotMarker_Auto = -1 is new); ImPlotCol drops the 5 per-item entries (Line/Fill/MarkerOutline/MarkerFill/ErrorBar); ImPlotStyleVar drops the 9 matching vars; ImPlotLegendFlags gains Reverse; ImPlotPieChartFlags gains Exploding + NoSliceBorder; new ImPlotBubblesFlags / ImPlotPolygonFlags enums are AST-driven.

Example: ExampleImPlot grows a "Per-Index Colors (v1.0 PR #672)" plot showing rainbow LineColors + MarkerFillColors + ramping MarkerSizes.

Note: this is source-incompatible for any caller of the affected Plot* methods or the removed SetNextX helpers. The incompatibility mirrors upstream implot's own v1.0 break and is the minimum footprint to expose the new ImPlotSpec-based API.

Dear ImGui submodule is intentionally left at v1.90.9-docking. implot v1.0 guards its 1.92-era uses (ImTextureRef, ImFontBaked, CalcFontSize) behind `#ifdef IMGUI_HAS_TEXTURES` / `IMGUI_VERSION_NUM` and compiles cleanly against 1.90.9.

## Type of change


- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
