### PR TITLE
Rewrite the contributor guide and tidy the repo docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 <!--
-PR titles become the commit subject on `main` (PRs are squash-merged), so write the title
-as a conventional-commit header: `feat(lwjgl3): add SDL3 backend`.
+Title: a short descriptive sentence covering the whole change — sentence case, no trailing
+period, no `type(scope):` prefix. "Add an SDL3 backend to imgui-lwjgl3", not
+"feat(lwjgl3): add SDL3 backend". The type is carried by the label.
 See CONTRIBUTING.md → "Pull requests".
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,25 @@
-<!-- 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
+<!--
+PR titles become the commit subject on `main` (PRs are squash-merged), so write the title
+as a conventional-commit header: `feat(lwjgl3): add SDL3 backend`.
+See CONTRIBUTING.md → "Pull requests".
 -->
+
+## Summary
+
+<!-- What changes and why. One or two sentences. Required. -->
 
 ## Type of change
 
-<!-- 
-Please check options that are relevant.
--->
+<!-- Please check options that are relevant. -->
 
 - [ ] Minor changes or tweaks (quality of life stuff)
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
+
+## Notes for reviewer
+
+<!-- Design decisions, deliberate scope boundaries, follow-ups left for later. Omit if none. -->
+
+<!-- Closes #<issue> -->

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ logs/
 *.iws
 .idea/
 
