### PR TITLE
Ensure GL device objects before renderDrawData after 1.86→1.87 upgrade

### DIFF
--- a/imgui-lwjgl3/src/main/java/imgui/gl3/ImGuiImplGl3.java
+++ b/imgui-lwjgl3/src/main/java/imgui/gl3/ImGuiImplGl3.java
@@ -242,6 +242,10 @@ public class ImGuiImplGl3 {
      * Method to do an initialization of the {@link ImGuiImplGl3} state.
      * It SHOULD be called before calling of the {@link ImGuiImplGl3#renderDrawData(ImDrawData)} method.
      * <p>
+     * GL device objects (shader, buffers, font texture) are <b>not</b> created here; they are
+     * created lazily on the first {@link #newFrame()} or {@link #renderDrawData(ImDrawData)} call
+     * (behavior since 1.87, matching upstream). Prefer calling {@link #newFrame()} every frame.
+     * <p>
      * Method takes an argument, which should be a valid GLSL string with the version to use.
      * <pre>
      * ----------------------------------------
@@ -371,7 +375,25 @@ public class ImGuiImplGl3 {
         data = null;
     }
 
+    /**
+     * Prepare per-frame GL resources.
+     * <p>
+     * Since Dear ImGui 1.87 / imgui-java 1.87, shader program, buffers and the font
+     * texture are created lazily here (not in {@link #init(String)}). Call this every
+     * frame before {@link ImGui#newFrame()}, or at least once after {@code init} and
+     * before the first {@link #renderDrawData(ImDrawData)}.
+     */
     public void newFrame() {
+        ensureDeviceObjects();
+    }
+
+    /**
+     * Create shader/program/VBO and font texture if they are not yet available.
+     * Shared by {@link #newFrame()} and {@link #renderDrawData(ImDrawData)} so that
+     * integrators that only call {@code init} + {@code renderDrawData} (the pre-1.87
+     * pattern) do not hit a native NULL dereference in {@code glDrawElementsBaseVertex}.
+     */
+    protected void ensureDeviceObjects() {
         if (data.shaderHandle == 0) {
             createDeviceObjects();
         }
@@ -469,6 +491,12 @@ public class ImGuiImplGl3 {
         if (drawData.getCmdListsCount() <= 0) {
             return;
         }
+
+        // Device objects used to be created in init() (imgui-java <= 1.86). Since 1.87 they are
+        // created lazily in newFrame() to match upstream imgui_impl_opengl3. Ensure them here as
+        // well so call sites that skip newFrame() (common after upgrades; see #361) do not crash
+        // with a native NULL pointer inside glDrawElementsBaseVertex.
+        ensureDeviceObjects();
 
         // In C++: iterates draw_data->Textures and calls ImGui_ImplOpenGL3_UpdateTexture for each non-OK status.
         // In Java: ImTextureData is not exposed in imgui-binding (follow-up); we keep the legacy createFontsTexture


### PR DESCRIPTION
## Summary

Since imgui-java 1.87, `ImGuiImplGl3` creates the shader/program/VBO and font texture lazily in `newFrame()` (not in `init()`), matching upstream `imgui_impl_opengl3`. Integrators that still use the pre-1.87 pattern of `init()` + `renderDrawData()` without `newFrame()` then crash in native code (`glDrawElementsBaseVertex` NULL dereference / EXCEPTION_ACCESS_VIOLATION).

This change reuses that lazy create path from `renderDrawData()` as a safety net, so the upgrade path reported in #361 no longer hard-crashes the JVM. Calling `newFrame()` every frame remains the recommended API.

## Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Notes for reviewer

- Root cause of #361: device objects never created when `newFrame()` is skipped; `shaderHandle` / buffer handles stay 0 and the draw call faults in the GL driver.
- The issue author later worked around it by calling `imGuiGl3.newFrame()` during init (see their jME hub write-up and @Enaium's comment). This patch keeps that recommendation and additionally makes `renderDrawData()` self-sufficient for the upgrade path.
- No new public API beyond a small protected `ensureDeviceObjects()` helper shared by `newFrame()` / `renderDrawData()`.
- Javadoc on `init` / `newFrame` updated to document the post-1.87 lazy create.

Fixes #361

## Test plan

- [x] `./gradlew :imgui-lwjgl3:compileJava :imgui-lwjgl3:checkstyleMain` (JDK 17)
- [ ] No automated GL unit test exists for this path; visual smoke would be `./gradlew :example:run` with local natives if desired