### PR TITLE
fix: set Java 8 release target for imgui-binding-natives compile

### DIFF
--- a/imgui-binding-natives/build.gradle
+++ b/imgui-binding-natives/build.gradle
@@ -10,6 +10,10 @@ java {
     }
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.release.set(8)
+}
+
 def packageName = 'imgui-java-natives-linux'
 def packageDesc = 'Native binaries for imgui-java binding for Linux'
 def moduleName = 'imgui.natives.linux'


### PR DESCRIPTION
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->

## Type of change

Fixes #403 

<!-- 
Please check options that are relevant.
-->

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