+# Eclipse / VS Code Java (Buildship) compile output.
+# Only per-module bin/ — the root bin/ holds tracked native libs.
+/*/bin/
+
 # Package Files #
 *.jar
 *.war

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,14 +207,17 @@ Use `providers.exec { ... }` for shell-outs, never `.execute()`. Capture resolve
   are fixed tables — pick from them, never invent a scope. `!` in the header requires a
   `BREAKING CHANGE:` footer.
 - **PR title** → a descriptive prose sentence covering the whole change, sentence case, **no**
-  `type(scope):` prefix — the type is carried by the label, so apply one from the mapping table
-  there. The conventional header is written into the squash subject at merge time, not the title.
+  `type(scope):` prefix — the type is carried by the label, so apply exactly one from the mapping
+  table there (one label per commit type; `build(deps)` takes `deps`), plus `breaking-change` on
+  top whenever the header carries `!`. The conventional header is written into the squash subject
+  at merge time, not the title.
 - **AI-assisted commits** → the `Co-authored-by` trailer is mandatory, family-level model name
   only. Strip versioned model names, session URLs, and "Generated with …" lines that tooling
   adds by default, and check the trailer survives the squash.
 - **Releases** → "Releases". Tag-driven (`git describe` is the version of record), version
   tracks Dear ImGui's `MAJOR.MINOR`, so a breaking change is only ever visible via `!`, the
-  footer, and the release notes. Never cut a release on stale `bin/` natives.
+  footer, the `breaking-change` label, and the release notes. Never cut a release on stale
+  `bin/` natives.
 
 The rule that submodule bumps, Gradle/deps bumps, and codegen-tooling changes each go in their
 own PR is in `.claude/rules/guardrails.md` ("Don't merge submodule bumps with feature work")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,8 +206,9 @@ Use `providers.exec { ... }` for shell-outs, never `.execute()`. Capture resolve
   and scopes (`api|native|generator|vendor|lwjgl3|app|example|deps|ci|gradle|readme|agents|contributing`)
   are fixed tables — pick from them, never invent a scope. `!` in the header requires a
   `BREAKING CHANGE:` footer.
-- **PR title** → must be a valid commit header; PRs are squash-merged and the title becomes
-  the subject line on `main`. Also apply the type label from the mapping table there.
+- **PR title** → a descriptive prose sentence covering the whole change, sentence case, **no**
+  `type(scope):` prefix — the type is carried by the label, so apply one from the mapping table
+  there. The conventional header is written into the squash subject at merge time, not the title.
 - **AI-assisted commits** → the `Co-authored-by` trailer is mandatory, family-level model name
   only. Strip versioned model names, session URLs, and "Generated with …" lines that tooling
   adds by default, and check the trailer survives the squash.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ upgrading submodules, and the codegen-internals conventions. The everyday conven
 - **`.claude/docs/patterns.md`** — recurring patterns when adding to the binding (the
   codegen loop, annotated stubs, struct wrappers, out-parameter `Im*` wrappers, module
   boundaries, application lifecycle).
-- **`docs/CONTRIBUTING.md`** — PR/commit workflow. Includes the conventional-commit
+- **`CONTRIBUTING.md`** — PR/commit workflow. Includes the conventional-commit
   format and, importantly, the **`Co-authored-by` trailer rule for AI-assisted commits**
   and the "you are responsible for the change" rule. Read it before opening a PR.
 
@@ -198,7 +198,7 @@ Use `providers.exec { ... }` for shell-outs, never `.execute()`. Capture resolve
 
 The full commit-message format, the conventional-commit types/scopes, and the
 mandatory `Co-authored-by` trailer for AI-assisted commits are documented in
-`docs/CONTRIBUTING.md` — follow that. The rule that submodule bumps, Gradle/deps
+`CONTRIBUTING.md` — follow that. The rule that submodule bumps, Gradle/deps
 bumps, and codegen-tooling changes each go in their own PR is in
 `.claude/rules/guardrails.md` ("Don't merge submodule bumps with feature work").
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,13 @@ upgrading submodules, and the codegen-internals conventions. The everyday conven
 - **`.claude/docs/patterns.md`** — recurring patterns when adding to the binding (the
   codegen loop, annotated stubs, struct wrappers, out-parameter `Im*` wrappers, module
   boundaries, application lifecycle).
-- **`CONTRIBUTING.md`** — PR/commit workflow. Includes the conventional-commit
-  format and, importantly, the **`Co-authored-by` trailer rule for AI-assisted commits**
-  and the "you are responsible for the change" rule. Read it before opening a PR.
+- **`CONTRIBUTING.md`** — the human-facing contributor guide, and the authority on
+  everything commit- and release-shaped: the conventional-commit types/scopes tables, PR
+  title and body rules (PRs are squash-merged, so the **PR title must be a valid commit
+  header**), label mapping, the versioning scheme (version tracks Dear ImGui, so it can
+  never signal a break), the release procedure, and — importantly — the **`Co-authored-by`
+  trailer rule for AI-assisted commits** plus the "you are responsible for the change"
+  rule. Read it before writing a commit message or opening a PR.
 
 If anything below conflicts with those files, the dedicated file wins — update it
 there, not here.
@@ -196,11 +200,24 @@ Use `providers.exec { ... }` for shell-outs, never `.execute()`. Capture resolve
 
 ## PR workflow
 
-The full commit-message format, the conventional-commit types/scopes, and the
-mandatory `Co-authored-by` trailer for AI-assisted commits are documented in
-`CONTRIBUTING.md` — follow that. The rule that submodule bumps, Gradle/deps
-bumps, and codegen-tooling changes each go in their own PR is in
-`.claude/rules/guardrails.md` ("Don't merge submodule bumps with feature work").
+`CONTRIBUTING.md` is the authority here — follow it, don't paraphrase it:
+
+- **Commit messages** → "Commit message format". Types (`feat|fix|perf|refactor|docs|test|build|chore|revert`)
+  and scopes (`api|native|generator|vendor|lwjgl3|app|example|deps|ci|gradle|readme|agents|contributing`)
+  are fixed tables — pick from them, never invent a scope. `!` in the header requires a
+  `BREAKING CHANGE:` footer.
+- **PR title** → must be a valid commit header; PRs are squash-merged and the title becomes
+  the subject line on `main`. Also apply the type label from the mapping table there.
+- **AI-assisted commits** → the `Co-authored-by` trailer is mandatory, family-level model name
+  only. Strip versioned model names, session URLs, and "Generated with …" lines that tooling
+  adds by default, and check the trailer survives the squash.
+- **Releases** → "Releases". Tag-driven (`git describe` is the version of record), version
+  tracks Dear ImGui's `MAJOR.MINOR`, so a breaking change is only ever visible via `!`, the
+  footer, and the release notes. Never cut a release on stale `bin/` natives.
+
+The rule that submodule bumps, Gradle/deps bumps, and codegen-tooling changes each go in their
+own PR is in `.claude/rules/guardrails.md` ("Don't merge submodule bumps with feature work")
+and restated in `CONTRIBUTING.md` § "Before you start".
 
 Operational guidance on top of those:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,22 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-See [AGENTS.md](AGENTS.md) — it is the canonical guidance for AI agents in this repo and covers everything Claude Code
-needs:
+Read [AGENTS.md](AGENTS.md) — it is the canonical and authoritative guidance for AI agents in this repo, covering
+project layout, build & test commands, the codegen workflow, submodule bumps, gotchas, conventions, and the PR process.
 
-- What the repo is (JNI binding for Dear ImGui + extensions, codegen-driven multi-module Gradle build).
-- Project layout (`imgui-binding/`, `imgui-lwjgl3/`, `imgui-app/`, `buildSrc/`, `include/` submodules, etc.).
-- The **golden rule**: never edit `imgui-binding/src/generated/java/` — it is regenerated from annotated sources in
-  `imgui-binding/src/main/java/`. Workflow: edit source → `./gradlew :imgui-binding:generateApi` → commit both trees
-  together.
-- Build & test commands (`compileJava`, `javadoc`, `generateApi`, `generateAst`, `generateLibs`, `build`) and the visual
-  smoke-test flow for backend/font/example changes.
-- Submodule-bump procedure for Dear ImGui and extensions, including AST regeneration scope rules.
-- Gotchas: doclint-vs-C++ comment patterns, vendor patches, `GenerateLibs.groovy` literal-string rewrites, AST drift,
-  rebase strategy for codegen output, submodule sync after branch switch, `bin/` ownership by CI.
-- Design conventions (dual font loader: stb_truetype + FreeType).
-- Codegen-internals conventions for `buildSrc/` (Spoon generic-type bounds, Gradle 9 configuration cache).
-- PR workflow and merge-ordering guidance.
+The golden rule from there, repeated because it is easy to trip over: **never edit
+`imgui-binding/src/generated/java/`** — it is regenerated from annotated sources in `imgui-binding/src/main/java/`.
 
-Treat `AGENTS.md` as authoritative. If something here ever conflicts with `AGENTS.md`, `AGENTS.md` wins — update it
-there, not here.
+If anything here ever conflicts with `AGENTS.md`, `AGENTS.md` wins — update it there, not here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,148 @@
 # Contributing to imgui-java
-We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
 
-- Reporting a bug
-- Discussing the current state of the code
-- Submitting a fix
-- Proposing new features
-- Becoming a maintainer
+Contributions are welcome — bug reports, missing-binding requests, fixes, new binding surface, backend work, and doc
+improvements alike.
 
-## We Develop with Github
-We use github to host code, to track issues and feature requests, as well as accept pull requests.
+This document covers the mechanics: how to build the project, the rules that decide whether a patch is reviewable, the
+commit format, the PR flow, and how releases are cut.
 
-## We Use [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow), So All Code Changes Happen Through Pull Requests
-Pull requests are the best way to propose changes to the codebase (we use [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow)). We actively welcome your pull requests:
+- **Contents**
+    - [Before you start](#before-you-start)
+    - [Quick start](#quick-start)
+    - [Development loop](#development-loop)
+    - [Commit message format](#commit-message-format)
+    - [Pull requests](#pull-requests)
+    - [Releases](#releases)
+    - [Contributing with AI agents](#contributing-with-ai-agents)
+    - [Reporting bugs](#reporting-bugs)
+    - [License](#license)
 
-1. Fork the repo and create your branch from `main`.
-2. Make sure your code lints.
-3. Issue that pull request!
+## Before you start
 
-## Commit Message Format
+Four rules cause most of the rejected patches in this repo. Read them before writing code.
 
-*This specification is inspired by and adapts 
-the [Angular commit message format](https://github.com/angular/angular/blob/92113d73dd38d0285e25e8d678c240cf4aa8834a/CONTRIBUTING.md#commit) 
-and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) practises.*
+### 1. Never edit `imgui-binding/src/generated/java/`
 
-We have very precise rules over how our Git commit messages must be formatted.
-This format leads to **easier to read commit history**.
+The Java API is **codegen-driven**. Hand-written annotated stubs live in `imgui-binding/src/main/java/`; the Spoon-based
+generator in `buildSrc/` expands them into `imgui-binding/src/generated/java/`. Both trees are committed, but only the
+first is a source. Edits to the generated tree are silently reverted on the next `generateApi` run.
 
-Each commit message consists of a **header**, a **body**, and a **footer**.
+```bash
+# edit imgui-binding/src/main/java/...
+./gradlew :imgui-binding:generateApi
+git add imgui-binding/src/main/java imgui-binding/src/generated/java
+```
 
+Source and regenerated output belong in the **same commit** — a commit that changes one without the other leaves the
+tree inconsistent.
+
+### 2. Never commit native binaries
+
+`bin/libimgui-java64.*` and `bin/imgui-java64.dll` are owned by CI. The `update-bin` job rebuilds them on `main` after a
+binding change and commits them as `[ci skip] update native binaries`. Locally built natives must not be staged.
+
+Use `git add <specific-path>` instead of `git add -A` / `git add .` — bulk staging picks up `bin/` and
+`imgui-binding/build/libsNative/` by accident.
+
+### 3. One topic per pull request
+
+Submodule bumps, Gradle/dependency bumps, codegen-tooling changes, and new API surface each go in their own PR. A
+submodule bump already produces a large regenerated diff; adding a feature on top makes it unreviewable and makes CI
+failures ambiguous. Land the bump first, add the new surface in a follow-up.
+
+### 4. Javadoc must pass doclint
+
+Doc comments in the binding are copied verbatim from Dear ImGui's C++ headers, and JDK 17's doclint rejects anything
+that parses as broken HTML. CI runs javadoc as part of the build; a doc-comment typo fails the whole pipeline.
+
+Wrap operators in `{@code ...}` — `<`, `>`, `&`, `&&`, `||`, `->` all break otherwise. Keep `@link` targets, `@param`,
+and `@return` in sync with the current method signature.
+
+## Quick start
+
+```bash
+git clone --recurse-submodules https://github.com/SpaiR/imgui-java.git
+cd imgui-java
+./gradlew :example:run
+```
+
+Already cloned without submodules, or switched branches?
+
+```bash
+git submodule update --init --recursive
+```
+
+`git checkout` does **not** update submodules. If `include/*` pointers differ between branches you will compile against
+the wrong headers and get mystifying errors.
+
+**Prerequisites**
+
+| What                          | Needed for                                       | Notes                                                     |
+|-------------------------------|--------------------------------------------------|-----------------------------------------------------------|
+| Any recent JDK                | Everything                                       | Gradle's toolchain pins JDK 17 and downloads it if missing |
+| A C++ toolchain               | Rebuilding the native library (`generateLibs`)   | Only if you touch JNI or `native` method signatures        |
+| `clang++`                     | `./gradlew generateAst`                          | Only when bumping a submodule                              |
+| `mingw-w64`                   | Cross-building the Windows native from Linux     | CI does this; rarely needed locally                        |
+
+Java-only changes run fine against the natives already committed in `bin/` — no C++ toolchain required.
+
+## Development loop
+
+### Adding or changing binding API
+
+```bash
+# 1. edit the annotated source
+$EDITOR imgui-binding/src/main/java/imgui/ImGui.java
+
+# 2. regenerate the Java API
+./gradlew :imgui-binding:generateApi
+
+# 3. check
+./gradlew :imgui-binding:compileJava
+./gradlew :imgui-binding:javadoc
+```
+
+If you add, rename, remove, or reorder a `native` method, the committed natives no longer match the Java side and you
+will get an `UnsatisfiedLinkError` at runtime — static checks will not catch it. Rebuild and smoke-test:
+
+```bash
+buildSrc/scripts/build.sh <macos|linux|windows>
+cp /tmp/imgui/dst/libimgui-java64.<so|dylib|dll> bin/
+./gradlew :example:run -PlibPath=$PWD/bin
+```
+
+Then **revert the `bin/` copy** before committing (see [rule 2](#2-never-commit-native-binaries)).
+
+Backend, font, texture, and example changes also need a real run — a blank font atlas or an assertion loop does not show
+up in a compile.
+
+### Checks before you push
+
+```bash
+./gradlew :imgui-binding:compileJava   # fastest sanity check
+./gradlew check                        # tests + Checkstyle (imgui-lwjgl3, imgui-app)
+./gradlew :imgui-binding:javadoc       # zero `error:` lines is the bar
+./gradlew buildAll                     # what CI runs
+```
+
+Checkstyle runs at `severity="error"` for `imgui-lwjgl3` and `imgui-app`. Fix the code rather than relaxing the rule; if
+a rule genuinely does not fit a construct, suppress at the smallest possible scope with `@SuppressWarnings`. Do not add
+entries to `config/checkstyle/suppressions.xml`.
+
+`imgui-binding` ships with **zero runtime dependencies**. Adding one is a breaking change for downstream consumers and
+needs sign-off before you write the code. Public modules also compile with `--release 8` — no `List.of`, `var`,
+`String.isBlank()`, or other Java 9+ APIs in `imgui-binding`, `imgui-lwjgl3`, or `imgui-app`.
+
+For deeper background — the codegen internals, the submodule-upgrade procedure, the dual font-loader design — see
+[`AGENTS.md`](AGENTS.md). It is written for AI agents but applies equally to humans.
+
+## Commit message format
+
+*Adapted from the
+[Angular commit message format](https://github.com/angular/angular/blob/92113d73dd38d0285e25e8d678c240cf4aa8834a/CONTRIBUTING.md#commit)
+and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).*
+
+Commit history is a changelog for the next maintainer. Precise messages make it readable.
 
 ```
 <header>
@@ -37,69 +152,89 @@ Each commit message consists of a **header**, a **body**, and a **footer**.
 <footer>
 ```
 
-The `header` is mandatory and must conform to the [Commit Message Header](#commit-header) format.
+The `header` is mandatory and must conform to the [header format](#commit-message-header).
 
-The `body` is mandatory for all commits except for those of type "docs".
-When the body is present it must be at least 20 characters long and must conform to the [Commit Message Body](#commit-body) format.
+The `body` is required whenever the reason for the change is not obvious from the header alone — anything with a
+trade-off, a workaround, an upstream cause, or a behavior change. It is optional for self-evident one-liners (typo
+fixes, `docs:` polish, dependency bumps).
 
-The `footer` is optional. The [Commit Message Footer](#commit-footer) format describes what the footer is used for and the structure it must have.
+The `footer` is optional, except where [noted below](#commit-message-footer).
 
-
-#### <a name="commit-header"></a>Commit Message Header
+### Commit message header
 
 ```
 <type>(<scope>): <short summary>
-  │       │             │
-  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
-  │       │
-  │       └─⫸ Commit Scope: api|generator|build
+  │      │             │
+  │      │             └─⫸ Summary in imperative, present tense. Not capitalized. No period at the end.
+  │      │
+  │      └─⫸ Commit scope: see the scope table
   │
-  └─⫸ Commit Type: feat|fix|chore|docs
+  └─⫸ Commit type: feat | fix | perf | refactor | docs | test | build | chore | revert
 ```
 
-The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
+`<type>` and `<summary>` are mandatory; `(<scope>)` is optional but strongly preferred. Append `!` after the type or
+scope (`feat(api)!:`) to flag a breaking change — that also requires a `BREAKING CHANGE:` footer.
 
+Keep the whole first line under 72 characters.
 
-##### Type
+#### Type
 
-Must be one of the following:
+| Type       | Use for                                                                                                                       |
+|------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `feat`     | New user-visible capability: new binding surface, a new backend, a new `Application` hook, a submodule bump that adds API.     |
+| `fix`      | A bug fix in the binding, generator, backend, or build.                                                                       |
+| `perf`     | Change whose point is speed or allocation — JNI marshaling, render-loop work. No behavior change. Say what you measured.        |
+| `refactor` | Internal restructuring with no behavior change: rename, extract, reorganize.                                                   |
+| `docs`     | Documentation only — `README.md`, `AGENTS.md`, this file, `.claude/`, or Javadoc-only edits.                                    |
+| `test`     | Adding or changing tests under `src/test/`.                                                                                     |
+| `build`    | Build system, Gradle, CI workflows, publishing, native toolchain, and **dependency bumps** (`build(deps)`, what Dependabot emits). |
+| `chore`    | Housekeeping that fits nothing above: `.gitignore`, editor config, repo metadata.                                               |
+| `revert`   | Reverts an earlier commit. The body must name it (`Reverts <sha>`) and say why.                                                 |
 
-* **feat**: A new feature
-* **fix**: A bug fix
-* **chore**: Routine tasks, refactoring, updates, minor improvements
-* **docs**: Documentation only changes
+Prefer the most specific type. `chore` is the fallback, not the default — a dependency bump is `build(deps)`, a rename
+is `refactor`, a Javadoc fix is `docs`.
 
-Type **build** can be used specifically to update dependencies. (Relying on `dependantbot` conventions.)
+#### Scope
 
+Pick from the table. If nothing fits, omit the scope rather than inventing one.
 
-##### Scope
-The following is the list of supported scopes:
+| Scope        | Covers                                                                                            |
+|--------------|---------------------------------------------------------------------------------------------------|
+| `api`        | Public binding surface: annotated sources in `imgui-binding/src/main/java/` + regenerated output.  |
+| `native`     | Hand-written JNI under `imgui-binding/src/main/native/` and the native build glue.                 |
+| `generator`  | The codegen in `buildSrc/` — Spoon transforms, AST parsing, Gradle tasks.                          |
+| `vendor`     | Submodule pointer bumps under `include/`, and the patches in `patches/` that keep them compiling.  |
+| `lwjgl3`     | `imgui-lwjgl3` — the GLFW, OpenGL 3, and SDL3 backends.                                            |
+| `app`        | `imgui-app` — the `Application` wrapper and bundled natives.                                        |
+| `example`    | The `example` module.                                                                              |
+| `deps`       | Dependency version bumps. Always paired with `build` (`build(deps)`).                               |
+| `ci`         | GitHub Actions workflows, issue/PR templates, Dependabot config.                                    |
+| `gradle`     | Build scripts, the wrapper, publishing setup.                                                       |
+| `readme`     | `README.md` only.                                                                                   |
+| `agents`     | `AGENTS.md`, `CLAUDE.md`, and `.claude/` rules.                                                     |
+| `contributing` | This file.                                                                                        |
 
-* `api` - changes to the API (ex. adding binding for another extension or new supported native methods)
-* `generator` - changes to the API generator (ex. improved generation code etc.)
-* `build` - changes that affect the build system, CI or external dependencies
+A submodule bump that also exposes new Java API is two commits — `vendor` for the pointer + regenerated AST, `api` for
+the new surface — or better, two PRs.
 
-##### Summary
+#### Summary
 
-Use the summary field to provide a succinct description of the change:
-
-* use the imperative, present tense: "change" not "changed" nor "changes"
+* imperative, present tense: "add" not "added" nor "adds"
 * don't capitalize the first letter
-* no dot (.) at the end
+* no period at the end
 
+### Commit message body
 
-#### <a name="commit-body"></a>Commit Message Body
+Same tense rules as the summary.
 
-Just as in the summary, use the imperative, present tense: "fix" not "fixed" nor "fixes".
+Explain **why**, not what — the diff already shows what changed. Name the upstream commit, the issue, the incident, or
+the constraint that forced the change. When behavior changes, contrast old and new.
 
-Explain the motivation for the change in the commit message body. This commit message should explain _why_ you are making the change.
-You can include a comparison of the previous behavior with the new behavior in order to illustrate the impact of the change.
+A 2–5 bullet list works well for multi-part changes.
 
+### Commit message footer
 
-#### <a name="commit-footer"></a>Commit Message Footer
-
-The footer can contain information about breaking changes and deprecations and is also the place to reference GitHub issues and other PRs that this commit closes or is related to.
-For example:
+The footer carries breaking-change and deprecation notes, issue references, and AI co-authorship trailers.
 
 ```
 BREAKING CHANGE: <breaking change summary>
@@ -121,36 +256,140 @@ DEPRECATED: <what is deprecated>
 Closes #<pr number>
 ```
 
-Breaking Change section should start with the phrase "BREAKING CHANGE: " followed by a summary of the breaking change, a blank line, and a detailed description of the breaking change that also includes migration instructions.
+A `BREAKING CHANGE:` footer is **mandatory** whenever the header carries `!`. The summary line is short; the description
+below must tell a downstream user exactly what to change in their code. This matters more here than in most projects —
+the project version tracks Dear ImGui (see [Releases](#releases)), so the version number alone can never signal a break.
 
-Similarly, a Deprecation section should start with "DEPRECATED: " followed by a short description of what is deprecated, a blank line, and a detailed description of the deprecation that also mentions the recommended update path.
+A `DEPRECATED:` footer is used when API is kept working for a release with a pointer to its replacement. Pair it with
+the `@Deprecated` annotation and a `{@link ...}` in the Javadoc.
 
-## Contributing with AI Agents
+## Pull requests
+
+1. Fork the repo (or branch off `main`, with direct push access).
+2. Keep the PR to [one topic](#3-one-topic-per-pull-request).
+3. Make sure `./gradlew buildAll` passes locally.
+4. Open the PR against `main`.
+
+### Title
+
+PRs are **squash-merged**, so the PR title becomes the commit subject on `main`. Write it as a valid
+[commit header](#commit-message-header):
+
+```
+feat(lwjgl3): add SDL3 backend
+fix(api): correct ImVec2 swap signature
+build(deps): bump Gradle wrapper to 9.5.1
+```
+
+Not `Add SDL3 support`, not `SDL3 stuff`, not the raw branch name.
+
+### Body
+
+`.github/pull_request_template.md` pre-fills the body. Fill in what applies:
+
+- **Summary** — the user-visible change and why it exists. Always required.
+- **Type of change** — tick the matching checkbox.
+- **Notes for reviewer** — design decisions, deliberate scope boundaries, follow-ups left for later. Omit if none.
+- `Closes #<n>` / `Fixes #<n>` at the bottom — GitHub links and closes the issue on merge.
+
+### Labels
+
+Apply one type label, derived from the commit type:
+
+| Commit type                                   | Label            |
+|-----------------------------------------------|------------------|
+| `feat`                                        | `feat`           |
+| `fix`                                         | `fix`            |
+| `docs`                                        | `docs`           |
+| `perf` / `refactor` / `test` / `chore` / `build` | `chore`       |
+| `build(deps)`                                 | `deps`           |
+| `revert`                                      | *(label of the change being reverted)* |
+
+Dependabot applies `deps` on its own. `bug`, `question`, `missing binding`, `invalid`, and `wontfix` are issue-triage
+labels — not for PRs. Don't invent labels; add one to the repo first if a genuinely new category shows up.
+
+### What CI does
+
+On every PR: builds the Java side (`buildAll`, which includes javadoc), then builds the native library for Linux,
+Windows, and macOS. All four jobs must be green.
+
+Two jobs run only on `main`, never on PRs or forks:
+
+- `update-bin` — rebuilds `bin/` natives when the binding hash changed, and commits them.
+- `release` — runs on `v*` tags only.
+
+CI failures are reproducible locally. Start with `gh pr checks <n>` to find the failing job, then
+`gh run view --job <job-id> --log`. Don't iterate by pushing to CI.
+
+### Review
+
+CI catches the mechanical problems — compilation, Checkstyle, javadoc, native builds on all three platforms. Review
+focuses on what it can't judge: anything touching `src/generated/java/`, new dependencies in `imgui-binding`, Java 9+
+APIs in consumed modules, and runtime behavior that no static check covers (a JNI signature change, a blank font atlas).
+
+## Releases
+
+Releases are cut by the maintainer. This section documents the procedure and the versioning rules that affect what you
+put in commit messages.
+
+### Versioning
+
+The project version **tracks Dear ImGui**, it is not independent SemVer:
+
+- `MAJOR.MINOR` mirrors the Dear ImGui release the binding tracks.
+- `PATCH` counts imgui-java's own releases on top of that upstream version.
+
+| imgui-java tag | Dear ImGui   |
+|----------------|--------------|
+| `v1.92.0`      | `1.92.7`     |
+| `v1.90.0`      | `1.90.9`     |
+| `v1.89.0`      | `1.89.9`     |
+| `v1.87.0` … `v1.87.7` | `1.87` — eight imgui-java releases on one upstream version |
+
+Consequence: **the version number cannot signal a breaking change.** Breaking changes are signalled by `!` in the commit
+header, a `BREAKING CHANGE:` footer, and an explicit entry in the GitHub release notes. Nothing else surfaces them.
+
+There is no version file to bump. `build.gradle` derives the version from `git describe --tags` (leading `v` stripped),
+so **the tag is the version of record**.
+
+### Cutting a release
+
+1. Make sure `main` is green and `bin/` is current — the `update-bin` job must have run after the last binding change.
+   Releasing on stale natives ships a library whose Java and native sides disagree.
+2. Tag and push:
+   ```bash
+   git tag v1.92.1
+   git push origin v1.92.1
+   ```
+3. The `release` job runs on the tag: builds Java, builds all three natives, publishes every module and native
+   classifier to Maven Central via `buildSrc/scripts/publish.sh`, then opens a **draft** GitHub release with
+   `java-libraries.zip` and `native-libraries.zip` attached.
+4. Write the release notes on the draft and publish it. Group by `feat` / `fix` / `build`, and give breaking changes
+   their own section at the top with migration instructions.
+5. Verify the artifacts appear on Maven Central under `io.github.spair`.
+
+## Contributing with AI agents
 
 AI coding agents (Claude Code, Copilot, Cursor, Codex, Gemini, etc.) are welcome to assist with contributions.
-See [AGENTS.md](AGENTS.md) for the canonical guidance on how AI agents should work in this repo (golden rules,
-codegen workflow, build commands, gotchas).
+[`AGENTS.md`](AGENTS.md) is the canonical guidance for how they should work in this repo — golden rules, codegen
+workflow, build commands, gotchas — with the detailed rules in `.claude/rules/`.
 
 Two extra rules apply on top of the regular contribution flow:
 
-1. **You are responsible for the change.** The agent is a tool — review the diff, run the build, and make sure the PR
-   meets the same bar as a hand-written one. "The agent did it" is not a defense for a broken or low-quality patch.
-2. **Every AI-assisted commit must be attributed via a `Co-authored-by` trailer** (see below). This applies whether the
-   agent wrote the whole commit or just a substantial part of it.
+1. **You are responsible for the change.** The agent is a tool — review the diff, run the build, run the example when
+   natives are involved, and hold the PR to the same bar as a hand-written one. "The agent did it" is not a defense for
+   a broken or low-quality patch.
+2. **Every AI-assisted commit must be attributed via a `Co-authored-by` trailer.** This applies whether the agent wrote
+   the whole commit or just a substantial part of it.
 
-### `Co-authored-by` trailer for AI-assisted commits
+### `Co-authored-by` trailer
 
-Add a `Co-authored-by` line to the [commit message footer](#commit-footer) for any commit that an AI agent helped
-produce. Use the **short, family-level name** of the model — not the specific version — followed by the standard
-vendor noreply email.
-
-Format:
+Add a `Co-authored-by` line to the [commit footer](#commit-message-footer) for any commit an AI agent helped produce.
+Use the **short, family-level name** of the model — not the specific version — followed by the vendor noreply email.
 
 ```
 Co-authored-by: <Model Family> <<vendor-noreply-email>>
 ```
-
-Examples (use the family name, drop the version/tier suffix):
 
 | Model used                                 | Trailer                                          |
 |--------------------------------------------|--------------------------------------------------|
@@ -159,7 +398,11 @@ Examples (use the family name, drop the version/tier suffix):
 | OpenAI Codex / GPT                         | `Co-authored-by: Codex <noreply@openai.com>`     |
 | Google Gemini                              | `Co-authored-by: Gemini <noreply@google.com>`    |
 
-Full commit message example:
+Agent tooling often emits more than this — a versioned model name, a session URL, a "Generated with …" line. **Strip
+all of it** and leave the family-level trailer. One `Co-authored-by` line per agent, at the very end of the message,
+separated from the body by a blank line.
+
+Full example:
 
 ```
 fix(api): correct ImVec2 swap signature
@@ -172,27 +415,31 @@ Fixes #123
 Co-authored-by: Claude <noreply@anthropic.com>
 ```
 
-If multiple agents contributed, add one `Co-authored-by` line per agent. Place the trailer(s) at the very end of the
-commit message, separated from the body by a blank line.
+Because PRs are squash-merged, verify the trailer survives into the final squash message — GitHub collects co-author
+trailers from the squashed commits, but a hand-edited squash body can drop them.
 
-## Any contributions you make will be under the MIT License
-In short, when you submit code changes, your submissions are understood to be under the same [MIT License](https://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
+## Reporting bugs
 
-## Report bugs using Github's [issues](https://github.com/SpaiR/imgui-java/issues)
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](); it's that easy!
+Open an issue with the matching template:
 
-## Write bug reports with detail, background, and sample code
-**Great Bug Reports** tend to have:
+- [**Bug report**](https://github.com/SpaiR/imgui-java/issues/new?template=bug_report.yml) — something is broken.
+- [**Missing bindings**](https://github.com/SpaiR/imgui-java/issues/new?template=missing_bindings.yml) — an upstream
+  function, flag, or struct field is not exposed in Java. This is the right template for "ImGui has X, imgui-java
+  doesn't".
 
-- A quick summary and/or background
-- Steps to reproduce
-  - Be specific!
-  - Give sample code if you can.
-- What you expected would happen
-- What actually happens
-- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+The templates ask for the version, what happened, and a reproducer. Beyond those fields, the reports that get fixed
+fastest include:
 
-People *love* thorough bug reports. I'm not even kidding.
+- the imgui-java version **and** the backend you use (imgui-app, imgui-lwjgl3 + GLFW, SDL3, or your own)
+- a minimal `ImGui.*` call sequence that triggers it — a runnable snippet beats a description
+- the OS and JDK
+- the full stack trace, especially for `UnsatisfiedLinkError` and native crashes
+- what you expected versus what happened, and anything you already tried
 
-## Use a Consistent Coding Style
-You can run `./gradlew check` to verify your changes beforehand.
+## License
+
+By contributing, you agree that your contributions are licensed under the same
+[MIT License](https://choosealicense.com/licenses/mit/) that covers the project. Contact the maintainer if that is a
+concern.
+
+Participation is governed by the [Code of Conduct](docs/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,19 +298,29 @@ is for the history.
 
 ### Labels
 
-Apply one type label, derived from the commit type:
+Apply exactly one **type** label. There is one per commit type, so the mapping is direct:
 
-| Commit type                                   | Label            |
-|-----------------------------------------------|------------------|
-| `feat`                                        | `feat`           |
-| `fix`                                         | `fix`            |
-| `docs`                                        | `docs`           |
-| `perf` / `refactor` / `test` / `chore` / `build` | `chore`       |
-| `build(deps)`                                 | `deps`           |
-| `revert`                                      | *(label of the change being reverted)* |
+| Commit type | Label      |
+|-------------|------------|
+| `feat`      | `feat`     |
+| `fix`       | `fix`      |
+| `perf`      | `perf`     |
+| `refactor`  | `refactor` |
+| `docs`      | `docs`     |
+| `test`      | `test`     |
+| `build`     | `build`    |
+| `chore`     | `chore`    |
+| `revert`    | `revert`   |
 
-Dependabot applies `deps` on its own. `bug`, `question`, `missing binding`, `invalid`, and `wontfix` are issue-triage
-labels — not for PRs. Don't invent labels; add one to the repo first if a genuinely new category shows up.
+`build(deps)` takes **`deps`** instead of `build` — dependency bumps are their own review category, and Dependabot
+applies that label on its own.
+
+Then add **`breaking-change`** on top of the type label whenever the PR carries a `BREAKING CHANGE:` footer or a `!` in
+the header. The version number can't signal a break (see [Releases](#releases)), so this label is how a breaking change
+stays visible in the PR list and in the release notes.
+
+`bug`, `question`, `missing binding`, `invalid`, and `wontfix` are issue-triage labels — not for PRs. Don't invent
+labels; add one to the repo first if a genuinely new category shows up.
 
 ### What CI does
 
@@ -351,7 +361,8 @@ The project version **tracks Dear ImGui**, it is not independent SemVer:
 | `v1.87.0` … `v1.87.7` | `1.87` — eight imgui-java releases on one upstream version |
 
 Consequence: **the version number cannot signal a breaking change.** Breaking changes are signalled by `!` in the commit
-header, a `BREAKING CHANGE:` footer, and an explicit entry in the GitHub release notes. Nothing else surfaces them.
+header, a `BREAKING CHANGE:` footer, the [`breaking-change` label](#labels) on the PR, and a dedicated section in the
+GitHub release notes. Nothing else surfaces them.
 
 There is no version file to bump. `build.gradle` derives the version from `git describe --tags` (leading `v` stripped),
 so **the tag is the version of record**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ Similarly, a Deprecation section should start with "DEPRECATED: " followed by a 
 ## Contributing with AI Agents
 
 AI coding agents (Claude Code, Copilot, Cursor, Codex, Gemini, etc.) are welcome to assist with contributions.
-See [AGENTS.md](../AGENTS.md) for the canonical guidance on how AI agents should work in this repo (golden rules,
+See [AGENTS.md](AGENTS.md) for the canonical guidance on how AI agents should work in this repo (golden rules,
 codegen workflow, build commands, gotchas).
 
 Two extra rules apply on top of the regular contribution flow:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,16 +272,20 @@ the `@Deprecated` annotation and a `{@link ...}` in the Javadoc.
 
 ### Title
 
-PRs are **squash-merged**, so the PR title becomes the commit subject on `main`. Write it as a valid
-[commit header](#commit-message-header):
+Write a short, **descriptive** title for the whole change — do **not** paste the first commit's header. The title is
+what a reviewer scans in the PR list, so it should read as plain prose describing the outcome, not as a
+`<type>(<scope>): …` commit line.
 
-```
-feat(lwjgl3): add SDL3 backend
-fix(api): correct ImVec2 swap signature
-build(deps): bump Gradle wrapper to 9.5.1
-```
+- Sentence case, no trailing period, aim for under ~72 characters.
+- Describe the whole PR, not just its first or largest commit.
+- No `type(scope):` prefix — the **type is carried by the [label](#labels)**, not the title.
 
-Not `Add SDL3 support`, not `SDL3 stuff`, not the raw branch name.
+Examples — `feat(lwjgl3): add SDL3 backend` (commit) becomes **"Add an SDL3 backend to imgui-lwjgl3"** (PR title);
+`fix(api): correct ImVec2 swap signature` becomes **"Fix reversed x/y in the ImVec2 swap overload"**.
+
+PRs are squash-merged, so the maintainer writes the squash subject as a proper
+[commit header](#commit-message-header) at merge time — the PR title is for humans reading the list, the commit subject
+is for the history.
 
 ### Body
 

--- a/README.md
+++ b/README.md
@@ -461,10 +461,13 @@ hand-edit `src/generated/`: it is regenerated and your changes will be lost. The
 # commit both src/main/java and src/generated/java in one commit
 ```
 
-[`AGENTS.md`](AGENTS.md) is the canonical contributor and AI-agent guide. It documents the codegen workflow, the
-procedure for upgrading Dear ImGui or any extension submodule, javadoc/doclint pitfalls when copying C++ comments, the
-dual font-loader design, codegen internals (Spoon generic-type bounds, Gradle 9 configuration cache requirements), and
-the PR/merge-order conventions used in this repo. Read it before bumping a submodule or touching the generator.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) is the contributor guide: build prerequisites, the checks to run before pushing,
+the commit-message format with its type/scope tables, PR and label conventions, and how releases are cut. Start there.
+
+[`AGENTS.md`](AGENTS.md) is the deep operational guide, written for AI agents but equally useful to humans. It documents
+the codegen workflow, the procedure for upgrading Dear ImGui or any extension submodule, javadoc/doclint pitfalls when
+copying C++ comments, the dual font-loader design, and codegen internals (Spoon generic-type bounds, Gradle 9
+configuration cache requirements). Read it before bumping a submodule or touching the generator.
 
 # Support
 


### PR DESCRIPTION
## Summary

Move `CONTRIBUTING.md` to the repo root, rewrite it into an actual contributor guide, and align `AGENTS.md`, `README.md`, and the PR template with it.

The old file was mostly the generic contributing template — an empty "open a new issue" link, a bug-report section duplicating the issue forms, and commit rules that had drifted from the real history (`build` listed as both a type and a scope, no `deps` scope, a mandatory 20-character body that most `fix`/`chore` commits ignore).

What the rewrite adds:

- **Quick start** — `--recurse-submodules`, prerequisites, the checks to run before pushing.
- **Before you start** — the four rules that actually block review, up top: never edit `src/generated/java/`, never commit `bin/` natives, one topic per PR, doclint must pass.
- **Commit format** — types extended to `feat|fix|perf|refactor|docs|test|build|chore|revert`, scopes from 3 to 13 matching the module layout, `!` + `BREAKING CHANGE:` convention.
- **Pull requests** — new section: the title must be a valid commit header since PRs are squash-merged, plus body sections, label mapping onto the labels that exist, and what CI covers.
- **Releases** — new section: the versioning scheme (`MAJOR.MINOR` tracks Dear ImGui, `PATCH` is our own counter), the consequence that the version can never signal a breaking change, and the tag → CI → draft release → Maven Central procedure.
- **Bug reports** — the two issue templates linked directly, replacing the generic prose.

Also on this branch: `CLAUDE.md` trimmed to defer entirely to `AGENTS.md`, and per-module `bin/` output from Eclipse/VS Code Java builds added to `.gitignore`.

## Type of change

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Notes for reviewer

- Docs only — no code, build, or CI logic touched.
- The versioning section is reverse-engineered from the tags: `v1.92.0`↔imgui `1.92.7`, `v1.90.0`↔`1.90.9`, `v1.89.0`↔`1.89.9`, and `v1.87.0`–`v1.87.7` on one upstream version. Worth confirming that is the intended rule and not just how it happened to land.
- The release procedure is written from `.github/workflows/ci.yml` and `buildSrc/scripts/publish.sh`. Any manual step that lives only in your head is missing from it.
- Repo labels were extended to one per commit type (`perf`, `refactor`, `test`, `build`, `revert` added, `chore` narrowed to housekeeping), plus `breaking-change`. The label table in the guide is now a direct mapping.
- PR titles are prose sentences rather than commit headers; the conventional header goes into the squash subject at merge time. That adds one step to the merge dialog — say if you'd rather switch to merge commits instead.

