### PR TITLE
fix(example): disambiguate Drop Target button IDs in Drag'N'Drop demo

### DIFF
--- a/example/src/main/java/ExampleDragAndDrop.java
+++ b/example/src/main/java/ExampleDragAndDrop.java
@@ -34,20 +34,26 @@ public class ExampleDragAndDrop {
             ImGui.separator();
 
             ImGui.text("Drop here any:");
+            ImGui.pushID("any");
             ImGui.button(data, 100, 50);
             setupTarget();
+            ImGui.popID();
 
             ImGui.separator();
 
             ImGui.text("Drop here string payload only");
+            ImGui.pushID("string");
             ImGui.button(data, 100, 50);
             setupStringPayloadTarget();
+            ImGui.popID();
 
             ImGui.separator();
 
             ImGui.text("Drop here class specific payload only");
+            ImGui.pushID("class");
             ImGui.button(data, 100, 50);
             setupClassSpecificPayloadTarget();
+            ImGui.popID();
         }
         ImGui.end();
     }


### PR DESCRIPTION
## Summary
- The Drag'N'Drop demo renders three drop-target buttons whose labels all come from the same mutable `data` field, so imgui hashes three identical item IDs inside the window.
- This was silently broken before 1.91 (drop zones shared hover/active state) and now surfaces as a visible "3 visible items with conflicting ID!" warning because imgui 1.91's `ConfigDebugHighlightIdConflicts` is on by default in debug builds.
- Wrap each drop-target block with `PushID("any"/"string"/"class")` / `PopID()` so buttons share a human-readable label but are distinguished in the ID stack — the resolution imgui's own warning recommends first.

## Type of change
- [X] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan
- [x] Run `./gradlew :example:run`, open the Drag'N'Drop demo window, hover each drop-target button — warning overlay no longer appears and hover highlight is per-button.